### PR TITLE
register rmw python extensions separately

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -77,6 +77,14 @@ macro(target)
     ${PythonExtra_INCLUDE_DIRS}
   )
 
+  # make an entry in the ament index for each rmw implementation for which
+  # a rclpy Python extension is built
+  # this is used in the Python code to avoid trying to import a Python
+  # extension for rmw implementations which do not have one
+  ament_index_register_resource("rmw_implementation_python_extension"
+    PACKAGE_NAME ${rmw_implementation}
+  )
+
   install(TARGETS ${PROJECT_NAME}${target_suffix}
     DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}")
 endmacro()

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -96,12 +96,16 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   rosidl_generator_py_get_typesupports(_typesupport_impls)
-  ament_index_get_preinstall_prefix(preinstall_ament_prefix)
+  ament_index_get_prefix_path(ament_prefix_path_list)
+  # Do this even on Windows, because the Python run_test.py will handle the : vs ; issues.
+  string(REPLACE ";" ":" ament_prefix_path "${ament_prefix_path_list}")
+  if(WIN32)
+    string(REPLACE "\\" "/" ament_prefix_path "${ament_prefix_path}")
+  endif()
   if(NOT "${_typesupport_impls} " STREQUAL " ")
     ament_add_nose_test(rclpytests test
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-      # Append the "mock" ament index in the build space for the tests.
-      APPEND_ENV AMENT_PREFIX_PATH=${preinstall_ament_prefix}
+      ENV AMENT_PREFIX_PATH=${ament_prefix_path}
     )
   endif()
 endif()

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -81,7 +81,7 @@ macro(target)
   # a rclpy Python extension is built
   # this is used in the Python code to avoid trying to import a Python
   # extension for rmw implementations which do not have one
-  ament_index_register_resource("rmw_implementation_python_extension"
+  ament_index_register_resource("rmw_python_extension"
     PACKAGE_NAME ${rmw_implementation}
   )
 
@@ -96,9 +96,12 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   rosidl_generator_py_get_typesupports(_typesupport_impls)
+  ament_index_get_preinstall_prefix(preinstall_ament_prefix)
   if(NOT "${_typesupport_impls} " STREQUAL " ")
     ament_add_nose_test(rclpytests test
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+      # Append the "mock" ament index in the build space for the tests.
+      APPEND_ENV AMENT_PREFIX_PATH=${preinstall_ament_prefix}
     )
   endif()
 endif()

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -96,21 +96,17 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   rosidl_generator_py_get_typesupports(_typesupport_impls)
-  ament_index_get_prefix_path(ament_prefix_path)
+  ament_index_get_prefix_path(ament_index_build_path SKIP_AMENT_PREFIX_PATH)
+  # Get the first item (it will be the build space version of the build path).
+  list(GET ament_index_build_path 0 ament_index_build_path)
   if(WIN32)
     # On Windows prevent CMake errors and prevent it being evaluated as a list.
-    string(REPLACE "\\" "/" ament_prefix_path "${ament_prefix_path}")
-    # TODO(wjwwood): change this when we have a better way to pass PATH lists
-    #   to environment variables on Windows.
-    string(REPLACE ";" "\;" ament_prefix_path "${ament_prefix_path}")
-  else()
-    # Otherwise convert the CMake list into a :-separated Unix like PATH list.
-    string(REPLACE ";" ":" ament_prefix_path "${ament_prefix_path}")
+    string(REPLACE "\\" "/" ament_index_build_path "${ament_index_build_path}")
   endif()
   if(NOT "${_typesupport_impls} " STREQUAL " ")
     ament_add_nose_test(rclpytests test
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-      ENV AMENT_PREFIX_PATH=${ament_prefix_path}
+      APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}
     )
   endif()
 endif()

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -96,11 +96,16 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   rosidl_generator_py_get_typesupports(_typesupport_impls)
-  ament_index_get_prefix_path(ament_prefix_path_list)
-  # Do this even on Windows, because the Python run_test.py will handle the : vs ; issues.
-  string(REPLACE ";" ":" ament_prefix_path "${ament_prefix_path_list}")
+  ament_index_get_prefix_path(ament_prefix_path)
   if(WIN32)
+    # On Windows prevent CMake errors and prevent it being evaluated as a list.
     string(REPLACE "\\" "/" ament_prefix_path "${ament_prefix_path}")
