### PR TITLE
Check exact capsules

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -638,17 +638,15 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
   *publisher = rcl_get_zero_initialized_publisher();
   rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();
 
-  if (!PyCapsule_CheckExact(pyqos_profile)) {
-    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_publisher");
-    return NULL;
-  }
-  void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-  publisher_ops.qos = *qos_profile;
-  PyMem_Free(p);
-  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-    // exception set by PyCapsule_SetPointer
-    return NULL;
+  if (PyCapsule_IsValid(pyqos_profile, NULL)) {
+    void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
+    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+    publisher_ops.qos = *qos_profile;
+    PyMem_Free(p);
+    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+      // exception set by PyCapsule_SetPointer
+      return NULL;
+    }
   }
 
   rcl_ret_t ret = rcl_publisher_init(publisher, node, ts, topic, &publisher_ops);
@@ -1083,17 +1081,15 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
   *subscription = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_ops = rcl_subscription_get_default_options();
 
-  if (!PyCapsule_CheckExact(pyqos_profile)) {
-    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_subscription");
-    return NULL;
-  }
-  void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-  subscription_ops.qos = *qos_profile;
-  PyMem_Free(p);
-  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-    // exception set by PyCapsule_SetPointer
-    return NULL;
+  if (PyCapsule_IsValid(pyqos_profile, NULL)) {
+    void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
+    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+    subscription_ops.qos = *qos_profile;
+    PyMem_Free(p);
+    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+      // exception set by PyCapsule_SetPointer
+      return NULL;
+    }
   }
 
   rcl_ret_t ret = rcl_subscription_init(subscription, node, ts, topic, &subscription_ops);
@@ -1169,17 +1165,15 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
   *client = rcl_get_zero_initialized_client();
   rcl_client_options_t client_ops = rcl_client_get_default_options();
 
-  if (!PyCapsule_CheckExact(pyqos_profile)) {
-    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_client");
-    return NULL;
-  }
-  void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-  client_ops.qos = *qos_profile;
-  PyMem_Free(p);
-  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-    // exception set by PyCapsule_SetPointer
-    return NULL;
+  if (PyCapsule_IsValid(pyqos_profile, NULL)) {
+    void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
+    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+    client_ops.qos = *qos_profile;
+    PyMem_Free(p);
+    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+      // exception set by PyCapsule_SetPointer
+      return NULL;
+    }
   }
 
   rcl_ret_t ret = rcl_client_init(client, node, ts, service_name, &client_ops);
@@ -1321,17 +1315,15 @@ rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
   *service = rcl_get_zero_initialized_service();
   rcl_service_options_t service_ops = rcl_service_get_default_options();
 
-  if (!PyCapsule_CheckExact(pyqos_profile)) {
-    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_service");
-    return NULL;
-  }
-  void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-  service_ops.qos = *qos_profile;
-  PyMem_Free(p);
-  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-    // exception set by PyCapsule_SetPointer
-    return NULL;
+  if (PyCapsule_IsValid(pyqos_profile, NULL)) {
+    void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
+    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+    service_ops.qos = *qos_profile;
+    PyMem_Free(p);
+    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+      // exception set by PyCapsule_SetPointer
+      return NULL;
+    }
   }
 
   rcl_ret_t ret = rcl_service_init(service, node, ts, service_name, &service_ops);

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -123,7 +123,10 @@ rclpy_trigger_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pygc;
 
