### PR TITLE
Executors and Callback Groups

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -14,11 +14,11 @@
 
 import sys
 
-from rclpy.constants import S_TO_NS
+from rclpy.executors import SingleThreadedExecutor as _SingleThreadedExecutor
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.node import Node
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
-from rclpy.utilities import ok  # noqa
+from rclpy.utilities import ok
 from rclpy.utilities import shutdown  # noqa
 from rclpy.utilities import try_shutdown  # noqa
 
@@ -32,74 +32,19 @@ def create_node(node_name, *, namespace=None):
 
 
 def spin_once(node, *, timeout_sec=None):
-    wait_set = _rclpy.rclpy_get_zero_initialized_wait_set()
+    executor = _SingleThreadedExecutor()
+    try:
+        executor.add_node(node)
+        executor.spin_once(timeout_sec=timeout_sec)
+    finally:
+        executor.shutdown()
 
-    _rclpy.rclpy_wait_set_init(
-        wait_set,
-        len(node.subscriptions),
-        1,
-        len(node.timers),
-        len(node.clients),
-        len(node.services))
 
-    [sigint_gc, sigint_gc_handle] = _rclpy.rclpy_get_sigint_guard_condition()
-    entities = {
-        'subscription': (node.subscriptions, 'subscription_handle'),
-        'client': (node.clients, 'client_handle'),
-        'service': (node.services, 'service_handle'),
-        'timer': (node.timers, 'timer_handle'),
-    }
-    for entity, (handles, handle_name) in entities.items():
-        _rclpy.rclpy_wait_set_clear_entities(entity, wait_set)
-        for h in handles:
-            _rclpy.rclpy_wait_set_add_entity(
-                entity, wait_set, h.__getattribute__(handle_name)
-            )
-    _rclpy.rclpy_wait_set_clear_entities('guard_condition', wait_set)
-    _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
-
-    if timeout_sec is None:
-        timeout = -1
-    else:
-        timeout = int(float(timeout_sec) * S_TO_NS)
-
-    _rclpy.rclpy_wait(wait_set, timeout)
-
-    guard_condition_ready_list = _rclpy.rclpy_get_ready_entities('guard_condition', wait_set)
-    if sigint_gc_handle in guard_condition_ready_list:
-        raise KeyboardInterrupt
-
-    timer_ready_list = _rclpy.rclpy_get_ready_entities('timer', wait_set)
-    for tmr in [t for t in node.timers if t.timer_pointer in timer_ready_list]:
-        if _rclpy.rclpy_is_timer_ready(tmr.timer_handle):
-            _rclpy.rclpy_call_timer(tmr.timer_handle)
-            tmr.callback()
-
-    sub_ready_list = _rclpy.rclpy_get_ready_entities('subscription', wait_set)
-    for sub in [s for s in node.subscriptions if s.subscription_pointer in sub_ready_list]:
-        msg = _rclpy.rclpy_take(sub.subscription_handle, sub.msg_type)
-        if msg:
-            sub.callback(msg)
-
-    client_ready_list = _rclpy.rclpy_get_ready_entities('client', wait_set)
-    for client in [c for c in node.clients if c.client_pointer in client_ready_list]:
-        response = _rclpy.rclpy_take_response(
-            client.client_handle, client.srv_type.Response, client.sequence_number)
-        if response:
-            # clients spawn their own thread to wait for a response in the wait_for_future function
-            # users can either use this mechanism or monitor the content of
-            # client.response themselves to check if a response have been received
-            client.response = response
-
-    service_ready_list = _rclpy.rclpy_get_ready_entities('service', wait_set)
-    for srv in [s for s in node.services if s.service_pointer in service_ready_list]:
-        request_and_header = _rclpy.rclpy_take_request(srv.service_handle, srv.srv_type.Request)
-        if request_and_header is None:
-            continue
-        [request, header] = request_and_header
-        if request:
-            response = srv.callback(request, srv.srv_type.Response())
-            srv.send_response(response, header)
-
-    _rclpy.rclpy_destroy_entity('guard_condition', sigint_gc)
-    _rclpy.rclpy_destroy_wait_set(wait_set)
+def spin(node):
+    executor = _SingleThreadedExecutor()
+    try:
+        executor.add_node(node)
+        while ok():
+            executor.spin_once()
+    finally:
+        executor.shutdown()

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -15,15 +15,12 @@
 import sys
 
 from rclpy.constants import S_TO_NS
-from rclpy.exceptions import NotInitializedException
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.node import Node
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
-from rclpy.utilities import ok
+from rclpy.utilities import ok  # noqa
 from rclpy.utilities import shutdown  # noqa
 from rclpy.utilities import try_shutdown  # noqa
-from rclpy.validate_namespace import validate_namespace
-from rclpy.validate_node_name import validate_node_name
 
 
 def init(*, args=None):
@@ -31,24 +28,7 @@ def init(*, args=None):
 
 
 def create_node(node_name, *, namespace=None):
