### PR TITLE
Remove duplicate call to rclpy_create_timer()

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -146,8 +146,7 @@ class Node:
 
     def create_timer(self, timer_period_sec, callback):
         timer_period_nsec = int(float(timer_period_sec) * S_TO_NS)
-        [timer_handle, timer_pointer] = _rclpy.rclpy_create_timer(timer_period_nsec)
-        timer = WallTimer(timer_handle, timer_pointer, callback, timer_period_nsec)
+        timer = WallTimer(callback, timer_period_nsec)
 
         self.timers.append(timer)
         return timer

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -18,7 +18,7 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 # TODO(mikaelarguedas) create a Timer or ROSTimer once we can specify custom time sources
 class WallTimer(object):
 
-    def __init__(self, timer_handle, timer_pointer, callback, timer_period_ns):
+    def __init__(self, callback, timer_period_ns):
         [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(timer_period_ns)
         self.timer_period_ns = timer_period_ns
         self.callback = callback


### PR DESCRIPTION
This removes an extra call to `rclpy_create_timer()`  and two unused arguments in `WallTimer.__init__()`. A timer handle was created inside of `Node.create_timer()` and given to `WallTimer.__init__()` which ignored the handle and created its own.