### PR TITLE
restore signal handler after wait

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1644,12 +1644,18 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pywait_set;
   PY_LONG_LONG timeout = -1;
 
-  signal(SIGINT, catch_function);
   if (!PyArg_ParseTuple(args, "O|K", &pywait_set, &timeout)) {
     return NULL;
   }
+#ifdef _WIN32
+  _crt_signal_t
+#else
+  sig_t
+#endif  // _WIN32
+  previous_handler = signal(SIGINT, catch_function);
   rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
   rcl_ret_t ret = rcl_wait(wait_set, timeout);
+  signal(SIGINT, previous_handler);
   if (ret != RCL_RET_OK && ret != RCL_RET_TIMEOUT) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to wait on wait set: %s", rcl_get_error_string_safe());


### PR DESCRIPTION
Otherwise Python code not blocked on `wait` but anywhere else can't be `Ctrl-C`ed.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2706)](http://ci.ros2.org/job/ci_linux/2706/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=247)](http://ci.ros2.org/job/ci_linux-aarch64/247/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2163)](http://ci.ros2.org/job/ci_osx/2163/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2836)](http://ci.ros2.org/job/ci_windows/2836/)