### PR TITLE
Rclpy GuardCondition

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -197,6 +197,13 @@ class Executor:
             response = srv.callback(request, srv.srv_type.Response())
             srv.send_response(response, header)
 
+    def _take_guard_condition(self, gc):
+        # Nothing to do
+        pass
+
+    def _execute_guard_condition(self, gc, _):
+        gc.callback()
+
     def _make_handler(self, entity, take_from_wait_list, call_callback):
         """
         Make a handler that performs work on an entity.
@@ -278,12 +285,13 @@ class Executor:
         while not yielded_work and not self._is_shutdown:
             # Gather entities that can be waited on
             subscriptions = []
-            num_guard_conditions = 2
+            guards = []
             timers = []
             clients = []
             services = []
             for node in nodes:
                 subscriptions.extend(self._filter_eligible_entities(node.subscriptions))
+                guards.extend(self._filter_eligible_entities(node.guards))
                 timers.extend(self._filter_eligible_entities(node.timers))
                 clients.extend(self._filter_eligible_entities(node.clients))
                 services.extend(self._filter_eligible_entities(node.services))
@@ -296,13 +304,14 @@ class Executor:
                 _rclpy.rclpy_wait_set_init(
                     wait_set,
                     len(subscriptions),
-                    num_guard_conditions,
+                    len(guards) + 2,
                     len(timers),
                     len(clients),
                     len(services))
 
                 entities = {
                     'subscription': (subscriptions, 'subscription_handle'),
+                    'guard_condition': (guards, 'guard_handle'),
                     'client': (clients, 'client_handle'),
                     'service': (services, 'service_handle'),
                     'timer': (timers, 'timer_handle'),
@@ -313,7 +322,6 @@ class Executor:
                         _rclpy.rclpy_wait_set_add_entity(
                             entity, wait_set, h.__getattribute__(handle_name)
                         )
-                _rclpy.rclpy_wait_set_clear_entities('guard_condition', wait_set)
                 _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
                 _rclpy.rclpy_wait_set_add_entity(
                     'guard_condition', wait_set, self._guard_condition)
@@ -350,6 +358,13 @@ class Executor:
                             sub, self._take_subscription, self._execute_subscription)
                         yielded_work = True
                         yield handler, sub, node
+
+                for gc in [g for g in node.guards if g.guard_pointer in guards_ready]:
+                    if gc.callback_group.can_execute(gc):
+                        handler = self._make_handler(
+                            gc, self._take_guard_condition, self._execute_guard_condition)
+                        yielded_work = True
+                        yield handler, gc, node
 
                 for client in [c for c in node.clients if c.client_pointer in clients_ready]:
                     if client.callback_group.can_execute(client):

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -1,0 +1,27 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+class GuardCondition:
+    def __init__(self, callback, callback_group):
+        self.guard_handle, self.guard_pointer = _rclpy.rclpy_create_guard_condition()
+        self.callback = callback
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
+
+    def trigger(self):
+        _rclpy.rclpy_trigger_guard_condition(self.guard_handle)

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -22,6 +22,8 @@ class GuardCondition:
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor
         self._executor_event = False
+        # True when the executor sees this has been triggered but has not yet been handled
+        self._executor_triggered = False
 
     def trigger(self):
         _rclpy.rclpy_trigger_guard_condition(self.guard_handle)

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -16,6 +16,7 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
 class GuardCondition:
+
     def __init__(self, callback, callback_group):
         self.guard_handle, self.guard_pointer = _rclpy.rclpy_create_guard_condition()
         self.callback = callback

--- a/rclpy/test/test_guard_condition.py
+++ b/rclpy/test/test_guard_condition.py
@@ -1,0 +1,56 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+
+
+class TestGuardCondition(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('TestGuardCondition', namespace='/rclpy/test')
+        cls.executor = SingleThreadedExecutor()
+        cls.executor.add_node(cls.node)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.executor.shutdown()
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_trigger(self):
+        called = False
+
+        def func():
+            nonlocal called
+            called = True
+
+        gc = self.node.create_guard_condition(func)
+
+        self.executor.spin_once(timeout_sec=0)
+        self.assertFalse(called)
+
+        gc.trigger()
+        self.executor.spin_once(timeout_sec=0)
+        self.assertTrue(called)
+
+        self.node.destroy_guard_condition(gc)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_guard_condition.py
+++ b/rclpy/test/test_guard_condition.py
@@ -51,6 +51,41 @@ class TestGuardCondition(unittest.TestCase):
 
         self.node.destroy_guard_condition(gc)
 
+    def test_double_trigger(self):
+        called1 = False
+        called2 = False
+
+        def func1():
+            nonlocal called1
+            called1 = True
+
+        def func2():
+            nonlocal called2
+            called2 = True
+
+        gc1 = self.node.create_guard_condition(func1)
+        gc2 = self.node.create_guard_condition(func2)
+
+        self.executor.spin_once(timeout_sec=0)
+        self.assertFalse(called1)
+        self.assertFalse(called2)
+
+        gc1.trigger()
+        gc2.trigger()
+        self.executor.spin_once(timeout_sec=0)
+        self.executor.spin_once(timeout_sec=0)
+        self.assertTrue(called1)
+        self.assertTrue(called2)
+
+        called1 = False
+        called2 = False
+        self.executor.spin_once(timeout_sec=0)
+        self.assertFalse(called1)
+        self.assertFalse(called2)
+
+        self.node.destroy_guard_condition(gc1)
+        self.node.destroy_guard_condition(gc2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a class `GuardCondition` that can be instantiated with `node.create_guard_condition(callback)`. The callback will be executed after `gc.trigger()` is called.

There is no queue of callbacks. If a user triggers a guard condition multiple times the callback will only be called once during the next spin cycle.

Labeled in-progress while CI is running. I'll switch it to in-review when the jobs complete.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3363)](http://ci.ros2.org/job/ci_linux/3363/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=618)](http://ci.ros2.org/job/ci_linux-aarch64/618/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2696)](http://ci.ros2.org/job/ci_osx/2696/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3420)](http://ci.ros2.org/job/ci_windows/3420/)