### PR TITLE
add hint if rclpy fails to be imported

### DIFF
--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -28,15 +28,14 @@ For example, you might use it like this:
 
 import importlib
 import os
-import sys
+import warnings
 
 try:
     rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
 except ImportError as e:
     if os.path.isfile(e.path):
-        print(
+        warnings.warn(
             "The C extension '%s' failed to be imported while being present on the system."
             " Please refer to '%s' for possible solutions\n" %
-            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'),
-            file=sys.stderr)
+            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'))
     raise

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -35,6 +35,6 @@ except ImportError as e:
     if os.path.isfile(e.path):
         e.msg += \
             "\nThe C extension '%s' failed to be imported while being present on the system." \
-            " Please refer to '%s' for possible solutions\n" % \
+            " Please refer to '%s' for possible solutions" % \
             (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint')
     raise

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -28,14 +28,13 @@ For example, you might use it like this:
 
 import importlib
 import os
-import warnings
 
 try:
     rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
 except ImportError as e:
     if os.path.isfile(e.path):
-        warnings.warn(
-            "The C extension '%s' failed to be imported while being present on the system."
-            " Please refer to '%s' for possible solutions\n" %
-            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'))
+        e.msg += \
+            "\nThe C extension '%s' failed to be imported while being present on the system." \
+            " Please refer to '%s' for possible solutions\n" % \
+            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint')
     raise

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -28,13 +28,15 @@ For example, you might use it like this:
 
 import importlib
 import os
+import sys
 
 try:
     rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
 except ImportError as e:
     if os.path.isfile(e.path):
-        raise ImportWarning(
+        print(
             "The C extension '%s' failed to be imported while being present on the system."
             " Please refer to '%s' for possible solutions\n" %
-            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'))
+            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'),
+            file=sys.stderr)
     raise

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -28,15 +28,13 @@ For example, you might use it like this:
 
 import importlib
 import os
-import sys
 
 try:
     rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
 except ImportError as e:
     if os.path.isfile(e.path):
-        print(
+        raise ImportWarning(
             "The C extension '%s' failed to be imported while being present on the system."
             " Please refer to '%s' for possible solutions\n" %
-            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'),
-            file=sys.stderr)
+            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'))
     raise

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -28,5 +28,17 @@ For example, you might use it like this:
 
 import importlib
 
+module_name = '._rclpy'
 
-rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
+try:
+    rclpy_implementation = importlib.import_module(module_name, package='rclpy')
+except ImportError as e:
+    import os
+    if os.path.isfile(e.path):
+        import sys
+        print(
+            "The module '%s' failed to be imported while being present on the system."
+            " Please refer to '%s' for possible solutions\n" %
+            (module_name, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'),
+            file=sys.stderr)
+    raise

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -27,18 +27,16 @@ For example, you might use it like this:
 """
 
 import importlib
-
-module_name = '._rclpy'
+import os
+import sys
 
 try:
-    rclpy_implementation = importlib.import_module(module_name, package='rclpy')
+    rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
 except ImportError as e:
-    import os
     if os.path.isfile(e.path):
-        import sys
         print(
-            "The module '%s' failed to be imported while being present on the system."
+            "The C extension '%s' failed to be imported while being present on the system."
             " Please refer to '%s' for possible solutions\n" %
-            (module_name, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'),
+            (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint'),
             file=sys.stderr)
     raise


### PR DESCRIPTION
closes #115 
connects to #115 

Thew content of the [referenced wiki page](https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint) can be updated at a later date

Without this change
```
Failed to load entry point 'pub': DLL load failed: The specified module could not be found.
Traceback (most recent call last):
  File "C:\dev\ros2\lib\demo_nodes_py\talker-script.py", line 11, in <module>
    load_entry_point('demo-nodes-py==0.0.0', 'console_scripts', 'talker')()
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 570, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 2687, in load_entry_point
    return ep.load()
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 2341, in load
    return self.resolve()
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 2347, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "C:\dev\ros2\Lib\site-packages\demo_nodes_py\topics\talker.py", line 17, in <module>
    import rclpy
  File "C:\dev\ros2\Lib\site-packages\rclpy\__init__.py", line 17, in <module>
    from rclpy.executors import SingleThreadedExecutor as _SingleThreadedExecutor
  File "C:\dev\ros2\Lib\site-packages\rclpy\executors.py", line 21, in <module>
    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
  File "C:\dev\ros2\Lib\site-packages\rclpy\impl\implementation_singleton.py", line 32, in <module>
    rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
  File "C:\Python36\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: DLL load failed: The specified module could not be found.
```

With this change
```
Failed to load entry point 'pub': DLL load failed: The specified module could not be found.
The module '._rclpy' failed to be imported while being present on the system. Please refer to 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint' for possible solutions

Traceback (most recent call last):
  File "C:\dev\ros2\lib\demo_nodes_py\talker-script.py", line 11, in <module>
    load_entry_point('demo-nodes-py==0.0.0', 'console_scripts', 'talker')()
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 570, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 2687, in load_entry_point
    return ep.load()
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 2341, in load
    return self.resolve()
  File "C:\Python36\lib\site-packages\pkg_resources\__init__.py", line 2347, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "C:\dev\ros2\Lib\site-packages\demo_nodes_py\topics\talker.py", line 17, in <module>
    import rclpy
  File "C:\dev\ros2\Lib\site-packages\rclpy\__init__.py", line 17, in <module>
    from rclpy.executors import SingleThreadedExecutor as _SingleThreadedExecutor
  File "C:\dev\ros2\Lib\site-packages\rclpy\executors.py", line 21, in <module>
    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
  File "C:\dev\ros2\Lib\site-packages\rclpy\impl\implementation_singleton.py", line 35, in <module>
    rclpy_implementation = importlib.import_module(module_name, package='rclpy')
  File "C:\Python36\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: DLL load failed: The specified module could not be found.
```

Alternatively we could not reraise the exception and exit. That will give a cleaner error message but has the downside of restricting user ability to catch it and fallback. So I settled on the current behavior
Without reraising
```
Failed to load entry point 'pub': DLL load failed: The specified module could not be found.
The module '._rclpy' failed to be imported while being present on the system. Please refer to 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint' for possible solutions
```