### PR TITLE
check for exceptions before returning from C extension

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1719,6 +1719,10 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+
   if (ret != RCL_RET_SUBSCRIPTION_TAKE_FAILED) {
     PyObject * pyconvert_to_py = PyObject_GetAttrString(pymsg_type, "_CONVERT_TO_PY");
 
@@ -1728,6 +1732,10 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
 
     PyObject * pytaken_msg = convert_to_py(taken_msg);
     destroy_ros_message(taken_msg);
+
+    if (PyErr_Occurred()) {
+      return NULL;
+    }
 
     Py_INCREF(pytaken_msg);
 


### PR DESCRIPTION
Some background on Python C extensions: a C function being called from Python can only do either of the two:

* return a non-`NULL` value or
* set an error (with `PyErr_`) or exception.

If both is done the call will trigger a `SystemError: <built-in function your-name-here> returned a result with an error set`.

Now consider the following case: a user presses Ctrl-C which sets the `KeyboardInterrupt` exception while a C function is running. If the function tries to return a non-`NULL` value a `SystemError` is the consequence. Instead before returning from the C function the code should check if an error is set (using `PyErr_Occurred`) and if that is the case return `NULL` (the standard rule applies to avoid leaking memory in that case).

The benefit of the current patch can be reproduced with the following example which has a high chance of hitting Ctrl-C while this C function is running:

* Invoke `ros2 run image_tools cam2image` in one terminal
* Invoke `ros2 topic echo /image` in a second terminal and while it is printing messages hit Ctrl-C

Without the patch you have a high chance of seeing the `SystemError`. With the patch the program should gracefully exit without a visible exception.

This PR currently only patches the function `rclpy_take`. The same would need to be done in all C function exposed in Python for each non-`NULL` return (which is in quite a few places). Before replicating the change for all other cases I would like to have feedback if this is viable or if there is a different way (or we don't care about the way this "crashes").