### PR TITLE
convert bool to int to fix failure on windshield

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2139,7 +2139,7 @@ rclpy_convert_from_py_qos_policy(PyObject * Py_UNUSED(self), PyObject * args)
   unsigned PY_LONG_LONG pyqos_depth;
   unsigned PY_LONG_LONG pyqos_reliability;
   unsigned PY_LONG_LONG pyqos_durability;
-  bool avoid_ros_namespace_conventions;
+  int avoid_ros_namespace_conventions;
 
   if (!PyArg_ParseTuple(
       args, "KKKKp",


### PR DESCRIPTION
Not sure exactly why this fails on some machines and pass on others. I found that patch when investigating the numerous python test failures on Windows Debug on windshield.

Looks like "p" provides a bool but it's actually an int.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2929)](http://ci.ros2.org/job/ci_linux/2929/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=397)](http://ci.ros2.org/job/ci_linux-aarch64/397/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2373)](http://ci.ros2.org/job/ci_osx/2373/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3054)](http://ci.ros2.org/job/ci_windows/3054/) (unrelated test failures)

Job on windshield:
Before patch:
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=nightly_win_deb&build=556)](http://ci.ros2.org/view/nightly/job/nightly_win_deb/556/) (all python tests fail)
After patch:
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_windows&build=1)](http://ci.ros2.org/job/test_ci_windows/1/) (only c/c++ errors)
