### PR TITLE
Use namespaces

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -21,9 +21,9 @@
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
   <test_depend>std_msgs</test_depend>
-  <test_depend>std_srvs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
   <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -27,9 +27,12 @@ def init(*, args=None):
 
 def create_node(node_name, *, namespace=None):
     namespace = namespace or ''
+    failed = False
     try:
         node_handle = _rclpy.rclpy_create_node(node_name, namespace)
     except ValueError:
+        failed = True
+    if failed:
         # these will raise more specific errors if the name or namespace is bad
         validate_node_name(node_name)
         # emulate what rcl_node_init() does to accept '' and relative namespaces
@@ -38,8 +41,6 @@ def create_node(node_name, *, namespace=None):
         if not namespace.startswith('/'):
             namespace = '/' + namespace
         validate_namespace(namespace)
-        # otherwise re-raise
-        raise
     return Node(node_handle)
 
 

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -25,3 +25,43 @@ class NoTypeSupportImportedException(Exception):
 
     def __init__(self, *args):
         Exception.__init__(self, 'no type_support imported')
+
+
+class NameValidationException(Exception):
+    """Raised when a topic name, node name, or namespace are invalid."""
+
+    def __init__(self, name_type, name, error_msg, invalid_index, *args):
+        msg = """\
+Invalid {name_type}: {error_msg}:
+  '{name}'
+   {indent}^\
+""".format(name_type=name_type, name=name, error_msg=error_msg, indent=' ' * invalid_index)
+        Exception.__init__(self, msg)
+
+
+class InvalidNamespaceException(NameValidationException):
+    """Raised when a namespace is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "namespace", name, error_msg, invalid_index)
+
+
+class InvalidNodeNameException(NameValidationException):
+    """Raised when a node name is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "node name", name, error_msg, invalid_index)
+
+
+class InvalidTopicNameException(NameValidationException):
+    """Raised when a topic name is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "topic name", name, error_msg, invalid_index)
+
+
+class InvalidServiceNameException(NameValidationException):
+    """Raised when a service name is invalid."""
+
+    def __init__(self, name, error_msg, invalid_index, *args):
+        NameValidationException.__init__(self, "service name", name, error_msg, invalid_index)

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -20,13 +20,6 @@ class NotInitializedException(Exception):
         Exception.__init__(self, 'rclpy.init() has not been called', *args)
 
 
-class NoImplementationAvailableException(Exception):
-    """Raised when there is no rmw implementation with a Python extension available."""
-
-    def __init__(self, *args):
-        Exception.__init__(self, 'no rmw implementation with a Python extension available')
-
-
 class NoTypeSupportImportedException(Exception):
     """Raised when there is no type support imported."""
 

--- a/rclpy/rclpy/expand_topic_name.py
+++ b/rclpy/rclpy/expand_topic_name.py
@@ -1,0 +1,33 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def expand_topic_name(topic_name, node_name, node_namespace):
+    """
+    Expand a given topic name using given node name and namespace as well.
+
+    Note that this function can succeed but the expanded topic name may still
+    be invalid.
+    The :py:func:validate_full_topic_name(): should be used on the expanded
+    topic name to ensure it is valid after expansion.
+
+    :param topic_name str: topic name to be expanded
+    :param node_name str: name of the node that this topic is associated with
+    :param namespace str: namespace that the topic is within
+    :returns: expanded topic name which is fully qualified
+    :raises: ValueError if the topic name, node name or namespace are invalid
+    """
+    return _rclpy.rclpy_expand_topic_name(topic_name, node_name, node_namespace)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -15,12 +15,17 @@
 from rclpy.client import Client
 from rclpy.constants import S_TO_NS
 from rclpy.exceptions import NoTypeSupportImportedException
+from rclpy.expand_topic_name import expand_topic_name
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
 from rclpy.subscription import Subscription
 from rclpy.timer import WallTimer
+from rclpy.validate_full_topic_name import validate_full_topic_name
+from rclpy.validate_namespace import validate_namespace
+from rclpy.validate_node_name import validate_node_name
+from rclpy.validate_topic_name import validate_topic_name
 
 
 class Node:
@@ -47,14 +52,28 @@ class Node:
     def get_namespace(self):
         return _rclpy.rclpy_get_node_namespace(self.handle)
 
+    def _validate_topic_or_service_name(self, topic_or_service_name, *, is_service=False):
+        name = self.get_name()
+        namespace = self.get_namespace()
+        validate_node_name(name)
+        validate_namespace(namespace)
+        validate_topic_name(topic_or_service_name, is_service=is_service)
+        expanded_topic_or_service_name = expand_topic_name(topic_or_service_name, name, namespace)
+        validate_full_topic_name(expanded_topic_or_service_name, is_service=is_service)
+
     def create_publisher(self, msg_type, topic, *, qos_profile=qos_profile_default):
         # this line imports the typesupport for the message module if not already done
         if msg_type.__class__._TYPE_SUPPORT is None:
             msg_type.__class__.__import_type_support__()
         if msg_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
-        publisher_handle = _rclpy.rclpy_create_publisher(
-            self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
+        try:
+            publisher_handle = _rclpy.rclpy_create_publisher(
+                self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
+        except ValueError:
+            self._validate_topic_or_service_name(topic)
+            # If none of those, re-raise the original
+            raise
         publisher = Publisher(publisher_handle, msg_type, topic, qos_profile, self.handle)
         self.publishers.append(publisher)
         return publisher
@@ -65,8 +84,13 @@ class Node:
             msg_type.__class__.__import_type_support__()
         if msg_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
-        [subscription_handle, subscription_pointer] = _rclpy.rclpy_create_subscription(
-            self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
+        try:
+            [subscription_handle, subscription_pointer] = _rclpy.rclpy_create_subscription(
+                self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
+        except ValueError:
+            self._validate_topic_or_service_name(topic)
+            # If none of those, re-raise the original
+            raise
 
         subscription = Subscription(
             subscription_handle, subscription_pointer, msg_type,
@@ -79,11 +103,16 @@ class Node:
             srv_type.__class__.__import_type_support__()
         if srv_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
-        [client_handle, client_pointer] = _rclpy.rclpy_create_client(
-            self.handle,
-            srv_type,
-            srv_name,
-            qos_profile.get_c_qos_profile())
+        try:
+            [client_handle, client_pointer] = _rclpy.rclpy_create_client(
+                self.handle,
+                srv_type,
+                srv_name,
+                qos_profile.get_c_qos_profile())
+        except ValueError:
+            self._validate_topic_or_service_name(srv_name, is_service=True)
+            # If none of those, re-raise the original
+            raise
         client = Client(
             self.handle, client_handle, client_pointer, srv_type, srv_name, qos_profile)
         self.clients.append(client)
@@ -95,11 +124,16 @@ class Node:
             srv_type.__class__.__import_type_support__()
         if srv_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
-        [service_handle, service_pointer] = _rclpy.rclpy_create_service(
-            self.handle,
-            srv_type,
-            srv_name,
-            qos_profile.get_c_qos_profile())
+        try:
+            [service_handle, service_pointer] = _rclpy.rclpy_create_service(
+                self.handle,
+                srv_type,
+                srv_name,
+                qos_profile.get_c_qos_profile())
+        except ValueError:
+            self._validate_topic_or_service_name(srv_name, is_service=True)
+            # If none of those, re-raise the original
+            raise
         service = Service(
             self.handle, service_handle, service_pointer,
             srv_type, srv_name, callback, qos_profile)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -67,13 +67,14 @@ class Node:
             msg_type.__class__.__import_type_support__()
         if msg_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
+        failed = False
         try:
             publisher_handle = _rclpy.rclpy_create_publisher(
                 self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
         except ValueError:
+            failed = True
+        if failed:
             self._validate_topic_or_service_name(topic)
-            # If none of those, re-raise the original
-            raise
         publisher = Publisher(publisher_handle, msg_type, topic, qos_profile, self.handle)
         self.publishers.append(publisher)
         return publisher
@@ -84,13 +85,14 @@ class Node:
             msg_type.__class__.__import_type_support__()
         if msg_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
+        failed = False
         try:
             [subscription_handle, subscription_pointer] = _rclpy.rclpy_create_subscription(
                 self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
         except ValueError:
+            failed = True
+        if failed:
             self._validate_topic_or_service_name(topic)
-            # If none of those, re-raise the original
-            raise
 
         subscription = Subscription(
             subscription_handle, subscription_pointer, msg_type,
@@ -103,6 +105,7 @@ class Node:
             srv_type.__class__.__import_type_support__()
         if srv_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
+        failed = False
         try:
             [client_handle, client_pointer] = _rclpy.rclpy_create_client(
                 self.handle,
@@ -110,9 +113,9 @@ class Node:
                 srv_name,
                 qos_profile.get_c_qos_profile())
         except ValueError:
+            failed = True
+        if failed:
             self._validate_topic_or_service_name(srv_name, is_service=True)
-            # If none of those, re-raise the original
-            raise
         client = Client(
             self.handle, client_handle, client_pointer, srv_type, srv_name, qos_profile)
         self.clients.append(client)
@@ -124,6 +127,7 @@ class Node:
             srv_type.__class__.__import_type_support__()
         if srv_type.__class__._TYPE_SUPPORT is None:
             raise NoTypeSupportImportedException
+        failed = False
         try:
             [service_handle, service_pointer] = _rclpy.rclpy_create_service(
                 self.handle,
@@ -131,9 +135,9 @@ class Node:
                 srv_name,
                 qos_profile.get_c_qos_profile())
         except ValueError:
+            failed = True
+        if failed:
             self._validate_topic_or_service_name(srv_name, is_service=True)
-            # If none of those, re-raise the original
-            raise
         service = Service(
             self.handle, service_handle, service_pointer,
             srv_type, srv_name, callback, qos_profile)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -44,6 +44,9 @@ class Node:
     def get_name(self):
         return _rclpy.rclpy_get_node_name(self.handle)
 
+    def get_namespace(self):
+        return _rclpy.rclpy_get_node_namespace(self.handle)
+
     def create_publisher(self, msg_type, topic, *, qos_profile=qos_profile_default):
         # this line imports the typesupport for the message module if not already done
         if msg_type.__class__._TYPE_SUPPORT is None:

--- a/rclpy/rclpy/validate_full_topic_name.py
+++ b/rclpy/rclpy/validate_full_topic_name.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_full_topic_name(name, *, is_service=False):
+    """
+    Validate a given topic or service name, and raise an exception if invalid.
+
+    The name must be fully-qualified and already expanded.
+
+    If the name is invalid then rclpy.exceptions.InvalidTopicNameException
+    will be raised.
+
+    :param name str: topic or service name to be validated
+    :param is_service bool: if true, InvalidServiceNameException is raised
+    :returns: True when it is valid
+    :raises: InvalidTopicNameException: when the name is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_full_topic_name(name)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    if is_service:
+        raise InvalidServiceNameException(name, error_msg, invalid_index)
+    else:
+        raise InvalidTopicNameException(name, error_msg, invalid_index)