-    namespace = namespace or ''
-    failed = False
-    if not ok():
-        raise NotInitializedException('cannot create node')
-    try:
-        node_handle = _rclpy.rclpy_create_node(node_name, namespace)
-    except ValueError:
-        failed = True
-    if failed:
-        # these will raise more specific errors if the name or namespace is bad
-        validate_node_name(node_name)
-        # emulate what rcl_node_init() does to accept '' and relative namespaces
-        if not namespace:
-            namespace = '/'
-        if not namespace.startswith('/'):
-            namespace = '/' + namespace
-        validate_namespace(namespace)
-    return Node(node_handle)
+    return Node(node_name, namespace=namespace)
 
 
 def spin_once(node, *, timeout_sec=None):

--- a/rclpy/rclpy/callback_groups.py
+++ b/rclpy/rclpy/callback_groups.py
@@ -1,0 +1,112 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from threading import Lock
+import weakref
+
+
+class CallbackGroup:
+    """Control when callbacks are allowed to be executed."""
+
+    def __init__(self):
+        super().__init__()
+        self.entities = set()
+
+    def add_entity(self, entity):
+        """
+        Add an entity to the callback group.
+
+        :param entity: a subscription, timer, client, or service instance
+        :rtype: None
+        """
+        self.entities.add(weakref.ref(entity))
+
+    def has_entity(self, entity):
+        """
+        Determine if an entity has been added to this group.
+
+        :param entity: a subscription, timer, client, or service instance
+        :rtype: bool
+        """
+        return weakref.ref(entity) in self.entities
+
+    def can_execute(self, entity):
+        """
+        Return true if an entity can be executed.
+
+        :param entity: a subscription, timer, client, or service instance
+        :rtype: bool
+        """
+        raise NotImplementedError
+
+    def beginning_execution(self, entity):
+        """
+        Get permission from the callback from the group to begin executing an entity.
+
+        Return true if the callback can be executed, false otherwise. If this returns True then
+        :func:`CallbackGroup.ending_execution` must be called after the callback has been executed.
+
+        :param entity: a subscription, timer, client, or service instance
+        :rtype: bool
+        """
+        raise NotImplementedError
+
+    def ending_execution(self, entity):
+        """
+        Notify group that a callback has finished executing.
+
+        :param entity: a subscription, timer, client, or service instance
+        :rtype: None
+        """
+        raise NotImplementedError
+
+
+class ReentrantCallbackGroup(CallbackGroup):
+    """Allow callbacks to be executed in parallel without restriction."""
+
+    def can_execute(self, entity):
+        return True
+
+    def beginning_execution(self, entity):
+        return True
+
+    def ending_execution(self, entity):
+        pass
+
+
+class MutuallyExclusiveCallbackGroup(CallbackGroup):
+    """Allow only one callback to be executing at a time."""
+
+    def __init__(self):
+        super().__init__()
+        self._active_entity = None
+        self._lock = Lock()
+
+    def can_execute(self, entity):
+        with self._lock:
+            assert weakref.ref(entity) in self.entities
+            return self._active_entity is None
+
+    def beginning_execution(self, entity):
+        with self._lock:
+            assert weakref.ref(entity) in self.entities
+            if self._active_entity is None:
+                self._active_entity = entity
+                return True
+        return False
+
+    def ending_execution(self, entity):
+        with self._lock:
+            assert self._active_entity == entity
+            self._active_entity = None

--- a/rclpy/rclpy/callback_groups.py
+++ b/rclpy/rclpy/callback_groups.py
@@ -48,7 +48,7 @@ class CallbackGroup:
         :param entity: a subscription, timer, client, or service instance
         :rtype: bool
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def beginning_execution(self, entity):
         """
@@ -60,7 +60,7 @@ class CallbackGroup:
         :param entity: a subscription, timer, client, or service instance
         :rtype: bool
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def ending_execution(self, entity):
         """
@@ -69,7 +69,7 @@ class CallbackGroup:
         :param entity: a subscription, timer, client, or service instance
         :rtype: None
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 class ReentrantCallbackGroup(CallbackGroup):

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -54,7 +54,7 @@ class ResponseThread(threading.Thread):
 class Client:
     def __init__(
             self, node_handle, client_handle, client_pointer,
-            srv_type, srv_name, qos_profile):
+            srv_type, srv_name, qos_profile, callback_group):
         self.node_handle = node_handle
         self.client_handle = client_handle
         self.client_pointer = client_pointer
