### PR TITLE
increase timeout for python tests

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -91,6 +91,7 @@ if(BUILD_TESTING)
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
       PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
       APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}
+      TIMEOUT 90
     )
   endif()
 endif()


### PR DESCRIPTION
connects to ros2/rmw_connext#236

Running these tests with Connext takes longer than 60s (http://ci.ros2.org/job/ci_linux/2907/). Therefore increasing the timeout (http://ci.ros2.org/job/ci_linux/2908/).