--- a/rclpy/rclpy/validate_namespace.py
+++ b/rclpy/rclpy/validate_namespace.py
@@ -1,0 +1,38 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidNamespaceException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_namespace(namespace):
+    """
+    Validate a given namespace, and raise an exception if it is invalid.
+
+    Unlike the node constructor, which allows namespaces without a leading '/'
+    and empty namespaces "", this function requires that the namespace be
+    absolute and non-empty.
+
+    If the namespace is invalid then rclpy.exceptions.InvalidNamespaceException
+    will be raised.
+
+    :param namespace str: namespace to be validated
+    :returns: True when it is valid
+    :raises: InvalidNamespaceException: when the namespace is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_namespace(namespace)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    raise InvalidNamespaceException(namespace, error_msg, invalid_index)

--- a/rclpy/rclpy/validate_node_name.py
+++ b/rclpy/rclpy/validate_node_name.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidNodeNameException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_node_name(node_name):
+    """
+    Validate a given node_name, and raise an exception if it is invalid.
+
+    If the node_name is invalid then rclpy.exceptions.InvalidNodeNameException
+    will be raised.
+
+    :param node_name str: node_name to be validated
+    :returns: True when it is valid
+    :raises: InvalidNodeNameException: when the node_name is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_node_name(node_name)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    raise InvalidNodeNameException(node_name, error_msg, invalid_index)