+    # TODO(wjwwood): change this when we have a better way to pass PATH lists
+    #   to environment variables on Windows.
+    string(REPLACE ";" "\;" ament_prefix_path "${ament_prefix_path}")
+  else()
+    # Otherwise convert the CMake list into a :-separated Unix like PATH list.
+    string(REPLACE ";" ":" ament_prefix_path "${ament_prefix_path}")
   endif()
   if(NOT "${_typesupport_impls} " STREQUAL " ")
     ament_add_nose_test(rclpytests test

--- a/rclpy/rclpy/impl/rmw_implementation_tools.py
+++ b/rclpy/rclpy/impl/rmw_implementation_tools.py
@@ -24,17 +24,13 @@ __rmw_implementations = None
 __selected_rmw_implementation = None
 __rmw_implementation_module = None
 
+AMENT_INDEX_NAME = 'rmw_implementation_python_extension'
+
 
 def reload_rmw_implementations():
     """(Re)Load the available rmw implementations by inspecting the ament index."""
     global __rmw_implementations
-    __rmw_implementations = sorted(ament_index_python.get_resources('rmw_implementation').keys())
-
-    # Remove implementations that are being filtered for in the rclpy CMakeLists so
-    # that they cannot be selected
-    __rmw_implementations = [
-        rmw_impl for rmw_impl in __rmw_implementations
-        if rmw_impl not in ['rmw_connext_dynamic_cpp', 'rmw_fastrtps_cpp']]
+    __rmw_implementations = sorted(ament_index_python.get_resources(AMENT_INDEX_NAME).keys())
     return __rmw_implementations
 
 

--- a/rclpy/rclpy/impl/rmw_implementation_tools.py
+++ b/rclpy/rclpy/impl/rmw_implementation_tools.py
@@ -24,7 +24,8 @@ __rmw_implementations = None
 __selected_rmw_implementation = None
 __rmw_implementation_module = None
 
-AMENT_INDEX_NAME = 'rmw_implementation_python_extension'
+AMENT_INDEX_NAME = 'rmw_python_extension'
+
 
 
 def reload_rmw_implementations():

--- a/rclpy/rclpy/impl/rmw_implementation_tools.py
+++ b/rclpy/rclpy/impl/rmw_implementation_tools.py
@@ -27,7 +27,6 @@ __rmw_implementation_module = None
 AMENT_INDEX_NAME = 'rmw_python_extension'
 
 
-
 def reload_rmw_implementations():
     """(Re)Load the available rmw implementations by inspecting the ament index."""
     global __rmw_implementations

--- a/rclpy/test/test_select_rmw_implementation.py
+++ b/rclpy/test/test_select_rmw_implementation.py
@@ -43,18 +43,7 @@ def func_import_each_available_rmw_implementation(rmw_implementation):
     assert(rmw_implementation in rmw_implementations)
 
     select_rmw_implementation(rmw_implementation)
-    try:
-        rclpy.init([])
-    except ImportError as exc:
-        if "No module named 'rclpy._rclpy__" in '{0}'.format(exc):
-            # Not all rmw implementations generate a Python implementation.
-            # TODO(wjwwood): prune get_rmw_implementations by
-            #   implementations that have generated a Python implementation
-            #   (probably use a separate ament index entry).
-            print("Failed to import rmw implementation '{0}', ignoring."
-                  .format(rmw_implementation), file=sys.stderr)
-            return ctypes.c_bool(True)
-        raise
+    rclpy.init([])
 
     set_rmw = rclpy.get_rmw_implementation_identifier()
 
@@ -93,18 +82,7 @@ def func_select_rmw_implementation_by_environment(rmw_implementation):
     rmw_implementations = get_rmw_implementations()
     assert(os.environ['RCLPY_IMPLEMENTATION'] in rmw_implementations)
 
-    try:
-        rclpy.init([])
-    except ImportError as exc:
-        if "No module named 'rclpy._rclpy__" in '{0}'.format(exc):
-            # Not all rmw implementations generate a Python implementation.
-            # TODO(wjwwood): prune get_rmw_implementations by
-            #   implementations that have generated a Python implementation
-            #   (probably use a separate ament index entry).
-            return ctypes.c_bool(True)
-            print("Failed to import rmw implementation '{0}', ignoring."
-                  .format(rmw_implementation), file=sys.stderr)
-        raise
+    rclpy.init([])
 
     set_rmw = rclpy.get_rmw_implementation_identifier()
 


### PR DESCRIPTION
I added a new "ament index" entry specifically for rmw implementations with Python extensions and use that to load from. This removes the need for the blacklist in #10 and also addresses the style issues from #10.

I also removed the exceptions in the tests for these failures. However, in order to get the tests working I had to add another patch to `ament_cmake` so that I can use the ament index before installing.