### PR TITLE
fix up warnings and use definition to specialize _rclpy.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,15 +198,12 @@ macro(target)
     return()
   endif()
 
-  configure_file(
-    src/rclpy/_rclpy.c.in
-    src/rclpy/_rclpy${target_suffix}.c
-  )
-
   add_library(
     ${PROJECT_NAME}${target_suffix}
-    SHARED src/rclpy/_rclpy${target_suffix}.c
+    SHARED src/rclpy/_rclpy.c
   )
+  target_compile_definitions(${PROJECT_NAME}${target_suffix}
+    PRIVATE "RMW_IMPLEMENTATION_SUFFIX=${target_suffix}")
 
   set_target_properties(${PROJECT_NAME}${target_suffix} PROPERTIES
     PREFIX ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,12 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rclpy)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
-find_package(ament_cmake_python REQUIRED)
-
-include_directories(include)
 
 if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 endif()
 
@@ -267,10 +264,10 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-  file(
-    COPY "${PROJECT_NAME}"
-    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
-  )
+file(
+  COPY "${PROJECT_NAME}"
+  DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+)
 
 ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,12 +261,18 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+# Copy the Python code to the folder where the C extensions will be generated.
+# This creates a folder in ${CMAKE_CURRENT_BINARY_DIR}/rclpy which has all the
+# necessary Python code and C Python extensions for running tests.
+# This folder is also ready to be installed directly as a Python package.
 file(
   COPY "${PROJECT_NAME}"
   DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
-ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}")
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}"
+)
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-project(rclpy)
+project(rclpy C)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)

--- a/src/rclpy/_rclpy.c
+++ b/src/rclpy/_rclpy.c
@@ -5,6 +5,10 @@
 #include <rcl/node.h>
 #include <rosidl_generator_c/message_type_support_struct.h>
 