--- a/rclpy/rclpy/validate_topic_name.py
+++ b/rclpy/rclpy/validate_topic_name.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+def validate_topic_name(name, *, is_service=False):
+    """
+    Validate a given topic or service name, and raise an exception if invalid.
+
+    The name does not have to be fully-qualified and is not expanded.
+
+    If the name is invalid then rclpy.exceptions.InvalidTopicNameException
+    will be raised.
+
+    :param name str: topic or service name to be validated
+    :param is_service bool: if true, InvalidServiceNameException is raised
+    :returns: True when it is valid
+    :raises: InvalidTopicNameException: when the name is invalid
+    """
+    result = _rclpy.rclpy_get_validation_error_for_topic_name(name)
+    if result is None:
+        return True
+    error_msg, invalid_index = result
+    if is_service:
+        raise InvalidServiceNameException(name, error_msg, invalid_index)
+    else:
+        raise InvalidTopicNameException(name, error_msg, invalid_index)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -38,11 +38,14 @@ static void catch_function(int signo)
 }
 
 /// Create a sigint guard condition
-/*
- * \return NULL on failure:
- *         List with 2 elements on success:
- *            first element: a Capsule pointing to the pointer of the created rcl_guard_condition_t * structure
- *            second element: an integer representing the memory address of the created rcl_guard_condition_t
+/**
+ * A successful call will return a list with two elements:
+ *
+ * - a Capsule with the pointer of the created rcl_guard_condition_t * structure
+ * - an integer representing the memory address of the rcl_guard_condition_t
+ *
+ * \return a list with the capsule and memory location, or
+ * \return NULL on failure
  */
 static PyObject *
 rclpy_get_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
@@ -81,11 +84,11 @@ rclpy_init(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 }
 
 /// Create a node
-/*
+/**
  * \param[in] node_name string name of the node to be created
  * \param[in] namespace string namespace for the node
+ * \return Capsule of the pointer to the created rcl_node_t * structure, or
  * \return NULL on failure
- *         Capsule pointing to the pointer of the created rcl_node_t * structure otherwise
  */
 static PyObject *
 rclpy_create_node(PyObject * Py_UNUSED(self), PyObject * args)
