### PR TITLE
restor spin timeout to 1sec

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -82,7 +82,7 @@ def spin_once(node, timeout_sec=None):
             )
 
     if timeout_sec is None:
-        timeout = -1
+        timeout = S_TO_NS
     else:
         timeout = int(float(timeout_sec) * S_TO_NS)
 

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -82,7 +82,7 @@ def spin_once(node, timeout_sec=None):
             )
 
     if timeout_sec is None:
-        timeout = S_TO_NS
+        timeout = 1 * S_TO_NS
     else:
         timeout = int(float(timeout_sec) * S_TO_NS)
 


### PR DESCRIPTION
Right now the absence of guard_condition support prevent python script to be interrupted when waiting in c (rcl_wait)
This sets the default value to 1sec.
see https://github.com/ros2/examples/pull/141#issuecomment-263388756