@@ -63,6 +63,9 @@ class Client:
         self.qos_profile = qos_profile
         self.sequence_number = 0
         self.response = None
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
 
     def call(self, req):
         self.response = None

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -1,0 +1,393 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
+import multiprocessing
+from threading import Condition as _Condition
+from threading import Lock as _Lock
+
+from rclpy.callback_groups import ReentrantCallbackGroup as _ReentrantGroup
+from rclpy.constants import S_TO_NS
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.timer import WallTimer as _WallTimer
+from rclpy.utilities import ok
+
+
+class _WaitSet:
+    """Make sure the wait set gets destroyed when a generator exits."""
+
+    def __enter__(self):
+        self.wait_set = _rclpy.rclpy_get_zero_initialized_wait_set()
+        return self.wait_set
+
+    def __exit__(self, t, v, tb):
+        _rclpy.rclpy_destroy_wait_set(self.wait_set)
+
+
+class Executor:
+    """
+    A base class for an executor.
+
+    An executor controls the threading model used to process callbacks. Callbacks are units of work
+    like subscription callbacks, timer callbacks, service calls, and received client responses. An
+    executor controls which threads callbacks get executed in.
+
+    A custom executor must define :func:`Executor.spin_once`. If the executor has any cleanup then
+    it should also define :func:`Executor.shutdown`.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._nodes = set()
+        self._nodes_lock = _Lock()
+        # This is triggered when wait_for_ready_callbacks should rebuild the wait list
+        gc, gc_handle = _rclpy.rclpy_create_guard_condition()
+        self._guard_condition = gc
+        self._guard_condition_handle = gc_handle
+        # True if shutdown has been called
+        self._is_shutdown = False
+        # Number of tasks that are being executed
+        self._num_work_executing = 0
+        self._work_condition = _Condition()
+
+    def shutdown(self, timeout_sec=None):
+        """
+        Stop executing callbacks and wait for their completion.
+
+        Return true if all outstanding callbacks finished executing.
+
+        :param timeout_sec: Seconds to wait. Block forever if None. Don't wait if <= 0
+        :type timeout_sec: float or None
+        :rtype: bool
+        """
+        self._is_shutdown = True
+        # Wait for all work to complete
+        if timeout_sec is None or timeout_sec >= 0:
+            with self._work_condition:
+                if not self._work_condition.wait_for(
+                        lambda: self._num_work_executing == 0, timeout_sec):
+                    return False
+        # Clean up stuff that won't be used anymore
+        with self._nodes_lock:
+            self._nodes = set()
+        _rclpy.rclpy_destroy_guard_condition(self._guard_condition)
+        self._guard_condition = None
+        return True
+
+    def __del__(self):
+        if self._guard_condition is not None:
+            _rclpy.rclpy_destroy_guard_condition(self._guard_condition)
+
+    def add_node(self, node):
+        """
+        Add a node whose callbacks should be managed by this executor.
+
+        Return true if the node was added.
+
+        :rtype: bool
+        """
+        with self._nodes_lock:
+            self._nodes.add(node)
+            # Rebuild the wait set so it includes this new node
+            _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+
+    def get_nodes(self):
+        """
+        Return nodes which have been added to this executor.
+
+        :rtype: list
+        """
+        with self._nodes_lock:
+            return [node for node in self._nodes]
+
+    def spin(self):
+        """Execute callbacks until shutdown."""
+        while ok():
+            self.spin_once()
+
+    def spin_once(self, timeout_sec=None):
+        """
+        Wait for and execute a single callback.
+
+        A custom executor should use :func:`Executor.wait_for_ready_callbacks` to get work.
+
+        :param timeout_sec: Seconds to wait. Block forever if None. Don't wait if <= 0
+        :type timeout_sec: float or None
+        :rtype: None
+        """
+        raise NotImplementedError
+
+    def _take_timer(self, tmr):
+        _rclpy.rclpy_call_timer(tmr.timer_handle)
+
+    def _execute_timer(self, tmr, _):
+        tmr.callback()
+
+    def _take_subscription(self, sub):
+        msg = _rclpy.rclpy_take(sub.subscription_handle, sub.msg_type)
+        return msg
+
+    def _execute_subscription(self, sub, msg):
+        if msg:
+            sub.callback(msg)
+
+    def _take_client(self, client):
+        response = _rclpy.rclpy_take_response(
+            client.client_handle, client.srv_type.Response, client.sequence_number)
+        return response
+
+    def _execute_client(self, client, response):
+        if response:
+            # clients spawn their own thread to wait for a response in the
+            # wait_for_future function. Users can either use this mechanism or monitor
+            # the content of client.response to check if a response has been received
+            client.response = response
+
+    def _take_service(self, srv):
+        request_and_header = _rclpy.rclpy_take_request(
+            srv.service_handle, srv.srv_type.Request)
+        return request_and_header
+
+    def _execute_service(self, srv, request_and_header):
+        if request_and_header is None:
+            return
+        (request, header) = request_and_header
+        if request:
+            response = srv.callback(request, srv.srv_type.Response())
+            srv.send_response(response, header)
+
+    def _make_handler(self, entity, take_from_wait_list, call_callback):
+        """
+        Make a handler that performs work on an entity.
+
+        :param entity: An entity to wait on
+        :param take_from_wait_list: Makes the entity to stop appearing in the wait list
+        :type take_from_wait_list: callable
+        :param call_callback: Does the work the entity is ready for
+        :type call_callback: callable
+        :rtype: callable
+        """
+        gc = self._guard_condition
+        work_cv = self._work_condition
+        num_work = self._num_work_executing
+        is_shutdown = self._is_shutdown
+        # Mark this so it doesn't get added back to the wait list
+        entity._executor_event = True
+
+        def handler():
+            nonlocal entity
+            nonlocal gc
+            nonlocal work_cv
+            nonlocal num_work
+            nonlocal is_shutdown
+            if not entity.callback_group.beginning_execution(entity):
+                # Didn't get the callback, try again later
+                entity._executor_event = False
+                _rclpy.rclpy_trigger_guard_condition(gc)
+                return
+            try:
+                # Track the amount of work being executed
+                if is_shutdown:
+                    return
+                with work_cv:
+                    num_work += 1
+
+                arg = take_from_wait_list(entity)
+
+                # Signal that this has been 'taken' and can be added back to the wait list
+                entity._executor_event = False
+                _rclpy.rclpy_trigger_guard_condition(gc)
+
+                call_callback(entity, arg)
+            finally:
+                # Track the amount of work being executed
+                with work_cv:
+                    num_work -= 1
+                    work_cv.notify_all()
+
+                entity.callback_group.ending_execution(entity)
+                # Signal that work has been done so the next callback in a mutually exclusive
+                # callback group can get executed
+                _rclpy.rclpy_trigger_guard_condition(gc)
+        return handler
+
+    def _filter_eligible_entities(self, entities):
+        """
+        Filter entities that should not be put onto the wait list.
+
+        :param entity_list: Entities to be checked for eligibility
+        :type entity_list: list
+        :rtype: list
+        """
+        return [e for e in entities if e.callback_group.can_execute(e) and not e._executor_event]
+
+    def wait_for_ready_callbacks(self, timeout_sec=None, nodes=None):
+        """
+        Yield callbacks that are ready to be performed.
+
+        :param timeout_sec: Seconds to wait. Block forever if None. Don't wait if <= 0
+        :type timeout_sec: float or None
+        :param nodes: A list of nodes to wait on. Wait on all nodes if None.
+        :type nodes: list or None
+        :rtype: Generator[(callable, entity, :class:`rclpy.node.Node`)]
+        """
+        if nodes is None:
+            nodes = self.get_nodes()
+
+        timeout_timer = None
+        # Get timeout in nanoseconds. 0 = don't wait. < 0 means block forever
+        timeout_nsec = None
+        if timeout_sec is None:
+            timeout_nsec = -1
+        elif timeout_sec <= 0:
+            timeout_nsec = 0
+        else:
+            timeout_nsec = int(float(timeout_sec) * S_TO_NS)
+            timeout_timer = _WallTimer(lambda: None, _ReentrantGroup(), timeout_nsec)
+
+        yielded_work = False
+        while not yielded_work and not self._is_shutdown:
+            # Gather entities that can be waited on
+            subscriptions = []
+            num_guard_conditions = 2
+            timers = []
+            clients = []
+            services = []
+            for node in nodes:
+                subscriptions.extend(self._filter_eligible_entities(node.subscriptions))
+                timers.extend(self._filter_eligible_entities(node.timers))
+                clients.extend(self._filter_eligible_entities(node.clients))
+                services.extend(self._filter_eligible_entities(node.services))
+            (sigint_gc, sigint_gc_handle) = _rclpy.rclpy_get_sigint_guard_condition()
+            if timeout_timer is not None:
+                timers.append(timeout_timer)
+
+            # Construct a wait set
+            with _WaitSet() as wait_set:
+                _rclpy.rclpy_wait_set_init(
+                    wait_set,
+                    len(subscriptions),
+                    num_guard_conditions,
+                    len(timers),
+                    len(clients),
+                    len(services))
+                entities = {
+                    'subscription': (subscriptions, 'subscription_handle'),
+                    'client': (clients, 'client_handle'),
+                    'service': (services, 'service_handle'),
+                    'timer': (timers, 'timer_handle'),
+                }
+                for entity, (handles, handle_name) in entities.items():
+                    _rclpy.rclpy_wait_set_clear_entities(entity, wait_set)
+                    for h in handles:
+                        _rclpy.rclpy_wait_set_add_entity(
+                            entity, wait_set, h.__getattribute__(handle_name)
+                        )
+                _rclpy.rclpy_wait_set_clear_entities('guard_condition', wait_set)
+                _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
+                _rclpy.rclpy_wait_set_add_entity(
+                    'guard_condition', wait_set, self._guard_condition)
+
+                # Wait for something to become ready
+                _rclpy.rclpy_wait(wait_set, timeout_nsec)
+
+                # get ready entities
+                subs_ready = _rclpy.rclpy_get_ready_entities('subscription', wait_set)
+                guards_ready = _rclpy.rclpy_get_ready_entities('guard_condition', wait_set)
+                timers_ready = _rclpy.rclpy_get_ready_entities('timer', wait_set)
+                clients_ready = _rclpy.rclpy_get_ready_entities('client', wait_set)
+                services_ready = _rclpy.rclpy_get_ready_entities('service', wait_set)
+
+            # Check sigint guard condition
+            if sigint_gc_handle in guards_ready:
+                raise KeyboardInterrupt
+            _rclpy.rclpy_destroy_entity('guard_condition', sigint_gc)
+
+            # Process ready entities one node at a time
+            for node in nodes:
+                for tmr in [t for t in node.timers if t.timer_pointer in timers_ready]:
+                    # Check that a timer is ready to workaround rcl issue with cancelled timers
+                    if _rclpy.rclpy_is_timer_ready(tmr.timer_handle):
+                        if tmr.callback_group.can_execute(tmr):
+                            handler = self._make_handler(
+                                tmr, self._take_timer, self._execute_timer)
+                            yielded_work = True
+                            yield handler, tmr, node
+
+                for sub in [s for s in node.subscriptions if s.subscription_pointer in subs_ready]:
+                    if sub.callback_group.can_execute(sub):
+                        handler = self._make_handler(
+                            sub, self._take_subscription, self._execute_subscription)
+                        yielded_work = True
+                        yield handler, sub, node
+
+                for client in [c for c in node.clients if c.client_pointer in clients_ready]:
+                    if client.callback_group.can_execute(client):
+                        handler = self._make_handler(
+                            client, self._take_client, self._execute_client)
+                        yielded_work = True
+                        yield handler, client, node
+
+                for srv in [s for s in node.services if s.service_pointer in services_ready]:
+                    if srv.callback_group.can_execute(srv):
+                        handler = self._make_handler(
+                            srv, self._take_service, self._execute_service)
+                        yielded_work = True
+                        yield handler, srv, node
+
+            # Check timeout timer
+            if timeout_timer is not None and timeout_timer.timer_pointer in timers_ready:
+                break
+
+
+class SingleThreadedExecutor(Executor):
+    """Runs callbacks in the thread which calls :func:`SingleThreadedExecutor.spin`."""
+
+    def __init__(self):
+        super().__init__()
+
+    def spin_once(self, timeout_sec=None):
+        try:
+            handler, entity, node = next(self.wait_for_ready_callbacks(timeout_sec=timeout_sec))
+            handler()
+        except StopIteration:
+            pass
+
+
+class MultiThreadedExecutor(Executor):
+    """Runs callbacks in a pool of threads."""
+
+    def __init__(self, num_threads=None):
+        """
+        Initialize the executor.
+
+        :param num_threads: number of worker threads in the pool. If None the number of threads
+                      will use multiprocessing.cpu_count(). If that's not implemented the number
+                      of threads defaults to 1.
+        :type num_threads: int
+        """
+        super().__init__()
+        if num_threads is None:
+            try:
+                num_threads = multiprocessing.cpu_count()
+            except NotImplementedError:
+                num_threads = 1
+        self._executor = _ThreadPoolExecutor(num_threads)
+
+    def spin_once(self, timeout_sec=None):
+        try:
+            handler, entity, node = next(self.wait_for_ready_callbacks(timeout_sec=timeout_sec))
+            self._executor.submit(handler)
+        except StopIteration:
+            pass

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -111,13 +111,14 @@ class Executor:
         # Clean up stuff that won't be used anymore
         with self._nodes_lock:
             self._nodes = set()
-        _rclpy.rclpy_destroy_guard_condition(self._guard_condition)
+        _rclpy.rclpy_destroy_entity('guard_condition', self._guard_condition)
+
         self._guard_condition = None
         return True
 
     def __del__(self):
         if self._guard_condition is not None:
-            _rclpy.rclpy_destroy_guard_condition(self._guard_condition)
+            _rclpy.rclpy_destroy_entity('guard_condition', self._guard_condition)
 
     def add_node(self, node):
         """

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -366,7 +366,8 @@ class Executor:
                         yield handler, srv, node
 
             # Check timeout timer
