### PR TITLE
remove unused dependencies

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -20,12 +20,7 @@
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>geometry_msgs</test_depend>
-  <test_depend>launch</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
-  <test_depend>rosidl_typesupport_opensplice_c</test_depend>
-  <test_depend>sensor_msgs</test_depend>
-  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
All these are artifacts from the time rclpy was testing pub/sub internally and not in test_communication.
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2036)](http://ci.ros2.org/job/ci_linux/2036)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1568)](http://ci.ros2.org/job/ci_osx/1568/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2025)](http://ci.ros2.org/job/ci_windows/2025/)