-  if (!PyArg_ParseTuple(args, "O", &pygc) || !PyCapsule_CheckExact(pygc)) {
+  if (!PyArg_ParseTuple(args, "O", &pygc)) {
+    return NULL;
+  }
+  if (!PyCapsule_CheckExact(pygc)) {
     Py_RETURN_FALSE;
   }
 
@@ -551,7 +554,6 @@ rclpy_expand_topic_name(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * node_namespace_py;
 
   if (!PyArg_ParseTuple(args, "OOO", &topic_name, &node_name_py, &node_namespace_py)) {
-    PyErr_Format(PyExc_RuntimeError, "Invalid arguments");
     return NULL;
   }
 
@@ -1435,7 +1437,7 @@ rclpy_destroy_node_entity(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pynode;
 
   if (!PyArg_ParseTuple(args, "zOO", &entity_type, &pyentity, &pynode)) {
-    Py_RETURN_FALSE;
+    return NULL;
   }
 
   void * p = PyCapsule_GetPointer(pynode, NULL);
@@ -1500,7 +1502,7 @@ rclpy_destroy_entity(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pyentity;
 
   if (!PyArg_ParseTuple(args, "zO", &entity_type, &pyentity)) {
-    Py_RETURN_FALSE;
+    return NULL;
   }
 
   void * p = PyCapsule_GetPointer(pyentity, NULL);

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -638,15 +638,17 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
   *publisher = rcl_get_zero_initialized_publisher();
   rcl_publisher_options_t publisher_ops = rcl_publisher_get_default_options();
 
+  if (!PyCapsule_CheckExact(pyqos_profile)) {
+    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_publisher");
+    return NULL;
+  }
   void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  if (Py_None != p) {
-    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-    publisher_ops.qos = *qos_profile;
-    PyMem_Free(p);
-    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-      // exception set by PyCapsule_SetPointer
-      return NULL;
-    }
+  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+  publisher_ops.qos = *qos_profile;
+  PyMem_Free(p);
+  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+    // exception set by PyCapsule_SetPointer
+    return NULL;
   }
 
   rcl_ret_t ret = rcl_publisher_init(publisher, node, ts, topic, &publisher_ops);
@@ -1081,15 +1083,17 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
   *subscription = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_ops = rcl_subscription_get_default_options();
 
+  if (!PyCapsule_CheckExact(pyqos_profile)) {
+    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_subscription");
+    return NULL;
+  }
   void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  if (Py_None != p) {
-    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-    subscription_ops.qos = *qos_profile;
-    PyMem_Free(p);
-    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-      // exception set by PyCapsule_SetPointer
-      return NULL;
-    }
+  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+  subscription_ops.qos = *qos_profile;
+  PyMem_Free(p);
+  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+    // exception set by PyCapsule_SetPointer
+    return NULL;
   }
 
   rcl_ret_t ret = rcl_subscription_init(subscription, node, ts, topic, &subscription_ops);
@@ -1165,15 +1169,17 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
   *client = rcl_get_zero_initialized_client();
   rcl_client_options_t client_ops = rcl_client_get_default_options();
 
+  if (!PyCapsule_CheckExact(pyqos_profile)) {
+    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_client");
+    return NULL;
+  }
   void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  if (Py_None != p) {
-    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-    client_ops.qos = *qos_profile;
-    PyMem_Free(p);
-    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-      // exception set by PyCapsule_SetPointer
-      return NULL;
-    }
+  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+  client_ops.qos = *qos_profile;
+  PyMem_Free(p);
+  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+    // exception set by PyCapsule_SetPointer
+    return NULL;
   }
 
   rcl_ret_t ret = rcl_client_init(client, node, ts, service_name, &client_ops);
@@ -1315,15 +1321,17 @@ rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
   *service = rcl_get_zero_initialized_service();
   rcl_service_options_t service_ops = rcl_service_get_default_options();
 
+  if (!PyCapsule_CheckExact(pyqos_profile)) {
+    PyErr_Format(PyExc_RuntimeError, "Invalid pyqos_profile capsule in rclpy_create_service");
+    return NULL;
+  }
   void * p = PyCapsule_GetPointer(pyqos_profile, NULL);
-  if (Py_None != p) {
-    rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
-    service_ops.qos = *qos_profile;
-    PyMem_Free(p);
-    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-      // exception set by PyCapsule_SetPointer
-      return NULL;
-    }
+  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)p;
+  service_ops.qos = *qos_profile;
+  PyMem_Free(p);
+  if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
+    // exception set by PyCapsule_SetPointer
+    return NULL;
   }
 
   rcl_ret_t ret = rcl_service_init(service, node, ts, service_name, &service_ops);


### PR DESCRIPTION
The first commit makes sure that we return `NULL` each time `PyArg_ParseTuple` fails and raises an exception.
The second commit uses `PyCapsule_CheckExact` rather than comparing capsules to `Py_None`. It is an attempt to address https://github.com/ros2/rclpy/pull/120#pullrequestreview-63114812 but doesnt reduce the amount of code unfortunately because we still need to extract the pointer (to pass it's value to the entity we create) and then free it... This could be changed to a call to `PyCapsule_IsValid` and adapt the names passed to in when our [capsules get names](https://github.com/ros2/rclpy/issues/124).