### PR TITLE
skip D401 on rclpy_excepthook

### DIFF
--- a/rclpy/rclpy/impl/excepthook.py
+++ b/rclpy/rclpy/impl/excepthook.py
@@ -19,7 +19,7 @@ __original_excepthook = None
 __unhandled_exception_addendums = {}
 
 
-def rclpy_excepthook(exc_type, value, traceback):
+def rclpy_excepthook(exc_type, value, traceback):  # noqa: D401
     """
     The rclpy custom except hook for unhandled exceptions.
 


### PR DESCRIPTION
I couldn't find a way to make the docstring imperative and still make sense. So I added a noqa as suggested by pydocstyle when this one gives a false positive. I'm 100% happy with the solution, but I'm going to merge it as soon as I get a green CI back since it is broken on master atm due to the new pydocstyle version.

If someone has a better solution please open up a new pr for it.