### PR TITLE
implicitly inherit from object

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -17,7 +17,7 @@ from enum import IntEnum
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
-class QoSProfile(object):
+class QoSProfile:
     """Define Quality of Service policies."""
 
     __slots__ = [

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -16,7 +16,7 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
 # TODO(mikaelarguedas) create a Timer or ROSTimer once we can specify custom time sources
-class WallTimer(object):
+class WallTimer:
 
     def __init__(self, callback, timer_period_ns):
         [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(timer_period_ns)


### PR DESCRIPTION
In python 3 classes [implicitely inherit from object](https://docs.python.org/3.5/tutorial/classes.html#multiple-inheritance), so no need to express inheritence except if the class inherits from something else.
Addresses https://github.com/ros2/rclpy/pull/104#discussion_r135370317