@@ -111,7 +114,7 @@ rclpy_create_node(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Get the name of a node.
-/*
+/**
  * \param[in] pynode Capsule pointing to the node to get the name from
  * \return NULL on failure
  *         String containing the name of the node otherwise
@@ -136,7 +139,7 @@ rclpy_get_node_name(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Create a publisher
-/*
+/**
  * This function will create a publisher and attach it to the provided topic name
  * This publisher will use the typesupport defined in the message module
  * provided as pymsg_type to send messages over the wire.
@@ -198,7 +201,7 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Publish a message
-/*
+/**
  * \param[in] pypublisher Capsule pointing to the publisher
  * \param[in] pymsg message to send
  * \return NULL
@@ -251,15 +254,22 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Create a timer
-/*
- * \param[in] period_nsec unsigned PyLong object storing the period of the timer in nanoseconds in a 64bits unsigned variable
- * \return NULL on failure:
- *            Raise RuntimeError on initialisation failure
- *            Raise TypeError if argument of invalid type
- *            Raise ValueError if argument cannot be converted to uint64_t
- *         List with 2 elements:
- *            first element: a Capsule pointing to the pointer of the created rcl_timer_t * structure
- *            second element: an integer representing the memory address of the created rcl_timer_t
+/**
+ * When successful a list with two elements is returned:
+ *
+ * - a Capsule pointing to the pointer of the created rcl_timer_t * structure
+ * - an integer representing the memory address of the created rcl_timer_t
+ *
+ * On failure, an exception is raised and NULL is returned if:
+ *
+ * - Raise RuntimeError on initialization failure
+ * - Raise TypeError if argument of invalid type
+ * - Raise ValueError if argument cannot be converted to uint64_t
+ *
+ * \param[in] period_nsec unsigned PyLong object storing the period of the
+ *   timer in nanoseconds in a 64-bit unsigned integer
+ * \return a list of the capsule and the memory address
+ * \return NULL on failure
  */
 static PyObject *
 rclpy_create_timer(PyObject * Py_UNUSED(self), PyObject * args)
@@ -288,7 +298,7 @@ rclpy_create_timer(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Returns the period of the timer in nanoseconds
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return NULL on failure:
  *            Raise RuntimeError on rcl error
@@ -314,7 +324,7 @@ rclpy_get_timer_period(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Cancel the timer
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return NULL on failure:
  *            Raise RuntimeError on rcl error
@@ -340,7 +350,7 @@ rclpy_cancel_timer(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Checks if timer is cancelled
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return False on failure:
  *            Raise RuntimeError on rcl error
@@ -370,7 +380,7 @@ rclpy_is_timer_canceled(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Reset the timer
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return NULL on failure:
  *            Raise RuntimeError on rcl error
@@ -396,7 +406,7 @@ rclpy_reset_timer(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Checks if timer reached its timeout
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return False on failure:
  *            Raise RuntimeError on rcl error
@@ -426,7 +436,7 @@ rclpy_is_timer_ready(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Set the last call time and start counting again
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return NULL on failure:
  *            Raise RuntimeError on rcl error
@@ -452,7 +462,7 @@ rclpy_call_timer(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Update the timer period
-/*
+/**
  * The change in period will take effect after the next timer call
  *
  * \param[in] pytimer Capsule pointing to the timer
@@ -483,7 +493,7 @@ rclpy_change_timer_period(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Get the time before the timer will be ready
-/*
+/**
  * the returned time can be negative, this means that the timer is ready and hasn't been called yet
  *
  * \param[in] pytimer Capsule pointing to the timer
@@ -512,7 +522,7 @@ rclpy_time_until_next_call(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Get the time since the timer has been called
-/*
+/**
  * \param[in] pytimer Capsule pointing to the timer
  * \return NULL on failure:
  *            Raise RuntimeError on rcl error
@@ -539,19 +549,22 @@ rclpy_time_since_last_call(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Create a subscription
-/*
- * This function will create a subscription and attach it to the provided topic name
+/**
+ * This function will create a subscription for the given topic name.
  * This subscription will use the typesupport defined in the message module
  * provided as pymsg_type to send messages over the wire.
  *
+ * On a successful call a list with two elements is returned:
+ *
+ * - a Capsule pointing to the pointer of the created rcl_subscription_t * structure
+ * - an integer representing the memory address of the created rcl_subscription_t
+ *
  * \param[in] pynode Capsule pointing to the node to add the subscriber to
  * \param[in] pymsg_type Message module associated with the subscriber
- * \param[in] pytopic Python object containing the name of the topic to attach the subscription to
- * \param[in] pyqos_profile QoSProfile Python object with the profile of this subscriber
+ * \param[in] pytopic Python object containing the topic name
+ * \param[in] pyqos_profile QoSProfile Python object for this subscription
+ * \return list with the capsule and memory address, or
  * \return NULL on failure
- *         List with 2 elements:
- *            first element: a Capsule pointing to the pointer of the created rcl_subscription_t * structure
- *            second element: an integer representing the memory address of the created rcl_subscription_t
  */
 static PyObject *
 rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
@@ -607,20 +620,22 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Create a client
-/*
- * This function will create a client and attach it to the topics <pyservice_name>Request and <pyservice_name>Reply
+/**
+ * This function will create a client for the given service name.
  * This client will use the typesupport defined in the service module
  * provided as pysrv_type to send messages over the wire.
  *
+ * On a successful call a list with two elements is returned:
+ *
+ * - a Capsule pointing to the pointer of the created rcl_client_t * structure
+ * - an integer representing the memory address of the created rcl_client_t
+ *
  * \param[in] pynode Capsule pointing to the node to add the client to
  * \param[in] pysrv_type Service module associated with the client
- * \param[in] pyservice_name Python object containing the name used to generate the
- *   <pyservice_name>Request and <pyservice_name>Reply topics names
- * \param[in] pyqos_profile QoSProfile Python object with the profile of this client
+ * \param[in] pyservice_name Python object containing the service name
+ * \param[in] pyqos_profile QoSProfile Python object for this client
+ * \return capsule and memory address, or
  * \return NULL on failure
- *         List with 2 elements:
- *            first element: a Capsule pointing to the pointer of the created rcl_client_t * structure
- *            second element: an integer representing the memory address of the created rcl_client_t
  */
 static PyObject *
 rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
@@ -676,7 +691,7 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Publish a request message
-/*
+/**
  * \param[in] pyclient Capsule pointing to the client
  * \param[in] pyrequest request message to send
  * \return sequence_number PyLong object representing the index of the sent request
@@ -736,20 +751,23 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Create a service server
-/*
- * This function will create a service server and attach it to the topics <pyservice_name>Request and <pyservice_name>Reply
+/**
+ * This function will create a service server for the given service name.
  * This service will use the typesupport defined in the service module
  * provided as pysrv_type to send messages over the wire.
  *
+ *
+ * On a successful call a list with two elements is returned:
+ *
+ * - a Capsule pointing to the pointer of the created rcl_service_t * structure
+ * - an integer representing the memory address of the created rcl_service_t
+ *
  * \param[in] pynode Capsule pointing to the node to add the service to
  * \param[in] pysrv_type Service module associated with the service
- * \param[in] pyservice_name Python object containing the name used to generate the
- *   <pyservice_name>Request and <pyservice_name>Reply topics names
- * \param[in] pyqos_profile QoSProfile Python object with the profile of this service
+ * \param[in] pyservice_name Python object for the service name
+ * \param[in] pyqos_profile QoSProfile Python object for this service
+ * \return capsule and memory address, or
  * \return NULL on failure
- *         List with 2 elements:
- *            first element: a Capsule pointing to the pointer of the created rcl_service_t * structure
- *            second element: an integer representing the memory address of the created rcl_service_t
  */
 static PyObject *
 rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
@@ -805,7 +823,7 @@ rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Publish a response message
-/*
+/**
  * \param[in] pyservice Capsule pointing to the client
  * \param[in] pyresponse reply message to send
  * \param[in] pyheader Capsule pointing to the rmw_request_id_t header of the request we respond to
@@ -872,8 +890,10 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Destroy an entity attached to a node
-/*
- * \param[in] entity_type string defining the entity ["subscription", "publisher", "client", "service"]
+/**
+ * Entity type must be one of ["subscription", "publisher", "client", "service"].
+ *
+ * \param[in] entity_type string defining the entity
  * \param[in] pyentity Capsule pointing to the entity to destroy
  * \param[in] pynode Capsule pointing to the node the entity belongs to
  * \return True on success, False on failure
@@ -918,7 +938,7 @@ rclpy_destroy_node_entity(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Destroy an rcl entity
-/*
+/**
  * \param[in] entity_type string defining the entity ["node"]
  * \param[in] pyentity Capsule pointing to the entity to destroy
  * \return True on success, False on failure
@@ -955,7 +975,7 @@ rclpy_destroy_entity(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Return the identifier of the current rmw_implementation
-/*
+/**
  * \return string containing the identifier of the current rmw_implementation
  */
 static PyObject *
@@ -981,7 +1001,7 @@ rclpy_get_zero_initialized_wait_set(PyObject * Py_UNUSED(self), PyObject * Py_UN
 }
 
 /// Initialize a waitset
-/*
+/**
  * \param[in] pywait_set Capsule pointing to the waitset structure
  * \param[in] node_name string name of the node to be created
  * \param[in] number_of_subscriptions int
@@ -1022,7 +1042,7 @@ rclpy_wait_set_init(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Clear all the pointers of a given wait_set field
-/*
+/**
  * \param[in] entity_type string defining the entity ["subscription, client, service"]
  * \param[in] pywait_set Capsule pointing to the waitset structure
  * \return NULL
@@ -1064,7 +1084,7 @@ rclpy_wait_set_clear_entities(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Add an entity to the waitset structure
-/*
+/**
  * \param[in] entity_type string defining the entity ["subscription, client, service"]
  * \param[in] pywait_set Capsule pointing to the waitset structure
  * \param[in] pyentity Capsule pointing to the entity to add
@@ -1130,7 +1150,7 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
   } \
   return entity_ready_list;
 /// Get list of non-null entities in waitset
-/*
+/**
  * \param[in] entity_type string defining the entity ["subscription, client, service"]
  * \param[in] pywait_set Capsule pointing to the waitset structure
  * \return List of wait_set entities pointers ready for take
@@ -1171,7 +1191,7 @@ rclpy_get_ready_entities(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Wait until timeout is reached or event happened
-/*
+/**
  * This function will wait for an event to happen or for the timeout to expire.
  * A negative timeout means wait forever, a timeout of 0 means no wait
  * \param[in] pywait_set Capsule pointing to the waitset structure
@@ -1199,7 +1219,7 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Take a message from a given subscription
-/*
+/**
  * \param[in] pysubscription Capsule pointing to the subscription to process the message
  * \param[in] pymsg_type Instance of the message type to take
  * \return Python message with all fields populated with received message
@@ -1270,7 +1290,7 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Take a request from a given service
-/*
+/**
  * \param[in] pyservice Capsule pointing to the service to process the request
  * \param[in] pyrequest_type Instance of the message type to take
  * \return List with 2 elements:
@@ -1349,7 +1369,7 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Take a response from a given client
-/*
+/**
  * \param[in] pyclient Capsule pointing to the client to process the response
  * \param[in] pyresponse_type Instance of the message type to take
  * \return Python response message with all fields populated with received response
@@ -1424,7 +1444,7 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Status of the the client library
-/*
+/**
  * \return True if rcl is running properly, False otherwise
  */
 static PyObject *
@@ -1439,7 +1459,7 @@ rclpy_ok(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 }
 
 /// Request shutdown of the client library
-/*
+/**
  * \return NULL
  */
 static PyObject *
@@ -1455,7 +1475,7 @@ rclpy_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 }
 
 /// Get the list of nodes discovered by the provided node
-/*
+/**
  * \param[in] pynode Capsule pointing to the node
  * \return Python list of strings
  */
@@ -1497,7 +1517,7 @@ rclpy_get_node_names(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Get the list of topics discovered by the provided node
-/*
+/**
  * \param[in] pynode Capsule pointing to the node
  * \return TopicNamesAndTypes object
  */
@@ -1559,7 +1579,8 @@ rclpy_get_topic_names_and_types(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Return a Python QoSProfile object
-/* This function creates a QoSProfile object from the QoS Policies provided
+/**
+ * This function creates a QoSProfile object from the QoS Policies provided
  * \param[in] pyqos_history enum of type QoSHistoryPolicy
  * \param[in] pyqos_depth int size of the DDS message queue
  * \param[in] pyqos_reliability enum of type QoSReliabilityPolicy
@@ -1591,7 +1612,7 @@ rclpy_convert_from_py_qos_policy(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 /// Convert a C rmw_qos_profile_t into a Python QoSProfile object
-/*
+/**
  * \param[in] void pointer to a rmw_qos_profile_t structure
  * \return QoSProfile object
  */
@@ -1617,7 +1638,9 @@ rclpy_convert_to_py_qos_policy(void * profile)
 }
 
 /// Fetch a predefined qos_profile from rmw and convert it to a Python QoSProfile Object
-/* This function takes a string defining a rmw_qos_profile_t and return the corresponding Python QoSProfile object
+/**
+ * This function takes a string defining a rmw_qos_profile_t and returns the
+ * corresponding Python QoSProfile object.
  * \param[in] string with the name of the profile to load
  * \return QoSProfile object
  */

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -34,6 +34,7 @@ static void catch_function(int signo)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to trigger guard_condition: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
   }
 }
 
@@ -59,6 +60,7 @@ rclpy_get_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * Py_UNUSE
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create guard_condition: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   g_sigint_gc_handle = sigint_gc;
@@ -78,6 +80,7 @@ rclpy_init(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to init: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -107,6 +110,7 @@ rclpy_create_node(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create node: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pynode = PyCapsule_New(node, NULL, NULL);
@@ -174,8 +178,8 @@ rclpy_get_node_namespace(PyObject * Py_UNUSED(self), PyObject * args)
  * \param[in] pytopic Python object containing the name of the topic
  * to attach the publisher to
  * \param[in] pyqos_profile QoSProfile object with the profile of this publisher
+ * \return Capsule of the pointer to the created rcl_publisher_t * structure, or
  * \return NULL on failure
- *         Capsule pointing to the pointer of the created rcl_publisher_t * structure otherwise
  */
 static PyObject *
 rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
@@ -219,6 +223,7 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create publisher: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pypublisher = PyCapsule_New(publisher, NULL, NULL);
@@ -272,6 +277,7 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to publish: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -312,6 +318,7 @@ rclpy_create_timer(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create subscriptions: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pytimer = PyCapsule_New(timer, NULL, NULL);
@@ -343,6 +350,7 @@ rclpy_get_timer_period(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to get timer period: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   return PyLong_FromUnsignedLongLong(timer_period);
@@ -368,6 +376,7 @@ rclpy_cancel_timer(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to reset timer: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -395,6 +404,7 @@ rclpy_is_timer_canceled(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to check timer ready: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   if (is_canceled) {
@@ -424,6 +434,7 @@ rclpy_reset_timer(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to reset timer: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -451,6 +462,7 @@ rclpy_is_timer_ready(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to check timer ready: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   if (is_ready) {
@@ -480,6 +492,7 @@ rclpy_call_timer(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to call timer: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -511,6 +524,7 @@ rclpy_change_timer_period(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to exchange timer period: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -540,6 +554,7 @@ rclpy_time_until_next_call(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to get time until next timer call: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -567,6 +582,7 @@ rclpy_time_since_last_call(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to get time since last timer call: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -634,6 +650,7 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create subscriptions: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pysubscription = PyCapsule_New(subscription, NULL, NULL);
@@ -705,6 +722,7 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create client: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pyclient = PyCapsule_New(client, NULL, NULL);
@@ -769,6 +787,7 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to send request: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -837,6 +856,7 @@ rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to create service: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pyservice = PyCapsule_New(service, NULL, NULL);
@@ -909,6 +929,7 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to send request: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -957,6 +978,7 @@ rclpy_destroy_node_entity(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to fini '%s': %s", entity_type, rcl_get_error_string_safe());
+    rcl_reset_error();
     Py_RETURN_FALSE;
   }
   Py_RETURN_TRUE;
@@ -994,6 +1016,7 @@ rclpy_destroy_entity(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to fini '%s': %s", entity_type, rcl_get_error_string_safe());
+    rcl_reset_error();
     Py_RETURN_FALSE;
   }
   Py_RETURN_TRUE;
@@ -1061,6 +1084,7 @@ rclpy_wait_set_init(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to initialize wait set: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -1103,6 +1127,7 @@ rclpy_wait_set_clear_entities(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to clear '%s' from wait set: %s", entity_type, rcl_get_error_string_safe());
+    rcl_reset_error();
     Py_RETURN_FALSE;
   }
   Py_RETURN_TRUE;
@@ -1156,6 +1181,7 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to add '%s' to wait set: %s", entity_type, rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -1238,6 +1264,7 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK && ret != RCL_RET_TIMEOUT) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to wait on wait set: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -1292,6 +1319,7 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK && ret != RCL_RET_SUBSCRIPTION_TAKE_FAILED) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to take from a subscription: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     destroy_ros_message(taken_msg);
     return NULL;
   }
@@ -1367,6 +1395,7 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK && ret != RCL_RET_SERVICE_TAKE_FAILED) {
     PyErr_Format(PyExc_RuntimeError,
       "Service failed to take request: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     destroy_ros_message(taken_request);
     return NULL;
   }
@@ -1446,6 +1475,7 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK && ret != RCL_RET_SERVICE_TAKE_FAILED) {
     PyErr_Format(PyExc_RuntimeError,
       "Client failed to take response: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     destroy_ros_message(taken_response);
     return NULL;
   }
@@ -1494,6 +1524,7 @@ rclpy_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to shutdown: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -1535,6 +1566,7 @@ rclpy_get_node_names(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCUTILS_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to destroy node_names: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 
@@ -1563,6 +1595,7 @@ rclpy_get_topic_names_and_types(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to get_topic_names_and_types: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
   PyObject * pynames_types_module = PyImport_ImportModule("rclpy.names_and_types");
@@ -1597,6 +1630,7 @@ rclpy_get_topic_names_and_types(PyObject * Py_UNUSED(self), PyObject * args)
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to destroy topic_names_and_types: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
     return NULL;
   }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -138,6 +138,31 @@ rclpy_get_node_name(PyObject * Py_UNUSED(self), PyObject * args)
   return PyUnicode_FromString(node_name);
 }
 
+/// Get the namespace of a node.
+/**
+ * \param[in] pynode Capsule pointing to the node to get the namespace from
+ * \return namespace, or
+ * \return NULL on failure
+ */
+static PyObject *
+rclpy_get_node_namespace(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pynode;
+
+  if (!PyArg_ParseTuple(args, "O", &pynode)) {
+    return NULL;
+  }
+
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, NULL);
+
+  const char * node_namespace = rcl_node_get_namespace(node);
+  if (!node_namespace) {
+    return NULL;
+  }
+
+  return PyUnicode_FromString(node_namespace);
+}
+
 /// Create a publisher
 /**
  * This function will create a publisher and attach it to the provided topic name
@@ -1683,6 +1708,8 @@ static PyMethodDef rclpy_methods[] = {
   {"rclpy_create_node", rclpy_create_node, METH_VARARGS,
    "Create a Node."},
   {"rclpy_get_node_name", rclpy_get_node_name, METH_VARARGS,
+   "Get the name of a node."},
+  {"rclpy_get_node_namespace", rclpy_get_node_namespace, METH_VARARGS,
    "Get the name of a node."},
   {"rclpy_create_publisher", rclpy_create_publisher, METH_VARARGS,
    "Create a Publisher."},

--- a/rclpy/test/test_expand_topic_name.py
+++ b/rclpy/test/test_expand_topic_name.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.expand_topic_name import expand_topic_name
+
+
+class TestExpandTopicName(unittest.TestCase):
+
+    def test_expand_topic_name(self):
+        tests = {
+            # 'expected output': ['input topic', 'node', '/ns']
+            '/ns/chatter': ['chatter', 'node_name', '/ns'],
+            '/chatter': ['chatter', 'node_name', '/'],
+            '/ns/node_name/chatter': ['~/chatter', 'node_name', '/ns'],
+            '/node_name/chatter': ['~/chatter', 'node_name', '/'],
+        }
+        for expected_topic, input_tuple in tests.items():
+            topic, node, namespace = input_tuple
+            expanded_topic = expand_topic_name(topic, node, namespace)
+            self.assertEqual(expanded_topic, expected_topic)
+
+    def test_expand_topic_name_invalid_node_name(self):
+        # node name may not contain '?'
+        with self.assertRaisesRegex(ValueError, 'node name'):
+            expand_topic_name('topic', 'invalid_node_name?', '/ns')
+
+    def test_expand_topic_name_invalid_namespace_empty(self):
+        # namespace may not be empty
+        with self.assertRaisesRegex(ValueError, 'namespace'):
+            expand_topic_name('topic', 'node_name', '')
+
+    def test_expand_topic_name_invalid_namespace_relative(self):
+        # namespace may not be relative
+        with self.assertRaisesRegex(ValueError, 'namespace'):
+            expand_topic_name('topic', 'node_name', 'ns')
+
+    def test_expand_topic_name_invalid_topic(self):
+        # topic may not contain '?'
+        with self.assertRaisesRegex(ValueError, 'topic name'):
+            expand_topic_name('invalid/topic?', 'node_name', '/ns')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -14,12 +14,10 @@
 
 import unittest
 
+from rcl_interfaces.srv import GetParameters
 import rclpy
-
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
-
-from rcl_interfaces.srv import GetParameters
 from std_msgs.msg import String
 
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -19,8 +19,8 @@ import rclpy
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
 
+from rcl_interfaces.srv import GetParameters
 from std_msgs.msg import String
-from std_srvs.srv import Empty
 
 
 class TestNode(unittest.TestCase):
@@ -61,22 +61,22 @@ class TestNode(unittest.TestCase):
             self.node.create_subscription(String, 'foo/{bad_sub}', lambda msg: print(msg))
 
     def test_create_client(self):
-        self.node.create_client(Empty, 'side/effect')
+        self.node.create_client(GetParameters, 'get/parameters')
         with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
-            self.node.create_client(Empty, 'side/effect?')
+            self.node.create_client(GetParameters, 'get/parameters?')
         with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
-            self.node.create_client(Empty, '/side/42effect')
+            self.node.create_client(GetParameters, '/get/42parameters')
         with self.assertRaisesRegex(ValueError, 'unknown substitution'):
-            self.node.create_client(Empty, 'foo/{bad_sub}')
+            self.node.create_client(GetParameters, 'foo/{bad_sub}')
 
     def test_create_service(self):
-        self.node.create_service(Empty, 'side/effect', lambda req: None)
+        self.node.create_service(GetParameters, 'get/parameters', lambda req: None)
         with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
-            self.node.create_service(Empty, 'side/effect?', lambda req: None)
+            self.node.create_service(GetParameters, 'get/parameters?', lambda req: None)
         with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
-            self.node.create_service(Empty, '/side/42effect', lambda req: None)
+            self.node.create_service(GetParameters, '/get/42parameters', lambda req: None)
         with self.assertRaisesRegex(ValueError, 'unknown substitution'):
-            self.node.create_service(Empty, 'foo/{bad_sub}', lambda req: None)
+            self.node.create_service(GetParameters, 'foo/{bad_sub}', lambda req: None)
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1,0 +1,83 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import rclpy
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+
+from std_msgs.msg import String
+from std_srvs.srv import Empty
+
+
+class TestNode(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('my_node', namespace='/my_ns')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_accessors(self):
+        self.assertIsNotNone(self.node.handle)
+        with self.assertRaises(AttributeError):
+            self.node.handle = 'garbage'
+        self.assertEqual(self.node.get_name(), 'my_node')
+        self.assertEqual(self.node.get_namespace(), '/my_ns')
+
+    def test_create_publisher(self):
+        self.node.create_publisher(String, 'chatter')
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            self.node.create_publisher(String, 'chatter?')
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
+            self.node.create_publisher(String, '/chatter/42_is_the_answer')
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_publisher(String, 'chatter/{bad_sub}')
+
+    def test_create_subscription(self):
+        self.node.create_subscription(String, 'chatter', lambda msg: print(msg))
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            self.node.create_subscription(String, 'chatter?', lambda msg: print(msg))
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
+            self.node.create_subscription(String, '/chatter/42ish', lambda msg: print(msg))
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_subscription(String, 'foo/{bad_sub}', lambda msg: print(msg))
+
+    def test_create_client(self):
+        self.node.create_client(Empty, 'side/effect')
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            self.node.create_client(Empty, 'side/effect?')
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
+            self.node.create_client(Empty, '/side/42effect')
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_client(Empty, 'foo/{bad_sub}')
+
+    def test_create_service(self):
+        self.node.create_service(Empty, 'side/effect', lambda req: None)
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            self.node.create_service(Empty, 'side/effect?', lambda req: None)
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
+            self.node.create_service(Empty, '/side/42effect', lambda req: None)
+        with self.assertRaisesRegex(ValueError, 'unknown substitution'):
+            self.node.create_service(Empty, 'foo/{bad_sub}', lambda req: None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_full_topic_name.py
+++ b/rclpy/test/test_validate_full_topic_name.py
@@ -1,0 +1,52 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.validate_full_topic_name import validate_full_topic_name
+
+
+class TestValidateFullTopicName(unittest.TestCase):
+
+    def test_validate_full_topic_name(self):
+        tests = [
+            '/chatter',
+            '/node_name/chatter',
+            '/ns/node_name/chatter',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_full_topic_name(topic)
+
+    def test_validate_full_topic_name_failures(self):
+        # topic name may not contain '?'
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            validate_full_topic_name('/invalid_topic?')
+        # topic name must start with /
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must be absolute'):
+            validate_full_topic_name('invalid_topic')
+
+    def test_validate_full_topic_name_failures_services(self):
+        # service name may not contain '?'
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            validate_full_topic_name('/invalid_service?', is_service=True)
+        # service name must start with /
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must be absolute'):
+            validate_full_topic_name('invalid_service', is_service=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_namespace.py
+++ b/rclpy/test/test_validate_namespace.py
@@ -1,0 +1,42 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidNamespaceException
+from rclpy.validate_namespace import validate_namespace
+
+
+class TestValidateNamespace(unittest.TestCase):
+
+    def test_validate_namespace(self):
+        tests = [
+            '/my_ns',
+            '/',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_namespace(topic)
+
+    def test_validate_namespace_failures(self):
+        # namespace must not be empty
+        with self.assertRaisesRegex(InvalidNamespaceException, 'empty'):
+            validate_namespace('')
+        # namespace must start with /
+        with self.assertRaisesRegex(InvalidNamespaceException, 'must be absolute'):
+            validate_namespace('invalid_namespace')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_node_name.py
+++ b/rclpy/test/test_validate_node_name.py
@@ -1,0 +1,44 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidNodeNameException
+from rclpy.validate_node_name import validate_node_name
+
+
+class TestValidateNodeName(unittest.TestCase):
+
+    def test_validate_node_name(self):
+        tests = [
+            'my_node',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_node_name(topic)
+
+    def test_validate_node_name_failures(self):
+        # node name must not be empty
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not be empty'):
+            validate_node_name('')
+        # node name may not contain '?'
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
+            validate_node_name('invalid_node?')
+        # node name must not contain /
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
+            validate_node_name('/invalid_node')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_validate_topic_name.py
+++ b/rclpy/test/test_validate_topic_name.py
@@ -1,0 +1,52 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.exceptions import InvalidServiceNameException
+from rclpy.exceptions import InvalidTopicNameException
+from rclpy.validate_topic_name import validate_topic_name
+
+
+class TestValidateTopicName(unittest.TestCase):
+
+    def test_validate_topic_name(self):
+        tests = [
+            'chatter',
+            '{node}/chatter',
+            '~/chatter',
+        ]
+        for topic in tests:
+            # Will raise if invalid
+            validate_topic_name(topic)
+
+    def test_validate_topic_name_failures(self):
+        # topic name may not contain '?'
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
+            validate_topic_name('/invalid_topic?')
+        # topic name must start with number in any token
+        with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
+            validate_topic_name('invalid/42topic')
+
+    def test_validate_topic_name_failures_service(self):
+        # service name may not contain '?'
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not contain characters'):
+            validate_topic_name('/invalid_service?', is_service=True)
+        # service name must start with number in any token
+        with self.assertRaisesRegex(InvalidServiceNameException, 'must not start with a number'):
+            validate_topic_name('invalid/42service', is_service=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Connects to ros2/rcl#137

Here are some examples of what it looks like when you give invalid names now:

- invalid node name

```
% python3 -c "import rclpy; rclpy.init(); rclpy.create_node('invalid_node?')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/__init__.py", line 38, in create_node
    validate_node_name(node_name)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/validate_node_name.py", line 34, in validate_node_name
    raise InvalidNodeNameException(node_name, error_msg, invalid_index)
rclpy.exceptions.InvalidNodeNameException: Invalid node name: node name must not contain characters other than alphanumerics or '_':
  'invalid_node?'
               ^
```

- invalid node namespace

```
% python3 -c "
import rclpy
rclpy.init()
rclpy.create_node('node_name', namespace='/invalid_ns?')"
Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/__init__.py", line 43, in create_node
    validate_namespace(namespace)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/validate_namespace.py", line 38, in validate_namespace
    raise InvalidNamespaceException(namespace, error_msg, invalid_index)
rclpy.exceptions.InvalidNamespaceException: Invalid namespace: namespace must not contain characters other than alphanumerics, '_', or '/':
  '/invalid_ns?'
              ^
```

- invalid topic name

```
% python3 -c "
import rclpy
from std_msgs.msg import String
rclpy.init()
n = rclpy.create_node('node_name')
n.create_publisher(String, 'chatter?')"
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/node.py", line 77, in create_publisher
    self._validate_topic_or_service_name(topic)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/node.py", line 60, in _validate_topic_or_service_name
    validate_topic_name(topic_or_service_name, is_service=is_service)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/validate_topic_name.py", line 41, in validate_topic_name
    raise InvalidTopicNameException(name, error_msg, invalid_index)
rclpy.exceptions.InvalidTopicNameException: Invalid topic name: topic name must not contain characters other than alphanumerics, '_', '~', '{', or '}':
  'chatter?'
          ^
```

- invalid service name

```
% python3 -c "
import rclpy
from std_srvs.srv import Empty
rclpy.init()
n = rclpy.create_node('node_name')
n.create_client(Empty, 'empty?')"
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/node.py", line 118, in create_client
    self._validate_topic_or_service_name(srv_name, is_service=True)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/node.py", line 60, in _validate_topic_or_service_name
    validate_topic_name(topic_or_service_name, is_service=is_service)
  File "/Users/william/ros2_ws/install/lib/python3.6/site-packages/rclpy/validate_topic_name.py", line 39, in validate_topic_name
    raise InvalidServiceNameException(name, error_msg, invalid_index)
rclpy.exceptions.InvalidServiceNameException: Invalid service name: topic name must not contain characters other than alphanumerics, '_', '~', '{', or '}':
  'empty?'
        ^
```