### PR TITLE
add function to destroy waitset and call it in spin_once

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -120,3 +120,5 @@ def spin_once(node, *, timeout_sec=None):
         if request:
             response = srv.callback(request, srv.srv_type.Response())
             srv.send_response(response, header)
+
+    _rclpy.rclpy_destroy_wait_set(wait_set)


### PR DESCRIPTION
Addresses the memory leak described in #74. The script still uses a large amount of memory though.

This PR only fixes the leak of the waitset. A similar patch is required for every entity allocated with `PyMem_Malloc` (node, publisher, subscriptions, service, client, timer, guard condition, header (twice), qos_profile).