### PR TITLE
Ignore vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Vim
+.*.sw?


### PR DESCRIPTION
Git ignore uses glob syntax. Editing files in vim produces a file with a leading `.` and suffix that starts with `.swp`. If a vim instance fails to close cleanly a new instance will bump the last character in the suffix to `.swo`. I've never crashed vim enough times in a row to see what happens when it gets to the last single character available, so that's not handled here.