-            if timeout_timer is not None and timeout_timer.timer_pointer in timers_ready:
+            if (timeout_nsec == 0 or
+                    (timeout_timer is not None and timeout_timer.timer_pointer in timers_ready)):
                 break
 
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -219,12 +219,10 @@ class Executor:
             nonlocal gc
             nonlocal is_shutdown
             nonlocal work_tracker
-            if not entity.callback_group.beginning_execution(entity):
-                # Didn't get the callback, try again later
+            if is_shutdown or not entity.callback_group.beginning_execution(entity):
+                # Didn't get the callback, or the executor has been ordered to stop
                 entity._executor_event = False
                 _rclpy.rclpy_trigger_guard_condition(gc)
-                return
-            if is_shutdown:
                 return
             with work_tracker:
                 arg = take_from_wait_list(entity)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -106,7 +106,7 @@ class Executor:
         :rtype: bool
         """
         self._is_shutdown = True
-        if not self._work_tracker.wait():
+        if not self._work_tracker.wait(timeout_sec):
             return False
         # Clean up stuff that won't be used anymore
         with self._nodes_lock:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -43,15 +43,12 @@ class Node:
         self._default_callback_group = MutuallyExclusiveCallbackGroup()
 
         namespace = namespace or ''
-        failed = False
         if not ok():
             raise NotInitializedException('cannot create node')
         try:
             node_handle = _rclpy.rclpy_create_node(node_name, namespace)
             self._handle = node_handle
         except ValueError:
-            failed = True
-        if failed:
             # these will raise more specific errors if the name or namespace is bad
             validate_node_name(node_name)
             # emulate what rcl_node_init() does to accept '' and relative namespaces

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -58,7 +58,7 @@ class Node:
                 namespace = '/' + namespace
             validate_namespace(namespace)
             # Should not get to this point
-            raise RuntimeError("rclpy_create_node failed for unknown reason")
+            raise RuntimeError('rclpy_create_node failed for unknown reason')
 
     @property
     def handle(self):

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -18,13 +18,16 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 class Service:
     def __init__(
             self, node_handle, service_handle, service_pointer,
-            srv_type, srv_name, callback, qos_profile):
+            srv_type, srv_name, callback, callback_group, qos_profile):
         self.node_handle = node_handle
         self.service_handle = service_handle
         self.service_pointer = service_pointer
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.callback = callback
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
         self.qos_profile = qos_profile
 
     def send_response(self, response, header):

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -17,11 +17,14 @@ class Subscription:
 
     def __init__(
             self, subscription_handle, subscription_pointer,
-            msg_type, topic, callback, qos_profile, node_handle):
+            msg_type, topic, callback, callback_group, qos_profile, node_handle):
         self.node_handle = node_handle
         self.subscription_handle = subscription_handle
         self.subscription_pointer = subscription_pointer
         self.msg_type = msg_type
         self.topic = topic
         self.callback = callback
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
         self.qos_profile = qos_profile

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -18,10 +18,13 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 # TODO(mikaelarguedas) create a Timer or ROSTimer once we can specify custom time sources
 class WallTimer:
 
-    def __init__(self, callback, timer_period_ns):
+    def __init__(self, callback, callback_group, timer_period_ns):
         [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(timer_period_ns)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
 
     @property
     def timer_period_ns(self):

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1761,7 +1761,13 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
 #endif  // _WIN32
   previous_handler = signal(SIGINT, catch_function);
   rcl_wait_set_t * wait_set = (rcl_wait_set_t *)PyCapsule_GetPointer(pywait_set, NULL);
-  rcl_ret_t ret = rcl_wait(wait_set, timeout);
+  rcl_ret_t ret;
+
+  // Could be a long wait, release the GIL
+  Py_BEGIN_ALLOW_THREADS;
+  ret = rcl_wait(wait_set, timeout);
+  Py_END_ALLOW_THREADS;
+
   signal(SIGINT, previous_handler);
   if (ret != RCL_RET_OK && ret != RCL_RET_TIMEOUT) {
     PyErr_Format(PyExc_RuntimeError,

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -77,6 +77,92 @@ rclpy_get_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * Py_UNUSE
   return pylist;
 }
 
+/// Create a general purpose guard condition
+/**
+ * A successful call will return a list with two elements:
+ *
+ * - a Capsule with the pointer of the created rcl_guard_condition_t * structure
+ * - an integer representing the memory address of the rcl_guard_condition_t
+ *
+ * \return a list with the capsule and memory location, or
+ * \return NULL on failure
+ */
+static PyObject *
+rclpy_create_guard_condition(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  rcl_guard_condition_t * gc =
+    (rcl_guard_condition_t *)PyMem_Malloc(sizeof(rcl_guard_condition_t));
+  *gc = rcl_get_zero_initialized_guard_condition();
+  rcl_guard_condition_options_t gc_options = rcl_guard_condition_get_default_options();
+
+  rcl_ret_t ret = rcl_guard_condition_init(gc, gc_options);
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to create guard_condition: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+    return NULL;
+  }
+  PyObject * pylist = PyList_New(0);
+  PyList_Append(pylist, PyCapsule_New(gc, NULL, NULL));
+  PyList_Append(pylist, PyLong_FromUnsignedLongLong((uint64_t)&gc->impl));
+
+  return pylist;
+}
+
+/// Destroy a general purpose guard condition
+/**
+ *
+ * \param[in] guard_condition Capsule pointing to guard condtition to destory
+ * \return True on success, False on failure
+ */
+static PyObject *
+rclpy_destroy_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pygc;
+
+  if (!PyArg_ParseTuple(args, "O", &pygc)) {
+    Py_RETURN_FALSE;
+  }
+
+  rcl_guard_condition_t * gc = (rcl_guard_condition_t *)PyCapsule_GetPointer(pygc, NULL);
+  rcl_ret_t ret = rcl_guard_condition_fini(gc);
+
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to fini guard_condition: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+    return NULL;
+  }
+  Py_RETURN_TRUE;
+}
+
+/// Trigger a general purpose guard condition
+/**
+ *
+ * \param[in] guard_condition Capsule pointing to guard condtition
+ * \return True on success, False on failure
+ */
+static PyObject *
+rclpy_trigger_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pygc;
+
+  if (!PyArg_ParseTuple(args, "O", &pygc)) {
+    Py_RETURN_FALSE;
+  }
+
+  rcl_guard_condition_t * gc = (rcl_guard_condition_t *)PyCapsule_GetPointer(pygc, NULL);
+  rcl_ret_t ret = rcl_trigger_guard_condition(gc);
+
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to trigger guard_condition: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+    return NULL;
+  }
+  Py_RETURN_TRUE;
+}
+
 /// Initialize rcl with default options, ignoring parameters
 static PyObject *
 rclpy_init(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
@@ -2367,6 +2453,12 @@ static PyMethodDef rclpy_methods[] = {
 
   {"rclpy_get_sigint_guard_condition", rclpy_get_sigint_guard_condition, METH_NOARGS,
    "Create a guard_condition triggered when sigint is received."},
+  {"rclpy_create_guard_condition", rclpy_create_guard_condition, METH_VARARGS,
+   "Create a general purpose guard_condition."},
+  {"rclpy_trigger_guard_condition", rclpy_trigger_guard_condition, METH_VARARGS,
+   "Trigger a general purpose guard_condition."},
+  {"rclpy_destroy_guard_condition", rclpy_destroy_guard_condition, METH_VARARGS,
+   "Destroy a general purpose guard_condition."},
 
   {"rclpy_destroy_node_entity", rclpy_destroy_node_entity, METH_VARARGS,
    "Destroy a Node entity."},

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -102,38 +102,12 @@ rclpy_create_guard_condition(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(ar
     rcl_reset_error();
     return NULL;
   }
-  PyObject * pylist = PyList_New(0);
-  PyList_Append(pylist, PyCapsule_New(gc, NULL, NULL));
-  PyList_Append(pylist, PyLong_FromUnsignedLongLong((uint64_t)&gc->impl));
+  PyObject * pylist = PyList_New(2);
+
+  PyList_SET_ITEM(pylist, 0, PyCapsule_New(gc, NULL, NULL));
+  PyList_SET_ITEM(pylist, 1, PyLong_FromUnsignedLongLong((uint64_t)&gc->impl));
 
   return pylist;
-}
-
-/// Destroy a general purpose guard condition
-/**
- *
- * \param[in] guard_condition Capsule pointing to guard condtition to destory
- * \return True on success, False on failure
- */
-static PyObject *
-rclpy_destroy_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  PyObject * pygc;
-
-  if (!PyArg_ParseTuple(args, "O", &pygc)) {
-    Py_RETURN_FALSE;
-  }
-
-  rcl_guard_condition_t * gc = (rcl_guard_condition_t *)PyCapsule_GetPointer(pygc, NULL);
-  rcl_ret_t ret = rcl_guard_condition_fini(gc);
-
-  if (ret != RCL_RET_OK) {
-    PyErr_Format(PyExc_RuntimeError,
-      "Failed to fini guard_condition: %s", rcl_get_error_string_safe());
-    rcl_reset_error();
-    return NULL;
-  }
-  Py_RETURN_TRUE;
 }
 
 /// Trigger a general purpose guard condition
@@ -2457,13 +2431,11 @@ static PyMethodDef rclpy_methods[] = {
    "Create a general purpose guard_condition."},
   {"rclpy_trigger_guard_condition", rclpy_trigger_guard_condition, METH_VARARGS,
    "Trigger a general purpose guard_condition."},
-  {"rclpy_destroy_guard_condition", rclpy_destroy_guard_condition, METH_VARARGS,
-   "Destroy a general purpose guard_condition."},
 
   {"rclpy_destroy_node_entity", rclpy_destroy_node_entity, METH_VARARGS,
    "Destroy a Node entity."},
   {"rclpy_destroy_entity", rclpy_destroy_entity, METH_VARARGS,
-   "Destroy a Node."},
+   "Destroy an rclpy entity."},
 
   {"rclpy_publish", rclpy_publish, METH_VARARGS,
    "Publish a message."},

--- a/rclpy/test/test_callback_group.py
+++ b/rclpy/test/test_callback_group.py
@@ -1,0 +1,100 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rcl_interfaces.srv import GetParameters
+import rclpy
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy.callback_groups import ReentrantCallbackGroup
+from std_msgs.msg import String
+
+
+class TestCallbackGroup(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('TestCallbackGroup', namespace='/rclpy')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_reentrant_group(self):
+        self.assertIsNotNone(self.node.handle)
+        group = ReentrantCallbackGroup()
+        t1 = self.node.create_timer(1.0, lambda: None, callback_group=group)
+        t2 = self.node.create_timer(1.0, lambda: None, callback_group=group)
+
+        self.assertTrue(group.can_execute(t1))
+        self.assertTrue(group.can_execute(t2))
+        self.assertTrue(group.beginning_execution(t1))
+        self.assertTrue(group.beginning_execution(t2))
+
+    def test_mutually_exclusive_group(self):
+        self.assertIsNotNone(self.node.handle)
+        group = MutuallyExclusiveCallbackGroup()
+        t1 = self.node.create_timer(1.0, lambda: None, callback_group=group)
+        t2 = self.node.create_timer(1.0, lambda: None, callback_group=group)
+
+        self.assertTrue(group.can_execute(t1))
+        self.assertTrue(group.can_execute(t2))
+
+        self.assertTrue(group.beginning_execution(t1))
+        self.assertFalse(group.can_execute(t2))
+        self.assertFalse(group.beginning_execution(t2))
+
+        group.ending_execution(t1)
+        self.assertTrue(group.can_execute(t2))
+        self.assertTrue(group.beginning_execution(t2))
+
+    def test_create_timer_with_group(self):
+        tmr1 = self.node.create_timer(1.0, lambda: None)
+        group = ReentrantCallbackGroup()
+        tmr2 = self.node.create_timer(1.0, lambda: None, callback_group=group)
+
+        self.assertFalse(group.has_entity(tmr1))
+        self.assertTrue(group.has_entity(tmr2))
+
+    def test_create_subscription_with_group(self):
+        sub1 = self.node.create_subscription(String, 'chatter', lambda msg: print(msg))
+        group = ReentrantCallbackGroup()
+        sub2 = self.node.create_subscription(
+            String, 'chatter', lambda msg: print(msg), callback_group=group)
+
+        self.assertFalse(group.has_entity(sub1))
+        self.assertTrue(group.has_entity(sub2))
+
+    def test_create_client_with_group(self):
+        cli1 = self.node.create_client(GetParameters, 'get/parameters')
+        group = ReentrantCallbackGroup()
+        cli2 = self.node.create_client(GetParameters, 'get/parameters', callback_group=group)
+
+        self.assertFalse(group.has_entity(cli1))
+        self.assertTrue(group.has_entity(cli2))
+
+    def test_create_service_with_group(self):
+        srv1 = self.node.create_service(GetParameters, 'get/parameters', lambda req: None)
+        group = ReentrantCallbackGroup()
+        srv2 = self.node.create_service(
+            GetParameters, 'get/parameters', lambda req: None, callback_group=group)
+
+        self.assertFalse(group.has_entity(srv1))
+        self.assertTrue(group.has_entity(srv2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -73,9 +73,9 @@ class TestExecutor(unittest.TestCase):
         self.assertIsNotNone(self.node.handle)
         executor = SingleThreadedExecutor()
         executor.add_node(self.node)
-        start = time.time()
+        start = time.monotonic()
         executor.spin_once(timeout_sec=0)
-        end = time.time()
+        end = time.monotonic()
         self.assertLess(start - end, 0.001)
 
 

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import unittest
 
 import rclpy
@@ -67,6 +68,15 @@ class TestExecutor(unittest.TestCase):
         executor = SingleThreadedExecutor()
         executor.add_node(self.node)
         self.assertIn(self.node, executor.get_nodes())
+
+    def test_executor_spin_non_blocking(self):
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor()
+        executor.add_node(self.node)
+        start = time.time()
+        executor.spin_once(timeout_sec=0)
+        end = time.time()
+        self.assertLess(start - end, 0.001)
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -1,0 +1,73 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import SingleThreadedExecutor
+
+
+class TestExecutor(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('TestExecutor', namespace='/rclpy')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def func_execution(self, executor):
+        got_callback = False
+
+        def timer_callback():
+            nonlocal got_callback
+            got_callback = True
+
+        tmr = self.node.create_timer(0.1, timer_callback)
+
+        executor.add_node(self.node)
+        executor.spin_once(timeout_sec=1.23)
+
+        self.node.destroy_timer(tmr)
+        return got_callback
+
+    def test_single_threaded_executor_executes(self):
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor()
+        try:
+            self.assertTrue(self.func_execution(executor))
+        finally:
+            executor.shutdown()
+
+    def test_multi_threaded_executor_executes(self):
+        self.assertIsNotNone(self.node.handle)
+        executor = MultiThreadedExecutor()
+        try:
+            self.assertTrue(self.func_execution(executor))
+        finally:
+            executor.shutdown()
+
+    def test_add_node_to_executor(self):
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor()
+        executor.add_node(self.node)
+        self.assertIn(self.node, executor.get_nodes())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds Executors and CallbackGroups to rclpy. This is part of feature parity with rclcpp.

Executors and CallbackGroups are added in the fourth commit on this branch. The first 3 commits are prerequisites:
1. Release the GIL so other python threads can run during a call to `rcl_wait()`
2. Add functions to rclpy for guard conditions
3. Change `Node.__init__` arguments so it can be created by inheriting from it

See examples in ros2/examples#182 and ros2/demos#169
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3213)](http://ci.ros2.org/job/ci_linux/3213/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=533)](http://ci.ros2.org/job/ci_linux-aarch64/533/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2568)](http://ci.ros2.org/job/ci_osx/2568/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3280)](http://ci.ros2.org/job/ci_windows/3280/)