### PR TITLE
support new qos avoid_ros_namespace_conventions

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -25,6 +25,7 @@ class QoSProfile(object):
         '_depth',
         '_reliability',
         '_durability',
+        '_avoid_ros_namespace_conventions',
     ]
 
     def __init__(self, **kwargs):
@@ -40,6 +41,9 @@ class QoSProfile(object):
         self.durability = kwargs.get(
             'durability',
             QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT)
+        self.avoid_ros_namespace_conventions = kwargs.get(
+            'avoid_ros_namespace_conventions',
+            False)
 
     @property
     def history(self):
@@ -101,9 +105,29 @@ class QoSProfile(object):
         assert isinstance(value, int)
         self._depth = value
 
+    @property
+    def avoid_ros_namespace_conventions(self):
+        """
+        Get field 'avoid_ros_namespace_conventions'.
+
+        :returns: avoid_ros_namespace_conventions attribute
+        :rtype: bool
+        """
+        return self._avoid_ros_namespace_conventions
+
+    @avoid_ros_namespace_conventions.setter
+    def avoid_ros_namespace_conventions(self, value):
+        assert isinstance(value, bool)
+        self._avoid_ros_namespace_conventions = value
+
     def get_c_qos_profile(self):
         return _rclpy.rclpy_convert_from_py_qos_policy(
-            self.history, self.depth, self.reliability, self.durability)
+            self.history,
+            self.depth,
+            self.reliability,
+            self.durability,
+            self.avoid_ros_namespace_conventions,
+        )
 
 
 class QoSHistoryPolicy(IntEnum):

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2037,9 +2037,15 @@ rclpy_convert_from_py_qos_policy(PyObject * Py_UNUSED(self), PyObject * args)
   unsigned PY_LONG_LONG pyqos_depth;
   unsigned PY_LONG_LONG pyqos_reliability;
   unsigned PY_LONG_LONG pyqos_durability;
+  bool avoid_ros_namespace_conventions;
 
   if (!PyArg_ParseTuple(
-      args, "KKKK", &pyqos_history, &pyqos_depth, &pyqos_reliability, &pyqos_durability))
+      args, "KKKKp",
+      &pyqos_history,
+      &pyqos_depth,
+      &pyqos_reliability,
+      &pyqos_durability,
+      &avoid_ros_namespace_conventions))
   {
     return NULL;
   }
@@ -2049,6 +2055,7 @@ rclpy_convert_from_py_qos_policy(PyObject * Py_UNUSED(self), PyObject * args)
   qos_profile->depth = pyqos_depth;
   qos_profile->reliability = pyqos_reliability;
   qos_profile->durability = pyqos_durability;
+  qos_profile->avoid_ros_namespace_conventions = avoid_ros_namespace_conventions;
   PyObject * pyqos_profile = PyCapsule_New(qos_profile, NULL, NULL);
   return pyqos_profile;
 }
@@ -2074,6 +2081,8 @@ rclpy_convert_to_py_qos_policy(void * profile)
     PyLong_FromUnsignedLong(qos_profile->reliability));
   PyObject_SetAttrString(pyqos_profile, "durability",
     PyLong_FromUnsignedLong(qos_profile->durability));
+  PyObject_SetAttrString(pyqos_profile, "avoid_ros_namespace_conventions",
+    Py_BuildValue("p", qos_profile->avoid_ros_namespace_conventions));
 
   assert(pyqos_profile != NULL);
   return pyqos_profile;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2082,7 +2082,7 @@ rclpy_convert_to_py_qos_policy(void * profile)
   PyObject_SetAttrString(pyqos_profile, "durability",
     PyLong_FromUnsignedLong(qos_profile->durability));
   PyObject_SetAttrString(pyqos_profile, "avoid_ros_namespace_conventions",
-    Py_BuildValue("p", qos_profile->avoid_ros_namespace_conventions));
+    PyBool_FromLong(qos_profile->avoid_ros_namespace_conventions));
 
   assert(pyqos_profile != NULL);
   return pyqos_profile;


### PR DESCRIPTION
CI:

- Linux:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2711)](http://ci.ros2.org/job/ci_linux/2711/)
- Linux-aarch64:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=253)](http://ci.ros2.org/job/ci_linux-aarch64/253/)
- macOS:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2170)](http://ci.ros2.org/job/ci_osx/2170/)
- macOS (with nightly release settings):
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2171)](http://ci.ros2.org/job/ci_osx/2171/)
- Windows:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2840)](http://ci.ros2.org/job/ci_windows/2840/)
- Windows (with nightly release settings):
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2841)](http://ci.ros2.org/job/ci_windows/2841/)

Fixes ros2/build_cop#29