### PR TITLE
fix destroy logic and error handling

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -207,27 +207,39 @@ class Node:
         if not class_ or class_.__name__ != 'PyCapsule':
             raise ValueError('The node handle must be a PyCapsule')
 
-        for sub in self.subscriptions:
-            ret &= _rclpy.rclpy_destroy_node_entity(
+        for sub in list(self.subscriptions):
+            destroyed = _rclpy.rclpy_destroy_node_entity(
                 'subscription', sub.subscription_handle, self.handle)
-            self.subscriptions.remove(sub)
-        for pub in self.publishers:
-            ret &= _rclpy.rclpy_destroy_node_entity(
+            if destroyed:
+                self.subscriptions.remove(sub)
+            ret &= destroyed
+        for pub in list(self.publishers):
+            destroyed = _rclpy.rclpy_destroy_node_entity(
                 'publisher', pub.publisher_handle, self.handle)
-            self.publishers.remove(pub)
-        for cli in self.clients:
-            ret &= _rclpy.rclpy_destroy_node_entity(
+            if destroyed:
+                self.publishers.remove(pub)
+            ret &= destroyed
+        for cli in list(self.clients):
+            destroyed = _rclpy.rclpy_destroy_node_entity(
                 'client', cli.client_handle, self.handle)
-            self.clients.remove(cli)
-        for srv in self.services:
-            ret &= _rclpy.rclpy_destroy_node_entity(
+            if destroyed:
+                self.clients.remove(cli)
+            ret &= destroyed
+        for srv in list(self.services):
+            destroyed = _rclpy.rclpy_destroy_node_entity(
                 'service', srv.service_handle, self.handle)
-            self.services.remove(srv)
-        for tmr in self.timers:
-            ret &= _rclpy.rclpy_destroy_entity('timer', tmr.timer_handle)
-            self.timers.remove(tmr)
-        ret &= _rclpy.rclpy_destroy_entity('node', self.handle)
-        self._handle = None
+            if destroyed:
+                self.services.remove(srv)
+            ret &= destroyed
+        for tmr in list(self.timers):
+            destroyed = _rclpy.rclpy_destroy_entity('timer', tmr.timer_handle)
+            if destroyed:
+                self.timers.remove(tmr)
+            ret &= destroyed
+        destroyed = _rclpy.rclpy_destroy_entity('node', self.handle)
+        if destroyed:
+            self._handle = None
+        ret &= destroyed
         return ret
 
     def get_topic_names_and_types(self, no_demangle=False):

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1362,13 +1362,13 @@ rclpy_destroy_node_entity(PyObject * Py_UNUSED(self), PyObject * args)
     ret = RCL_RET_ERROR;  // to avoid a linter warning
     PyErr_Format(PyExc_RuntimeError,
       "%s is not a known entity", entity_type);
-    Py_RETURN_FALSE;
+    return NULL;
   }
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to fini '%s': %s", entity_type, rcl_get_error_string_safe());
     rcl_reset_error();
-    Py_RETURN_FALSE;
+    return NULL;
   }
   Py_RETURN_TRUE;
 }
@@ -1511,13 +1511,13 @@ rclpy_wait_set_clear_entities(PyObject * Py_UNUSED(self), PyObject * args)
     ret = RCL_RET_ERROR;  // to avoid a linter warning
     PyErr_Format(PyExc_RuntimeError,
       "%s is not a known entity", entity_type);
-    Py_RETURN_FALSE;
+    return NULL;
   }
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to clear '%s' from wait set: %s", entity_type, rcl_get_error_string_safe());
     rcl_reset_error();
-    Py_RETURN_FALSE;
+    return NULL;
   }
   Py_RETURN_TRUE;
 }
@@ -1565,7 +1565,7 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
     ret = RCL_RET_ERROR;  // to avoid a linter warning
     PyErr_Format(PyExc_RuntimeError,
       "%s is not a known entity", entity_type);
-    Py_RETURN_FALSE;
+    return NULL;
   }
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,


### PR DESCRIPTION
The patch fixes three problems:

* The destroy logic was broken. Removing elements from a list while iterating of it results in the wrong behavior (only every second item was destroyed before).
* When an exception is being set the function must return `NULL` in order to pass it correctly from the C extension to Python.
* ~~Before using the node handle for the destroy calls in needs to be checked if it is valid.~~ **Update:** covered by the fixed error handling code already.

This can be reproduced by running these two commands with `rmw_connext_cpp`:

* `ros2 run examples_rclpy_minimal_service examples_rclpy_minimal_service`
* `ros2 run examples_rclpy_minimal_client examples_rclpy_minimal_client_async`

With the patch the problem of the node being invalid when the client is trying to be destroyed is at least reported correctly.

Updated CI links with only two commits being in this PR:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2829)](http://ci.ros2.org/job/ci_linux/2829/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=333)](http://ci.ros2.org/job/ci_linux-aarch64/333/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2285)](http://ci.ros2.org/job/ci_osx/2285/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2965)](http://ci.ros2.org/job/ci_windows/2965/)

Ready for review.