### PR TITLE
add sigint guard condition

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -63,11 +63,12 @@ def spin_once(node, timeout_sec=None):
     _rclpy.rclpy_wait_set_init(
         wait_set,
         len(node.subscriptions),
-        0,
+        1,
         len(node.timers),
         len(node.clients),
         len(node.services))
 
+    [sigint_gc, sigint_gc_handle] = _rclpy.rclpy_get_sigint_guard_condition()
     entities = {
         'subscription': (node.subscriptions, 'subscription_handle'),
         'client': (node.clients, 'client_handle'),
@@ -80,6 +81,8 @@ def spin_once(node, timeout_sec=None):
             _rclpy.rclpy_wait_set_add_entity(
                 entity, wait_set, h.__getattribute__(handle_name)
             )
+    _rclpy.rclpy_wait_set_clear_entities('guard_condition', wait_set)
+    _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
 
     if timeout_sec is None:
         timeout = -1
@@ -87,6 +90,10 @@ def spin_once(node, timeout_sec=None):
         timeout = int(float(timeout_sec) * S_TO_NS)
 
     _rclpy.rclpy_wait(wait_set, timeout)
+
+    guard_condition_ready_list = _rclpy.rclpy_get_ready_entities('guard_condition', wait_set)
+    if sigint_gc_handle in guard_condition_ready_list:
+        raise KeyboardInterrupt
 
     timer_ready_list = _rclpy.rclpy_get_ready_entities('timer', wait_set)
     for tmr in [t for t in node.timers if t.timer_pointer in timer_ready_list]:


### PR DESCRIPTION
Round 2 without windows failure.
Use dummily sigint and doesn't leverage sigactions.
This could be refactored onece executor and guard conditions are properly integrated but it does solve the problem of script not being killed by Ctrl-C when waiting for something to happen in waitset.
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2025)](http://ci.ros2.org/job/ci_linux/2025)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1554)](http://ci.ros2.org/job/ci_osx/1554/) (pub/sub flaky tests not related)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2006)](http://ci.ros2.org/job/ci_windows/2006/) (warnings not related)