### PR TITLE
Updates for global severity threshold -> default severity threshold

### DIFF
--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -25,11 +25,11 @@ class LoggingSeverity(IntEnum):
     This enum must match the one defined in rcutils/logging.h
     """
 
-    DEBUG = 0
-    INFO = 1
-    WARN = 2
-    ERROR = 3
-    FATAL = 4
+    DEBUG = 10
+    INFO = 20
+    WARN = 30
+    ERROR = 40
+    FATAL = 50
 
 
 def get_named_logger(name):

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -29,19 +29,19 @@ rclpy_logging_initialize(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   Py_RETURN_NONE;
 }
 
-/// Get the global severity threshold of the logging system.
+/// Get the default severity threshold of the logging system.
 /**
  * \return severity
  */
 static PyObject *
 rclpy_logging_get_severity_threshold(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
-  int severity = rcutils_logging_get_severity_threshold();
+  int severity = rcutils_logging_get_default_severity_threshold();
 
   return PyLong_FromLong(severity);
 }
 
-/// Set the global severity threshold of the logging system.
+/// Set the default severity threshold of the logging system.
 /**
  *
  * \param[in] severity Threshold to set
@@ -55,7 +55,7 @@ rclpy_logging_set_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args
     return NULL;
   }
 
-  rcutils_logging_set_severity_threshold(severity);
+  rcutils_logging_set_default_severity_threshold(severity);
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
connects to ros2/rcutils#57

This is the minimum PR required to keep rclpy working with the changes in https://github.com/ros2/rcutils/pull/57

It does not attempt to leverage any of the configuration of loggers (that'll be a separate PR)