### PR TITLE
Improved rclpy import failed message

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -20,8 +20,12 @@ from rclpy.exceptions import InvalidRCLPYImplementation
 from rclpy.impl import implementation_singleton
 from rclpy.impl import rmw_implementation_tools
 from rclpy.node import Node
+from rclpy.impl import excepthook
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+# install the excepthook
+excepthook.install_rclpy_excepthook()
 
 
 def init(args=None):

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -19,6 +19,7 @@ import sys
 from rclpy.exceptions import InvalidRCLPYImplementation
 from rclpy.impl import implementation_singleton
 from rclpy.impl import rmw_implementation_tools
+from rclpy.impl.rmw_implementation_tools import RCLPY_IMPLEMENTATION_ENV_NAME
 from rclpy.node import Node
 from rclpy.impl import excepthook
 
@@ -29,7 +30,7 @@ excepthook.install_rclpy_excepthook()
 
 
 def init(args=None):
-    rclpy_rmw_env = os.getenv('RCLPY_IMPLEMENTATION', None)
+    rclpy_rmw_env = os.getenv(RCLPY_IMPLEMENTATION_ENV_NAME, None)
     if rclpy_rmw_env is not None:
         available_rmw_implementations = rmw_implementation_tools.get_rmw_implementations()
         if rclpy_rmw_env not in available_rmw_implementations:

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -13,13 +13,6 @@
 # limitations under the License.
 
 
-class NotInitializedException(Exception):
-    """Raised when the rclpy implementation is accessed before rclpy.init()."""
-
-    def __init__(self, *args):
-        Exception.__init__(self, 'rclpy.init() has not been called', *args)
-
-
 class ImplementationAlreadyImportedException(Exception):
     """Raised on select_rmw_implemenation() after import_rmw_implementation() has been called."""
 
@@ -32,3 +25,17 @@ class InvalidRCLPYImplementation(Exception):
 
     def __init__(self, *args):
         Exception.__init__(self, 'requested invalid rmw implementation', *args)
+
+
+class NotInitializedException(Exception):
+    """Raised when the rclpy implementation is accessed before rclpy.init()."""
+
+    def __init__(self, *args):
+        Exception.__init__(self, 'rclpy.init() has not been called', *args)
+
+
+class NoImplementationAvailableException(Exception):
+    """Raised when there is no rmw implementation with a Python extension available."""
+
+    def __init__(self, *args):
+        Exception.__init__(self, 'no rmw implementation with a Python extension available')

--- a/rclpy/rclpy/impl/excepthook.py
+++ b/rclpy/rclpy/impl/excepthook.py
@@ -20,7 +20,7 @@ __unhandled_exception_addendums = {}
 
 
 def rclpy_excepthook(exc_type, value, traceback):
-    """rclpy's custom except hook for unhandled exceptions.
+    """The rclpy custom except hook for unhandled exceptions.
 
     This excepthook will check for any unhandled exception addendum's,
     log them if they exist, and then call the original excepthook.

--- a/rclpy/rclpy/impl/excepthook.py
+++ b/rclpy/rclpy/impl/excepthook.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+__original_excepthook = None
+__unhandled_exception_addendums = {}
+
+
+def rclpy_excepthook(exc_type, value, traceback):
+    """rclpy's custom except hook for unhandled exceptions.
+
+    This excepthook will check for any unhandled exception addendum's,
+    log them if they exist, and then call the original excepthook.
+    The original excepthook is what ever was in ``sys.excepthook`` when
+    :py:func:`install_rclpy_excepthook` was called.
+
+    Any addendum found during this excepthook will be removed after logging.
+    """
+    if value in __unhandled_exception_addendums:
+        logger = logging.getLogger('rclpy')
+        logger.error(__unhandled_exception_addendums[value])
+        del __unhandled_exception_addendums[value]
+    return __original_excepthook(exc_type, value, traceback)
+
+
+def install_rclpy_excepthook():
+    """Replace the system excepthook with the custom rclpy excepthook.
+
+    Repeated calls to this function will return without any side effects.
+    """
+    global __original_excepthook
+    if __original_excepthook is not None:
+        # The rclpy excepthook has already been installed.
+        return
+    __original_excepthook = sys.excepthook
+    sys.excepthook = rclpy_excepthook
+
+
+def add_unhandled_exception_addendum(exception, message):
+    """Add an addendum for the given exception.
+
+    If the exception is never handled, then the addendum will be logged before
+    passing the exception to the original excepthook.
+    This only works if the custom rclpy excepthook has been installed with
+    :py:func:`install_rclpy_excepthook`.
+    """
+    __unhandled_exception_addendums[exception] = message

--- a/rclpy/rclpy/impl/rmw_implementation_tools.py
+++ b/rclpy/rclpy/impl/rmw_implementation_tools.py
@@ -97,7 +97,7 @@ def import_rmw_implementation():
     try:
         __rmw_implementation_module = importlib.import_module(module_name, package='rclpy')
     except ImportError as exc:
-        if "No module named 'rclpy._rclpy__" in str(exc):
+        if "No module named 'rclpy.{0}".format(module_name) in str(exc):
             if available_implementations:
                 rmw_implementations_msg = '\n'.join(
                     ['  - {0}'.format(x) for x in available_implementations]


### PR DESCRIPTION
I achieved this by adding a helpful message which prints when the import fails, but only if it goes unhandled.

I wanted to avoid printing it always incase someone is explicitly trying each of the implementations and wants to avoid the logging output. To accomplish this I added a custom `excepthook` for `rclpy` to override the built-in `sys.excepthook`. You can also add "addendum's" for uncaught exceptions, which will printed before the traceback. In the custom `excepthook`, it looks for a matching addendum, prints it if it finds one, and then passes along the unhandled exception to the original `excepthook`.

This is the observed behavior:

- In the normal case you get something like:

```
% python3 -c "import talker_py; talker_py.main()"

Failed to import the Python extension for the 'rmw_fastrtps_cpp' rmw implementation.
A different rmw implementation can be selected using the 'RCLPY_IMPLEMENTATION' env variable.
These are the available rmw implementations:
  - rmw_fastrtps_cpp
  - rmw_opensplice_cpp

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/william/ros2_ws/build_isolated/rclpy_examples/talker_py.py", line 27, in main
    rclpy.init(args)
  File "/Users/william/ros2_ws/install_isolated/rclpy/lib/python3.5/site-packages/rclpy/__init__.py", line 47, in init
    rmw_implementation_tools.import_rmw_implementation()
  File "/Users/william/ros2_ws/install_isolated/rclpy/lib/python3.5/site-packages/rclpy/impl/rmw_implementation_tools.py", line 90, in import_rmw_implementation
    __rmw_implementation_module = importlib.import_module(module_name, package='rclpy')
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 956, in _find_and_load_unlocked
ImportError: No module named 'rclpy._rclpy__rmw_fastrtps_cpp'
```

- In the case that you catch it, you get:
```
% python3 -c "
import talker_py
try:
    talker_py.main()
except ImportError:
    print('failed to import')
"
failed to import
```