### PR TITLE
cleanup node correctly in test

### DIFF
--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -54,12 +54,15 @@ def func_destroy_corrupted_node():
     rclpy.init()
     node = rclpy.create_node('test_node2')
     assert node.destroy_node() is True
+    org_handle = node._handle
     node._handle = 'garbage'
     ret = False
     try:
         node.destroy_node()
     except ValueError:
         ret = True
+        node._handle = org_handle
+        node.destroy_node()
     finally:
         rclpy.shutdown()
     return ret


### PR DESCRIPTION
After messing with the internal node handle and testing that the destroy function will raise the expected exception the test needs to restore the original node handle and actually destroy the node correctly. Otherwise the Python GC will try to delete the node (eventually) later and run into the same exception the test checked for.

This will get rid of the exception which is being raised even though the actual test passes (happening in existing CI jobs e.g. http://ci.ros2.org/view/nightly/job/nightly_linux_debug/524/consoleFull#console-section-264):

```
test 1
    Start 1: rclpytests

1: Test command: /home/rosbuild/ci_scripts/venv/bin/python3 "-u" "/home/rosbuild/ci_scripts/ws/install/ament_cmake_test/share/ament_cmake_test/cmake/run_test.py" "/home/rosbuild/ci_scripts/ws/build/rclpy/test_results/rclpy/rclpytests.xunit.xml" "--output-file" "/home/rosbuild/ci_scripts/ws/build/rclpy/ament_cmake_nose/rclpytests.txt" "--append-env" "AMENT_PREFIX_PATH=/home/rosbuild/ci_scripts/ws/build/rclpy/ament_cmake_index" "--command" "/home/rosbuild/ci_scripts/venv/bin/python3" "-u" "/usr/bin/nosetests3" "/home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/test" "--nocapture" "--with-xunit" "--xunit-file=/home/rosbuild/ci_scripts/ws/build/rclpy/test_results/rclpy/rclpytests.xunit.xml" "--xunit-testsuite-name=rclpy.nosetests"
1: Test timeout computed to be: 60
1: -- run_test.py: extra environment variables to append:
1:  - AMENT_PREFIX_PATH=/home/rosbuild/ci_scripts/ws/build/rclpy/ament_cmake_index
1: -- run_test.py: invoking following command in '/home/rosbuild/ci_scripts/ws/build/rclpy':
1:  - /home/rosbuild/ci_scripts/venv/bin/python3 -u /usr/bin/nosetests3 /home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/test --nocapture --with-xunit --xunit-file=/home/rosbuild/ci_scripts/ws/build/rclpy/test_results/rclpy/rclpytests.xunit.xml --xunit-testsuite-name=rclpy.nosetests
1: .........Exception ignored in: <bound method Node.__del__ of <rclpy.node.Node object at 0x7f3774e64da0>>
1: Traceback (most recent call last):
1:   File "/home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/rclpy/node.py", line 255, in __del__
1:     self.destroy_node()
1:   File "/home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/rclpy/node.py", line 208, in destroy_node
1:     raise ValueError('The node handle must be a PyCapsule')
1: ValueError: The node handle must be a PyCapsule
1: ........................................
1: ----------------------------------------------------------------------
1: Ran 49 tests in 3.398s
1: 
1: OK
1: -- run_test.py: return code 0
1: -- run_test.py: verify result file '/home/rosbuild/ci_scripts/ws/build/rclpy/test_results/rclpy/rclpytests.xunit.xml'
1/8 Test #1: rclpytests .......................   Passed    4.14 sec
```

With this patch the exception is gone (with the test still passing as it was before): http://ci.ros2.org/job/ci_linux/2906/consoleFull#console-section-115