+#ifndef RMW_IMPLEMENTATION_SUFFIX
+#error "RMW_IMPLEMENTATION_SUFFIX is required to be set for _rclpy.c"
+#endif
+
 static PyObject *
 rclpy_init(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
 {
@@ -338,8 +342,10 @@ static struct PyModuleDef _rclpymodule = {
    NULL
 };
 
-PyMODINIT_FUNC
-PyInit__rclpy@target_suffix@(void)
+#define MAKE_FN_NAME(x) PyInit__rclpy ## x
+#define FUNCTION_NAME(suffix) MAKE_FN_NAME(suffix)
+
+PyMODINIT_FUNC FUNCTION_NAME(RMW_IMPLEMENTATION_SUFFIX)(void)
 {
   return PyModule_Create(&_rclpymodule);
 }

--- a/src/rclpy/_rclpy.c
+++ b/src/rclpy/_rclpy.c
@@ -41,7 +41,7 @@ rclpy_create_node(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_node_t *node = PyMem_Malloc(sizeof(rcl_node_t));
+  rcl_node_t * node = (rcl_node_t *)PyMem_Malloc(sizeof(rcl_node_t));
   node->impl = NULL;
   rcl_node_options_t default_options = rcl_node_get_default_options();
   rcl_ret_t ret = rcl_node_init(node, node_name, &default_options);
@@ -65,15 +65,16 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
 
   char * topic = (char *)PyUnicode_1BYTE_DATA(pytopic);
 
-  rcl_node_t *node = PyCapsule_GetPointer(pynode, NULL);
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, NULL);
 
   PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
   PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
 
-  rosidl_message_type_support_t * ts = PyCapsule_GetPointer(pyts, NULL);
+  rosidl_message_type_support_t * ts =
+    (rosidl_message_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
 
-  rcl_publisher_t *publisher = PyMem_Malloc(sizeof(rcl_publisher_t));
+  rcl_publisher_t * publisher = (rcl_publisher_t *)PyMem_Malloc(sizeof(rcl_publisher_t));
   publisher->impl = NULL;
   rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();
   rcl_ret_t ret = rcl_publisher_init(publisher, node, ts, topic, &publisher_ops);
@@ -92,7 +93,7 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_publisher_t *publisher = PyCapsule_GetPointer(pypublisher, NULL);
+  rcl_publisher_t * publisher = (rcl_publisher_t *)PyCapsule_GetPointer(pypublisher, NULL);
 
   PyObject * pymsg_type = PyObject_GetAttrString(pymsg, "__class__");
 
@@ -100,7 +101,9 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
 
   PyObject * pyconvert_from_py = PyObject_GetAttrString(pymetaclass, "_CONVERT_FROM_PY");
 
-  void *(*convert_from_py)(PyObject *) = PyCapsule_GetPointer(pyconvert_from_py, NULL);
+  typedef void * (* convert_from_py_signature)(PyObject *);
+  convert_from_py_signature convert_from_py =
+    (convert_from_py_signature)PyCapsule_GetPointer(pyconvert_from_py, NULL);
 
   void * raw_ros_message = convert_from_py(pymsg);
 
@@ -122,17 +125,19 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
 
   assert(PyUnicode_Check(pytopic));
 
-  char *topic = (char *)PyUnicode_1BYTE_DATA(pytopic);
+  char * topic = (char *)PyUnicode_1BYTE_DATA(pytopic);
 
-  rcl_node_t *node = PyCapsule_GetPointer(pynode, NULL);
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, NULL);
 
   PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
   PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
 
-  rosidl_message_type_support_t * ts = PyCapsule_GetPointer(pyts, NULL);
+  rosidl_message_type_support_t * ts =
+    (rosidl_message_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
 
-  rcl_subscription_t *subscription = PyMem_Malloc(sizeof(rcl_subscription_t));
+  rcl_subscription_t * subscription =
+    (rcl_subscription_t *)PyMem_Malloc(sizeof(rcl_subscription_t));
   subscription->impl = NULL;
   rcl_subscription_options_t subscription_ops = rcl_subscription_get_default_options();
   rcl_ret_t ret = rcl_subscription_init(subscription, node, ts, topic, &subscription_ops);
@@ -155,7 +160,7 @@ rclpy_get_implementation_identifier(PyObject * Py_UNUSED(self), PyObject * Py_UN
 static PyObject *
 rclpy_get_zero_initialized_wait_set(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
-  rcl_wait_set_t *wait_set = PyMem_Malloc(sizeof(rcl_wait_set_t));
+  rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyMem_Malloc(sizeof(rcl_wait_set_t));
   wait_set->subscriptions = NULL;
   wait_set->size_of_subscriptions = 0;
   wait_set->guard_conditions = NULL;
@@ -182,7 +187,7 @@ rclpy_wait_set_init(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_wait_set_t *wait_set = PyCapsule_GetPointer(pywait_set, NULL);
+  rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
 
   rcl_wait_set_init(
     wait_set, number_of_subscriptions, number_of_guard_conditions, number_of_timers,
@@ -199,8 +204,8 @@ rclpy_wait_set_clear_subscriptions(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_wait_set_t *wait_set = PyCapsule_GetPointer(pywait_set, NULL);
-  rcl_wait_set_clear_subscriptions(wait_set); 
+  rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
+  rcl_ret_t ret = rcl_wait_set_clear_subscriptions(wait_set);
   Py_RETURN_NONE;
 }
 
@@ -214,9 +219,10 @@ rclpy_wait_set_add_subscription(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_wait_set_t *wait_set = PyCapsule_GetPointer(pywait_set, NULL);
-  rcl_subscription_t *subscription = PyCapsule_GetPointer(pysubscription, NULL);
-  rcl_wait_set_add_subscription(wait_set, subscription); 
+  rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
+  rcl_subscription_t * subscription =
+    (rcl_subscription_t *)PyCapsule_GetPointer(pysubscription, NULL);
+  rcl_ret_t ret = rcl_wait_set_add_subscription(wait_set, subscription);
   Py_RETURN_NONE;
 }
 
@@ -229,8 +235,8 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_wait_set_t *wait_set = PyCapsule_GetPointer(pywait_set, NULL);
-  rcl_wait(wait_set, RCL_S_TO_NS(1));
+  rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
+  rcl_ret_t ret = rcl_wait(wait_set, RCL_S_TO_NS(1));
   Py_RETURN_NONE;
 }
 
@@ -244,13 +250,16 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_subscription_t *subscription = PyCapsule_GetPointer(pysubscription, NULL);
+  rcl_subscription_t * subscription =
+    (rcl_subscription_t *)PyCapsule_GetPointer(pysubscription, NULL);
 
   PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
   PyObject * pyconvert_from_py = PyObject_GetAttrString(pymetaclass, "_CONVERT_FROM_PY");
 
-  void *(*convert_from_py)(PyObject *) = PyCapsule_GetPointer(pyconvert_from_py, NULL);
+  typedef void *(* convert_from_py_signature)(PyObject *);
+  convert_from_py_signature convert_from_py =
+    (convert_from_py_signature)PyCapsule_GetPointer(pyconvert_from_py, NULL);
 
   PyObject * pymsg = PyObject_CallObject(pymsg_type, NULL);
 
@@ -263,7 +272,9 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
   if (taken) {
     PyObject * pyconvert_to_py = PyObject_GetAttrString(pymsg_type, "_CONVERT_TO_PY");
 
-    PyObject *(*convert_to_py)(void *) = PyCapsule_GetPointer(pyconvert_to_py, NULL);
+    typedef PyObject *(* convert_to_py_signature)(void *);
+    convert_to_py_signature convert_to_py =
+      (convert_to_py_signature)PyCapsule_GetPointer(pyconvert_to_py, NULL);
 
     PyObject * pytaken_msg = convert_to_py(taken_msg);
 

--- a/src/rclpy/_rclpy.c
+++ b/src/rclpy/_rclpy.c
@@ -24,21 +24,20 @@
 #endif
 
 static PyObject *
-rclpy_init(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+rclpy_init(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
-  /* TODO(esteve): parse args */
+  // TODO(esteve): parse args
   rcl_ret_t ret = rcl_init(0, NULL, rcl_get_default_allocator());
   (void)ret;
   Py_RETURN_NONE;
 }
 
 static PyObject *
-rclpy_create_node(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_create_node(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  const char *node_name;
+  const char * node_name;
 
-  if (!PyArg_ParseTuple(args, "s", &node_name))
-  {
+  if (!PyArg_ParseTuple(args, "s", &node_name)) {
     return NULL;
   }
 
@@ -47,31 +46,30 @@ rclpy_create_node(PyObject *Py_UNUSED(self), PyObject *args)
   rcl_node_options_t default_options = rcl_node_get_default_options();
   rcl_ret_t ret = rcl_node_init(node, node_name, &default_options);
   (void)ret;
-  PyObject *pynode = PyCapsule_New(node, NULL, NULL);
+  PyObject * pynode = PyCapsule_New(node, NULL, NULL);
   return pynode;
 }
 
 static PyObject *
-rclpy_create_publisher(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pynode;
-  PyObject *pymsg_type;
-  PyObject *pytopic;
+  PyObject * pynode;
+  PyObject * pymsg_type;
+  PyObject * pytopic;
 
-  if (!PyArg_ParseTuple(args, "OOO", &pynode, &pymsg_type, &pytopic))
-  {
+  if (!PyArg_ParseTuple(args, "OOO", &pynode, &pymsg_type, &pytopic)) {
     return NULL;
   }
 
   assert(PyUnicode_Check(pytopic));
 
-  char *topic = (char *)PyUnicode_1BYTE_DATA(pytopic);
+  char * topic = (char *)PyUnicode_1BYTE_DATA(pytopic);
 
   rcl_node_t *node = PyCapsule_GetPointer(pynode, NULL);
 
-  PyObject *pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
+  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
-  PyObject *pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
+  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
 
   rosidl_message_type_support_t * ts = PyCapsule_GetPointer(pyts, NULL);
 
@@ -80,32 +78,31 @@ rclpy_create_publisher(PyObject *Py_UNUSED(self), PyObject *args)
   rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();
   rcl_ret_t ret = rcl_publisher_init(publisher, node, ts, topic, &publisher_ops);
   (void)ret;
-  PyObject *pypublisher = PyCapsule_New(publisher, NULL, NULL);
+  PyObject * pypublisher = PyCapsule_New(publisher, NULL, NULL);
   return pypublisher;
 }
 
 static PyObject *
-rclpy_publish(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pypublisher;
-  PyObject *pymsg;
+  PyObject * pypublisher;
+  PyObject * pymsg;
 
-  if (!PyArg_ParseTuple(args, "OO", &pypublisher, &pymsg))
-  {
+  if (!PyArg_ParseTuple(args, "OO", &pypublisher, &pymsg)) {
     return NULL;
   }
 
   rcl_publisher_t *publisher = PyCapsule_GetPointer(pypublisher, NULL);
 
-  PyObject *pymsg_type = PyObject_GetAttrString(pymsg, "__class__");
+  PyObject * pymsg_type = PyObject_GetAttrString(pymsg, "__class__");
 
-  PyObject *pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
+  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
-  PyObject *pyconvert_from_py = PyObject_GetAttrString(pymetaclass, "_CONVERT_FROM_PY");
+  PyObject * pyconvert_from_py = PyObject_GetAttrString(pymetaclass, "_CONVERT_FROM_PY");
 
   void *(*convert_from_py)(PyObject *) = PyCapsule_GetPointer(pyconvert_from_py, NULL);
 
-  void *raw_ros_message = convert_from_py(pymsg);
+  void * raw_ros_message = convert_from_py(pymsg);
 
   rcl_publish(publisher, raw_ros_message);
 
@@ -113,14 +110,13 @@ rclpy_publish(PyObject *Py_UNUSED(self), PyObject *args)
 }
 
 static PyObject *
-rclpy_create_subscription(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pynode;
-  PyObject *pymsg_type;
-  PyObject *pytopic;
+  PyObject * pynode;
+  PyObject * pymsg_type;
+  PyObject * pytopic;
 
-  if (!PyArg_ParseTuple(args, "OOO", &pynode, &pymsg_type, &pytopic))
-  {
+  if (!PyArg_ParseTuple(args, "OOO", &pynode, &pymsg_type, &pytopic)) {
     return NULL;
   }
 
@@ -130,9 +126,9 @@ rclpy_create_subscription(PyObject *Py_UNUSED(self), PyObject *args)
 
   rcl_node_t *node = PyCapsule_GetPointer(pynode, NULL);
 
-  PyObject *pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
+  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
-  PyObject *pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
+  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
 
   rosidl_message_type_support_t * ts = PyCapsule_GetPointer(pyts, NULL);
 
@@ -141,23 +137,23 @@ rclpy_create_subscription(PyObject *Py_UNUSED(self), PyObject *args)
   rcl_subscription_options_t subscription_ops = rcl_subscription_get_default_options();
   rcl_ret_t ret = rcl_subscription_init(subscription, node, ts, topic, &subscription_ops);
   (void)ret;
-  PyObject *pysubscription = PyCapsule_New(subscription, NULL, NULL);
+  PyObject * pysubscription = PyCapsule_New(subscription, NULL, NULL);
   return pysubscription;
 }
 
 static PyObject *
-rclpy_get_implementation_identifier(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+rclpy_get_implementation_identifier(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   const char * rmw_implementation_identifier = rmw_get_implementation_identifier();
 
-  PyObject * pyrmw_implementation_identifier =  Py_BuildValue(
+  PyObject * pyrmw_implementation_identifier = Py_BuildValue(
     "s", rmw_implementation_identifier);
 
   return pyrmw_implementation_identifier;
 }
 
 static PyObject *
-rclpy_get_zero_initialized_wait_set(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+rclpy_get_zero_initialized_wait_set(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   rcl_wait_set_t *wait_set = PyMem_Malloc(sizeof(rcl_wait_set_t));
   wait_set->subscriptions = NULL;
@@ -167,21 +163,21 @@ rclpy_get_zero_initialized_wait_set(PyObject *Py_UNUSED(self), PyObject *Py_UNUS
   wait_set->timers = NULL;
   wait_set->size_of_timers = 0;
   wait_set->impl = NULL;
-  PyObject *pywait_set = PyCapsule_New(wait_set, NULL, NULL);
+  PyObject * pywait_set = PyCapsule_New(wait_set, NULL, NULL);
   return pywait_set;
 }
 
 static PyObject *
-rclpy_wait_set_init(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_wait_set_init(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pywait_set;
+  PyObject * pywait_set;
   unsigned PY_LONG_LONG number_of_subscriptions;
   unsigned PY_LONG_LONG number_of_guard_conditions;
   unsigned PY_LONG_LONG number_of_timers;
 
   if (!PyArg_ParseTuple(
-    args, "OKKK", &pywait_set, &number_of_subscriptions,
-    &number_of_guard_conditions, &number_of_timers))
+      args, "OKKK", &pywait_set, &number_of_subscriptions,
+      &number_of_guard_conditions, &number_of_timers))
   {
     return NULL;
   }
@@ -195,12 +191,11 @@ rclpy_wait_set_init(PyObject *Py_UNUSED(self), PyObject *args)
 }
 
 static PyObject *
-rclpy_wait_set_clear_subscriptions(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_wait_set_clear_subscriptions(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pywait_set;
+  PyObject * pywait_set;
 
-  if (!PyArg_ParseTuple(args, "O", &pywait_set))
-  {
+  if (!PyArg_ParseTuple(args, "O", &pywait_set)) {
     return NULL;
   }
 
@@ -210,13 +205,12 @@ rclpy_wait_set_clear_subscriptions(PyObject *Py_UNUSED(self), PyObject *args)
 }
 
 static PyObject *
-rclpy_wait_set_add_subscription(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_wait_set_add_subscription(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pywait_set;
-  PyObject *pysubscription;
+  PyObject * pywait_set;
+  PyObject * pysubscription;
 
-  if (!PyArg_ParseTuple(args, "OO", &pywait_set, &pysubscription))
-  {
+  if (!PyArg_ParseTuple(args, "OO", &pywait_set, &pysubscription)) {
     return NULL;
   }
 
@@ -227,12 +221,11 @@ rclpy_wait_set_add_subscription(PyObject *Py_UNUSED(self), PyObject *args)
 }
 
 static PyObject *
-rclpy_wait(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pywait_set;
+  PyObject * pywait_set;
 
-  if (!PyArg_ParseTuple(args, "O", &pywait_set))
-  {
+  if (!PyArg_ParseTuple(args, "O", &pywait_set)) {
     return NULL;
   }
 
@@ -242,39 +235,37 @@ rclpy_wait(PyObject *Py_UNUSED(self), PyObject *args)
 }
 
 static PyObject *
-rclpy_take(PyObject *Py_UNUSED(self), PyObject *args)
+rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject *pysubscription;
-  PyObject *pymsg_type;
+  PyObject * pysubscription;
+  PyObject * pymsg_type;
 
-  if (!PyArg_ParseTuple(args, "OO", &pysubscription, &pymsg_type))
-  {
+  if (!PyArg_ParseTuple(args, "OO", &pysubscription, &pymsg_type)) {
     return NULL;
   }
 
   rcl_subscription_t *subscription = PyCapsule_GetPointer(pysubscription, NULL);
 
-  PyObject *pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
+  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
 
-  PyObject *pyconvert_from_py = PyObject_GetAttrString(pymetaclass, "_CONVERT_FROM_PY");
+  PyObject * pyconvert_from_py = PyObject_GetAttrString(pymetaclass, "_CONVERT_FROM_PY");
 
   void *(*convert_from_py)(PyObject *) = PyCapsule_GetPointer(pyconvert_from_py, NULL);
 
-  PyObject *pymsg = PyObject_CallObject(pymsg_type, NULL);
+  PyObject * pymsg = PyObject_CallObject(pymsg_type, NULL);
 
-  void *taken_msg = convert_from_py(pymsg);
+  void * taken_msg = convert_from_py(pymsg);
 
   bool taken = false;
 
   rcl_take(subscription, taken_msg, &taken, NULL);
 
-  if (taken)
-  {
-    PyObject *pyconvert_to_py = PyObject_GetAttrString(pymsg_type, "_CONVERT_TO_PY");
+  if (taken) {
+    PyObject * pyconvert_to_py = PyObject_GetAttrString(pymsg_type, "_CONVERT_TO_PY");
 
     PyObject *(*convert_to_py)(void *) = PyCapsule_GetPointer(pyconvert_to_py, NULL);
 
-    PyObject *pytaken_msg = convert_to_py(taken_msg);
+    PyObject * pytaken_msg = convert_to_py(taken_msg);
 
     Py_INCREF(pytaken_msg);
 
@@ -284,27 +275,25 @@ rclpy_take(PyObject *Py_UNUSED(self), PyObject *args)
 }
 
 static PyObject *
-rclpy_ok(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+rclpy_ok(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   bool ok = rcl_ok();
-  if(ok)
-  {
+  if (ok) {
     Py_RETURN_TRUE;
-  } else
-  {
+  } else {
     Py_RETURN_FALSE;
   }
 }
 
 static PyObject *
-rclpy_shutdown(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+rclpy_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   rcl_shutdown();
   Py_RETURN_NONE;
 }
 
 static PyMethodDef rclpy_methods[] = {
-  {"rclpy_init",  rclpy_init, METH_VARARGS,
+  {"rclpy_init", rclpy_init, METH_VARARGS,
    "Initialize RCL."},
   {"rclpy_create_node", rclpy_create_node, METH_VARARGS,
    "Create a Node."},
@@ -345,15 +334,15 @@ static PyMethodDef rclpy_methods[] = {
 };
 
 static struct PyModuleDef _rclpymodule = {
-   PyModuleDef_HEAD_INIT,
-   "_rclpy",
-   "_rclpy_doc",
-   -1,  /* -1 means that the module keeps state in global variables */
-   rclpy_methods,
-   NULL,
-   NULL,
-   NULL,
-   NULL
+  PyModuleDef_HEAD_INIT,
+  "_rclpy",
+  "_rclpy_doc",
+  -1,   /* -1 means that the module keeps state in global variables */
+  rclpy_methods,
+  NULL,
+  NULL,
+  NULL,
+  NULL
 };
 
 #define MAKE_FN_NAME(x) PyInit__rclpy ## x

--- a/src/rclpy/_rclpy.c
+++ b/src/rclpy/_rclpy.c
@@ -1,3 +1,17 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <Python.h>
 
 #include <rmw/rmw.h>

--- a/src/rclpy/_rclpy.c
+++ b/src/rclpy/_rclpy.c
@@ -411,7 +411,6 @@ static struct PyModuleDef _rclpymodule = {
 #define MAKE_FN_NAME(x) PyInit__rclpy ## x
 #define FUNCTION_NAME(suffix) MAKE_FN_NAME(suffix)
 
-PyMODINIT_FUNC FUNCTION_NAME(RMW_IMPLEMENTATION_SUFFIX)(void)
-{
+PyMODINIT_FUNC FUNCTION_NAME(RMW_IMPLEMENTATION_SUFFIX)(void) {
   return PyModule_Create(&_rclpymodule);
 }


### PR DESCRIPTION
The big change here is that I renamed `_rclpy.c.in` to `_rclpy.c` and changed to using a preprocessor definition instead of the CMake template that was being used before. I thought this was better so that editors could more easily detect and color the file, and for me it allowed me to add a definition to my C++ checker and then it could parse and check for warnings/errors in my editor, which is obviously harder when it's a CMake template.

I also addressed the style stuff in `_rclpy.c` according to uncrusfity and cpplint, added a copyright header, and changed it so that rcl errors are propagated up to Python as `RuntimeError`'s.

@esteve I made this as a pull request so you could consider the changes before merging it into your pull request.