### PR TITLE
Add sigint guard condition

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -63,11 +63,12 @@ def spin_once(node, timeout_sec=None):
     _rclpy.rclpy_wait_set_init(
         wait_set,
         len(node.subscriptions),
-        0,
+        1,
         len(node.timers),
         len(node.clients),
         len(node.services))
 
+    [sigint_gc, sigint_gc_handle] = _rclpy.rclpy_get_sigint_guard_condition()
     entities = {
         'subscription': (node.subscriptions, 'subscription_handle'),
         'client': (node.clients, 'client_handle'),
@@ -80,6 +81,8 @@ def spin_once(node, timeout_sec=None):
             _rclpy.rclpy_wait_set_add_entity(
                 entity, wait_set, h.__getattribute__(handle_name)
             )
+    _rclpy.rclpy_wait_set_clear_entities('guard_condition', wait_set)
+    _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
 
     if timeout_sec is None:
         timeout = -1
@@ -87,6 +90,10 @@ def spin_once(node, timeout_sec=None):
         timeout = int(float(timeout_sec) * S_TO_NS)
 
     _rclpy.rclpy_wait(wait_set, timeout)
+
+    guard_condition_ready_list = _rclpy.rclpy_get_ready_entities('guard_condition', wait_set)
+    if sigint_gc_handle in guard_condition_ready_list:
+        raise KeyboardInterrupt
 
     timer_ready_list = _rclpy.rclpy_get_ready_entities('timer', wait_set)
     for tmr in [t for t in node.timers if t.timer_pointer in timer_ready_list]:

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -25,6 +25,47 @@
 #error "RMW_IMPLEMENTATION_SUFFIX is required to be set for _rclpy.c"
 #endif
 
+static rcl_guard_condition_t * g_sigint_gc_handle;
+
+/// Catch signals
+static void catch_function(int signo)
+{
+  (void) signo;
+  rcl_ret_t ret = rcl_trigger_guard_condition(g_sigint_gc_handle);
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to trigger guard_condition: %s", rcl_get_error_string_safe());
+  }
+}
+
+/// Create a sigint guard condition 
+/*
+ * \return NULL on failure:
+ *         List with 2 elements on success:
+ *            first element: a Capsule pointing to the pointer of the created rcl_guard_condition_t * structure
+ *            second element: an integer representing the memory address of the created rcl_guard_condition_t
+ */
+static PyObject *
+rclpy_get_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  rcl_guard_condition_t * sigint_gc = (rcl_guard_condition_t *)PyMem_Malloc(sizeof(rcl_guard_condition_t));
+  *sigint_gc = rcl_get_zero_initialized_guard_condition();
+  rcl_guard_condition_options_t sigint_gc_options = rcl_guard_condition_get_default_options();
+  
+  rcl_ret_t ret = rcl_guard_condition_init(sigint_gc, sigint_gc_options);
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to create guard_condition: %s", rcl_get_error_string_safe());
+    return NULL;
+  }
+  g_sigint_gc_handle = sigint_gc;
+  PyObject * pylist = PyList_New(0);
+  PyList_Append(pylist, PyCapsule_New(sigint_gc, NULL, NULL));
+  PyList_Append(pylist, PyLong_FromUnsignedLongLong((uint64_t)&sigint_gc->impl));
+
+  return pylist;
+}
+
 /// Initialize rcl with default options, ignoring parameters
 static PyObject *
 rclpy_init(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
@@ -908,8 +949,6 @@ rclpy_wait_set_init(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
-
-  // TODO(jacquelinekay) Services.
   rcl_ret_t ret = rcl_wait_set_init(
     wait_set, number_of_subscriptions, number_of_guard_conditions, number_of_timers,
     number_of_clients, number_of_services, rcl_get_default_allocator());
@@ -947,6 +986,8 @@ rclpy_wait_set_clear_entities(PyObject * Py_UNUSED(self), PyObject * args)
     ret = rcl_wait_set_clear_services(wait_set);
   } else if (0 == strcmp(entity_type, "timer")) {
     ret = rcl_wait_set_clear_timers(wait_set);
+  } else if (0 == strcmp(entity_type, "guard_condition")) {
+    ret = rcl_wait_set_clear_guard_conditions(wait_set);
   } else {
     PyErr_Format(PyExc_RuntimeError,
       "%s is not a known entity", entity_type);
@@ -995,6 +1036,10 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
     rcl_timer_t * timer =
       (rcl_timer_t *)PyCapsule_GetPointer(pyentity, NULL);
     ret = rcl_wait_set_add_timer(wait_set, timer);
+  } else if (0 == strcmp(entity_type, "guard_condition")) {
+    rcl_guard_condition_t * guard_condition =
+      (rcl_guard_condition_t *)PyCapsule_GetPointer(pyentity, NULL);
+    ret = rcl_wait_set_add_guard_condition(wait_set, guard_condition);
   } else {
     PyErr_Format(PyExc_RuntimeError,
       "%s is not a known entity", entity_type);
@@ -1051,6 +1096,8 @@ rclpy_get_ready_entities(PyObject * Py_UNUSED(self), PyObject * args)
     GET_LIST_READY_ENTITIES(service)
   } else if (0 == strcmp(entity_type, "timer")) {
     GET_LIST_READY_ENTITIES(timer)
+  } else if (0 == strcmp(entity_type, "guard_condition")) {
+    GET_LIST_READY_ENTITIES(guard_condition)
   } else {
     PyErr_Format(PyExc_RuntimeError,
       "%s is not a known entity", entity_type);
@@ -1073,7 +1120,8 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pywait_set;
   PY_LONG_LONG timeout = -1;
-
+  
+  signal(SIGINT, catch_function);
   if (!PyArg_ParseTuple(args, "O|K", &pywait_set, &timeout)) {
     return NULL;
   }
@@ -1387,6 +1435,9 @@ static PyMethodDef rclpy_methods[] = {
   {"rclpy_create_timer", rclpy_create_timer, METH_VARARGS,
    "Create a Timer."},
 
+  {"rclpy_get_sigint_guard_condition", rclpy_get_sigint_guard_condition, METH_NOARGS,
+   "Create a guard_condition triggered when sigint is received."},
+
   {"rclpy_destroy_node_entity", rclpy_destroy_node_entity, METH_VARARGS,
    "Destroy a Node entity."},
   {"rclpy_destroy_entity", rclpy_destroy_entity, METH_VARARGS,
@@ -1464,6 +1515,7 @@ static PyMethodDef rclpy_methods[] = {
 
   {"rclpy_get_rmw_implementation_identifier", rclpy_get_rmw_implementation_identifier,
    METH_NOARGS, "Retrieve the identifier for the active RMW implementation."},
+
   {NULL, NULL, 0, NULL}  /* sentinel */
 };
 


### PR DESCRIPTION
This add support for SIGINT signals to be processed from C code and raise the interrupt in Python.
This solves the current issue of Python scripts not killable if they're spinning