### PR TITLE
Named logger config + logger hierarchy

### DIFF
--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Provide singleton access to the rclpy C module.
+Provide singleton access to the rclpy C modules.
 
 For example, you might use it like this:
 
@@ -38,3 +38,4 @@ except ImportError as e:
             " Please refer to '%s' for possible solutions" % \
             (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint')
     raise
+rclpy_logging_implementation = importlib.import_module('._rclpy_logging', package='rclpy')

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -31,6 +31,7 @@ import os
 
 try:
     rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
+    rclpy_logging_implementation = importlib.import_module('._rclpy_logging', package='rclpy')
 except ImportError as e:
     if os.path.isfile(e.path):
         e.msg += \
@@ -38,4 +39,3 @@ except ImportError as e:
             " Please refer to '%s' for possible solutions" % \
             (e.path, 'https://github.com/ros2/ros2/wiki/Rclpy-Import-error-hint')
     raise
-rclpy_logging_implementation = importlib.import_module('._rclpy_logging', package='rclpy')

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -221,6 +221,8 @@ class RcutilsLogger:
         self.contexts = {}
 
     def get_child(self, name):
+        if not name or len(name) == 0:
+            raise ValueError('Child logger name should not be empty.')
         return RcutilsLogger(name=self.name + '.' + name)
 
     def get_severity_threshold(self):

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -15,12 +15,11 @@
 
 from collections import namedtuple
 from collections import OrderedDict
-import importlib
 import inspect
 import os
 import time
 
-_rclpy_logging = importlib.import_module('._rclpy_logging', package='rclpy')
+from rclpy.impl.implementation_singleton import rclpy_logging_implementation as _rclpy_logging
 
 # Known filenames from which logging methods can be called (will be ignored in `_find_caller`).
 _internal_callers = []
@@ -223,13 +222,14 @@ class RcutilsLogger:
 
     def get_severity_threshold(self):
         from rclpy.logging import LoggingSeverity
-        severity = LoggingSeverity(_rclpy_logging.rclpy_logging_get_default_severity_threshold())
+        severity = LoggingSeverity(
+            _rclpy_logging.rclpy_logging_get_logger_severity_threshold(self.name))
         return severity
 
     def set_severity_threshold(self, severity):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)
-        return _rclpy_logging.rclpy_logging_set_default_severity_threshold(severity)
+        return _rclpy_logging.rclpy_logging_set_logger_severity_threshold(self.name, severity)
 
     def log(self, message, severity, **kwargs):
         r"""

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -234,6 +234,12 @@ class RcutilsLogger:
         severity = LoggingSeverity(severity)
         return _rclpy_logging.rclpy_logging_set_logger_severity_threshold(self.name, severity)
 
+    def get_effective_severity_threshold(self):
+        from rclpy.logging import LoggingSeverity
+        severity = LoggingSeverity(
+            _rclpy_logging.rclpy_logging_get_logger_effective_severity_threshold(self.name))
+        return severity
+
     def is_enabled_for(self, severity):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -234,7 +234,7 @@ class RcutilsLogger:
     def is_enabled_for(self, severity):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)
-        return _rclpy_logging.rclpy_logging_is_enabled_for(self.name, severity)
+        return _rclpy_logging.rclpy_logging_logger_is_enabled_for(self.name, severity)
 
     def log(self, message, severity, **kwargs):
         r"""

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -223,13 +223,13 @@ class RcutilsLogger:
 
     def get_severity_threshold(self):
         from rclpy.logging import LoggingSeverity
-        severity = LoggingSeverity(_rclpy_logging.rclpy_logging_get_severity_threshold())
+        severity = LoggingSeverity(_rclpy_logging.rclpy_logging_get_default_severity_threshold())
         return severity
 
     def set_severity_threshold(self, severity):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)
-        return _rclpy_logging.rclpy_logging_set_severity_threshold(severity)
+        return _rclpy_logging.rclpy_logging_set_default_severity_threshold(severity)
 
     def log(self, message, severity, **kwargs):
         r"""

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -221,9 +221,12 @@ class RcutilsLogger:
         self.contexts = {}
 
     def get_child(self, name):
-        if not name or len(name) == 0:
-            raise ValueError('Child logger name should not be empty.')
-        return RcutilsLogger(name=self.name + '.' + name)
+        if not name:
+            raise ValueError('Child logger name must not be empty.')
+        if self.name:
+            # Prepend the name of this logger
+            name = self.name + '.' + name
+        return RcutilsLogger(name=name)
 
     def get_severity_threshold(self):
         from rclpy.logging import LoggingSeverity

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -231,6 +231,11 @@ class RcutilsLogger:
         severity = LoggingSeverity(severity)
         return _rclpy_logging.rclpy_logging_set_logger_severity_threshold(self.name, severity)
 
+    def is_enabled_for(self, severity):
+        from rclpy.logging import LoggingSeverity
+        severity = LoggingSeverity(severity)
+        return _rclpy_logging.rclpy_logging_is_enabled_for(self.name, severity)
+
     def log(self, message, severity, **kwargs):
         r"""
         Log a message with the specified severity.
@@ -300,7 +305,7 @@ class RcutilsLogger:
                 return False
 
         # Only log the message if the severity is appropriate.
-        if severity < self.get_severity_threshold():
+        if not self.is_enabled_for(severity):
             return False
 
         # Call the relevant function from the C extension.

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -220,6 +220,9 @@ class RcutilsLogger:
         self.name = name
         self.contexts = {}
 
+    def get_child(self, name):
+        return RcutilsLogger(name=self.name + '.' + name)
+
     def get_severity_threshold(self):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -61,7 +61,7 @@ def set_logger_severity_threshold(name, severity):
 
 
 def get_logger_effective_severity_threshold(name):
-    severity = _rclpy_logging.rclpy_logging_get_logger_effective_threshold(name)
+    severity = _rclpy_logging.rclpy_logging_get_logger_effective_severity_threshold(name)
     return LoggingSeverity(severity)
 
 

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -25,11 +25,11 @@ class LoggingSeverity(IntEnum):
     This enum must match the one defined in rcutils/logging.h
     """
 
-    DEBUG = 0
-    INFO = 1
-    WARN = 2
-    ERROR = 3
-    FATAL = 4
+    DEBUG = 10
+    INFO = 20
+    WARN = 30
+    ERROR = 40
+    FATAL = 50
 
 
 def get_named_logger(name):

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -15,6 +15,7 @@
 
 from enum import IntEnum
 
+from rclpy.impl.implementation_singleton import rclpy_logging_implementation as _rclpy_logging
 import rclpy.impl.rcutils_logger
 
 
@@ -40,12 +41,12 @@ root_logger = get_named_logger('')
 
 
 def get_default_severity_threshold():
-    return LoggingSeverity(root_logger.get_severity_threshold())
+    return _rclpy_logging.rclpy_logging_get_default_severity_threshold()
 
 
 def set_default_severity_threshold(severity):
     severity = LoggingSeverity(severity)
-    return root_logger.set_severity_threshold(severity)
+    return _rclpy_logging.rclpy_logging_set_default_severity_threshold(severity)
 
 
 def logdebug(message, **kwargs):

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -39,11 +39,11 @@ def get_named_logger(name):
 root_logger = get_named_logger('')
 
 
-def get_severity_threshold():
+def get_default_severity_threshold():
     return LoggingSeverity(root_logger.get_severity_threshold())
 
 
-def set_severity_threshold(severity):
+def set_default_severity_threshold(severity):
     severity = LoggingSeverity(severity)
     return root_logger.set_severity_threshold(severity)
 

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -34,11 +34,13 @@ class LoggingSeverity(IntEnum):
     FATAL = 50
 
 
+root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()
+
+
 def get_named_logger(name):
-    return rclpy.impl.rcutils_logger.RcutilsLogger(name)
-
-
-root_logger = get_named_logger('')
+    if not name:
+        raise ValueError('Logger name must not be empty.')
+    return root_logger.get_child(name)
 
 
 def initialize():

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -34,7 +34,11 @@ class LoggingSeverity(IntEnum):
     FATAL = 50
 
 
-root_logger = rclpy.impl.rcutils_logger.RcutilsLogger('ros')
+def get_named_logger(name):
+    return rclpy.impl.rcutils_logger.RcutilsLogger(name)
+
+
+root_logger = get_named_logger('')
 
 
 def initialize():
@@ -49,10 +53,6 @@ def clear_config():
     """Clear the configuration of the logging system, e.g. logger severity thresholds."""
     shutdown()
     initialize()
-
-
-def get_named_logger(name):
-    return root_logger.get_child(name)
 
 
 def get_default_severity_threshold():

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -37,6 +37,20 @@ class LoggingSeverity(IntEnum):
 root_logger = rclpy.impl.rcutils_logger.RcutilsLogger('ros.rclpy')
 
 
+def initialize():
+    return _rclpy_logging.rclpy_logging_initialize()
+
+
+def shutdown():
+    return _rclpy_logging.rclpy_logging_shutdown()
+
+
+def clear_config():
+    """Clear the configuration of the logging system, e.g. logger severity thresholds."""
+    shutdown()
+    initialize()
+
+
 def get_named_logger(name):
     return root_logger.get_child(name)
 

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -57,15 +57,6 @@ def clear_config():
     initialize()
 
 
-def get_default_severity_threshold():
-    return _rclpy_logging.rclpy_logging_get_default_severity_threshold()
-
-
-def set_default_severity_threshold(severity):
-    severity = LoggingSeverity(severity)
-    return _rclpy_logging.rclpy_logging_set_default_severity_threshold(severity)
-
-
 def get_logger_severity_threshold(name):
     severity = _rclpy_logging.rclpy_logging_get_logger_severity_threshold(name)
     return LoggingSeverity(severity)

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -26,6 +26,7 @@ class LoggingSeverity(IntEnum):
     This enum must match the one defined in rcutils/logging.h
     """
 
+    UNSET = 0
     DEBUG = 10
     INFO = 20
     WARN = 30
@@ -47,6 +48,21 @@ def get_default_severity_threshold():
 def set_default_severity_threshold(severity):
     severity = LoggingSeverity(severity)
     return _rclpy_logging.rclpy_logging_set_default_severity_threshold(severity)
+
+
+def get_logger_severity_threshold(name):
+    severity = _rclpy_logging.rclpy_logging_get_logger_severity_threshold(name)
+    return LoggingSeverity(severity)
+
+
+def set_logger_severity_threshold(name, severity):
+    severity = LoggingSeverity(severity)
+    return _rclpy_logging.rclpy_logging_set_logger_severity_threshold(name, severity)
+
+
+def get_logger_effective_severity_threshold(name):
+    severity = _rclpy_logging.rclpy_logging_get_logger_effective_threshold(name)
+    return LoggingSeverity(severity)
 
 
 def logdebug(message, **kwargs):

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -34,7 +34,7 @@ class LoggingSeverity(IntEnum):
     FATAL = 50
 
 
-root_logger = rclpy.impl.rcutils_logger.RcutilsLogger('ros.rclpy')
+root_logger = rclpy.impl.rcutils_logger.RcutilsLogger('ros')
 
 
 def initialize():

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -34,11 +34,11 @@ class LoggingSeverity(IntEnum):
     FATAL = 50
 
 
+root_logger = rclpy.impl.rcutils_logger.RcutilsLogger('ros.rclpy')
+
+
 def get_named_logger(name):
-    return rclpy.impl.rcutils_logger.RcutilsLogger(name)
-
-
-root_logger = get_named_logger('')
+    return root_logger.get_child(name)
 
 
 def get_default_severity_threshold():

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -19,7 +19,7 @@ from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import NoTypeSupportImportedException
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-from rclpy.logging import root_logger
+from rclpy.logging import get_named_logger
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
@@ -50,10 +50,13 @@ def check_for_type_support(msg_type):
 
 class Node:
 
-    def __init__(self, node_name, *, namespace=None, parent_logger=root_logger):
+    def __init__(self, node_name, *, namespace=None, parent_logger=None):
         self.clients = []
         self._handle = None
-        self.logger = parent_logger.get_child(node_name)
+        if parent_logger:
+            self.logger = parent_logger.get_child(node_name)
+        else:
+            self.logger = get_named_logger(node_name)
         self.publishers = []
         self.services = []
         self.subscriptions = []

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -19,7 +19,6 @@ from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import NoTypeSupportImportedException
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-from rclpy.logging import get_named_logger
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
@@ -50,13 +49,9 @@ def check_for_type_support(msg_type):
 
 class Node:
 
-    def __init__(self, node_name, *, namespace=None, parent_logger=None):
+    def __init__(self, node_name, *, namespace=None):
         self.clients = []
         self._handle = None
-        if parent_logger:
-            self.logger = parent_logger.get_child(node_name)
-        else:
-            self.logger = get_named_logger(node_name)
         self.publishers = []
         self.services = []
         self.subscriptions = []

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -19,6 +19,7 @@ from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import NoTypeSupportImportedException
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.logging import root_logger
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
@@ -49,9 +50,10 @@ def check_for_type_support(msg_type):
 
 class Node:
 
-    def __init__(self, node_name, *, namespace=None):
+    def __init__(self, node_name, *, namespace=None, parent_logger=root_logger):
         self.clients = []
         self._handle = None
+        self.logger = parent_logger.get_child(node_name)
         self.publishers = []
         self.services = []
         self.subscriptions = []

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -53,36 +53,6 @@ rclpy_logging_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   Py_RETURN_NONE;
 }
 
-/// Get the default severity threshold of the logging system.
-/**
- * \return severity
- */
-static PyObject *
-rclpy_logging_get_default_severity_threshold(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
-{
-  int severity = rcutils_logging_get_default_severity_threshold();
-
-  return PyLong_FromLong(severity);
-}
-
-/// Set the default severity threshold of the logging system.
-/**
- *
- * \param[in] severity Threshold to set
- * \return None
- */
-static PyObject *
-rclpy_logging_set_default_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  int severity;
-  if (!PyArg_ParseTuple(args, "i", &severity)) {
-    return NULL;
-  }
-
-  rcutils_logging_set_default_severity_threshold(severity);
-  Py_RETURN_NONE;
-}
-
 /// Get the severity threshold of a logger.
 /**
  * \param[in] name Fully-qualified name of logger.
@@ -229,14 +199,6 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_shutdown", rclpy_logging_shutdown, METH_NOARGS,
     "Shutdown the logging system."
-  },
-  {
-    "rclpy_logging_get_default_severity_threshold", rclpy_logging_get_default_severity_threshold,
-    METH_NOARGS, "Get the global severity threshold."
-  },
-  {
-    "rclpy_logging_set_default_severity_threshold", rclpy_logging_set_default_severity_threshold,
-    METH_VARARGS, "Set the global severity threshold."
   },
   {
     "rclpy_logging_get_logger_severity_threshold", rclpy_logging_get_logger_severity_threshold,

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -62,7 +62,7 @@ rclpy_logging_set_default_severity_threshold(PyObject * Py_UNUSED(self), PyObjec
 /// Get the severity threshold of a logger.
 /**
  * \param[in] name Fully-qualified name of logger.
- * \return severity
+ * \return The logger severity threshold if it has been set or UNSET otherwise.
  */
 static PyObject *
 rclpy_logging_get_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
@@ -71,8 +71,9 @@ rclpy_logging_get_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject
   if (!PyArg_ParseTuple(args, "s", &name)) {
     return NULL;
   }
-  int severity = rcutils_logging_get_logger_effective_threshold(name);
+  int severity = rcutils_logging_get_logger_severity_threshold(name);
 
+  // TODO(dhood): error handling
   return PyLong_FromLong(severity);
 }
 
@@ -94,6 +95,25 @@ rclpy_logging_set_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject
 
   rcutils_logging_set_logger_severity_threshold(name, severity);
   Py_RETURN_NONE;
+}
+
+/// Get the effective severity threshold of a logger.
+/**
+ * \param[in] name Fully-qualified name of logger.
+ * \return The effective severity threshold: the logger severity if it has been set, otherwise
+ *   the severity threshold determined by that of the logger's ancestors, otherwise
+ *   the default severity threshold.
+ */
+static PyObject *
+rclpy_logging_get_logger_effective_threshold(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  const char * name;
+  if (!PyArg_ParseTuple(args, "s", &name)) {
+    return NULL;
+  }
+  int severity = rcutils_logging_get_logger_effective_threshold(name);
+
+  return PyLong_FromLong(severity);
 }
 
 /// Determine if the logger is enabled for a severity.
@@ -174,6 +194,10 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_set_logger_severity_threshold", rclpy_logging_set_logger_severity_threshold,
     METH_VARARGS, "Set the severity threshold of a logger."
+  },
+  {
+    "rclpy_logging_get_logger_effective_threshold", rclpy_logging_get_logger_effective_threshold,
+    METH_VARARGS, "Get the effective severity threshold of a logger."
   },
   {
     "rclpy_logging_is_enabled_for", rclpy_logging_is_enabled_for,

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -59,6 +59,43 @@ rclpy_logging_set_default_severity_threshold(PyObject * Py_UNUSED(self), PyObjec
   Py_RETURN_NONE;
 }
 
+/// Get the severity threshold of a logger.
+/**
+ * \param[in] name Fully-qualified name of logger.
+ * \return severity
+ */
+static PyObject *
+rclpy_logging_get_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  const char * name;
+  if (!PyArg_ParseTuple(args, "s", &name)) {
+    return NULL;
+  }
+  int severity = rcutils_logging_get_logger_effective_threshold(name);
+
+  return PyLong_FromLong(severity);
+}
+
+/// Set the severity threshold of a logger.
+/**
+ *
+ * \param[in] name Fully-qualified name of logger.
+ * \param[in] severity Threshold to set
+ * \return None
+ */
+static PyObject *
+rclpy_logging_set_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  const char * name;
+  int severity;
+  if (!PyArg_ParseTuple(args, "si", &name, &severity)) {
+    return NULL;
+  }
+
+  rcutils_logging_set_logger_severity_threshold(name, severity);
+  Py_RETURN_NONE;
+}
+
 /// Log a message through rcutils with the specified severity.
 /**
  *
@@ -104,6 +141,14 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_set_default_severity_threshold", rclpy_logging_set_default_severity_threshold,
     METH_VARARGS, "Set the global severity threshold."
+  },
+  {
+    "rclpy_logging_get_logger_severity_threshold", rclpy_logging_get_logger_severity_threshold,
+    METH_VARARGS, "Get the severity threshold of a logger."
+  },
+  {
+    "rclpy_logging_set_logger_severity_threshold", rclpy_logging_set_logger_severity_threshold,
+    METH_VARARGS, "Set the severity threshold of a logger."
   },
   {
     "rclpy_logging_rcutils_log", rclpy_logging_rcutils_log, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -96,6 +96,31 @@ rclpy_logging_set_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject
   Py_RETURN_NONE;
 }
 
+/// Determine if the logger is enabled for a severity.
+/**
+ *
+ * \param[in] name Fully-qualified name of logger.
+ * \param[in] severity Logging severity to compare against.
+ * \return True if the logger is enabled for the severity.
+ *         False otherwise.
+ */
+static PyObject *
+rclpy_logging_is_enabled_for(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  const char * name;
+  int severity;
+  if (!PyArg_ParseTuple(args, "si", &name, &severity)) {
+    return NULL;
+  }
+
+  bool is_enabled = rcutils_logging_is_enabled_for(name, severity);
+  if (is_enabled) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 /// Log a message through rcutils with the specified severity.
 /**
  *
@@ -149,6 +174,10 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_set_logger_severity_threshold", rclpy_logging_set_logger_severity_threshold,
     METH_VARARGS, "Set the severity threshold of a logger."
+  },
+  {
+    "rclpy_logging_is_enabled_for", rclpy_logging_is_enabled_for,
+    METH_VARARGS, "Determine if a logger is enabled for a severity."
   },
   {
     "rclpy_logging_rcutils_log", rclpy_logging_rcutils_log, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -25,7 +25,20 @@
 static PyObject *
 rclpy_logging_initialize(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
+  // TODO(dhood): error checking
   rcutils_logging_initialize();
+  Py_RETURN_NONE;
+}
+
+/// Shutdown the logging system.
+/**
+ * \return None
+ */
+static PyObject *
+rclpy_logging_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  // TODO(dhood): error checking
+  rcutils_logging_shutdown();
   Py_RETURN_NONE;
 }
 
@@ -178,6 +191,10 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_initialize", rclpy_logging_initialize, METH_NOARGS,
     "Initialize the logging system."
+  },
+  {
+    "rclpy_logging_shutdown", rclpy_logging_shutdown, METH_NOARGS,
+    "Shutdown the logging system."
   },
   {
     "rclpy_logging_get_default_severity_threshold", rclpy_logging_get_default_severity_threshold,

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -34,7 +34,7 @@ rclpy_logging_initialize(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
  * \return severity
  */
 static PyObject *
-rclpy_logging_get_severity_threshold(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+rclpy_logging_get_default_severity_threshold(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   int severity = rcutils_logging_get_default_severity_threshold();
 
@@ -48,7 +48,7 @@ rclpy_logging_get_severity_threshold(PyObject * Py_UNUSED(self), PyObject * Py_U
  * \return None
  */
 static PyObject *
-rclpy_logging_set_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
+rclpy_logging_set_default_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
 {
   int severity;
   if (!PyArg_ParseTuple(args, "i", &severity)) {
@@ -98,12 +98,12 @@ static PyMethodDef rclpy_logging_methods[] = {
     "Initialize the logging system."
   },
   {
-    "rclpy_logging_get_severity_threshold", rclpy_logging_get_severity_threshold, METH_NOARGS,
-    "Get the global severity threshold."
+    "rclpy_logging_get_default_severity_threshold", rclpy_logging_get_default_severity_threshold,
+    METH_NOARGS, "Get the global severity threshold."
   },
   {
-    "rclpy_logging_set_severity_threshold", rclpy_logging_set_severity_threshold, METH_VARARGS,
-    "Set the global severity threshold."
+    "rclpy_logging_set_default_severity_threshold", rclpy_logging_set_default_severity_threshold,
+    METH_VARARGS, "Set the global severity threshold."
   },
   {
     "rclpy_logging_rcutils_log", rclpy_logging_rcutils_log, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -105,13 +105,13 @@ rclpy_logging_set_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject
  *   the default severity threshold.
  */
 static PyObject *
-rclpy_logging_get_logger_effective_threshold(PyObject * Py_UNUSED(self), PyObject * args)
+rclpy_logging_get_logger_effective_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
 {
   const char * name;
   if (!PyArg_ParseTuple(args, "s", &name)) {
     return NULL;
   }
-  int severity = rcutils_logging_get_logger_effective_threshold(name);
+  int severity = rcutils_logging_get_logger_effective_severity_threshold(name);
 
   return PyLong_FromLong(severity);
 }
@@ -125,7 +125,7 @@ rclpy_logging_get_logger_effective_threshold(PyObject * Py_UNUSED(self), PyObjec
  *         False otherwise.
  */
 static PyObject *
-rclpy_logging_is_enabled_for(PyObject * Py_UNUSED(self), PyObject * args)
+rclpy_logging_logger_is_enabled_for(PyObject * Py_UNUSED(self), PyObject * args)
 {
   const char * name;
   int severity;
@@ -133,7 +133,7 @@ rclpy_logging_is_enabled_for(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  bool is_enabled = rcutils_logging_is_enabled_for(name, severity);
+  bool is_enabled = rcutils_logging_logger_is_enabled_for(name, severity);
   if (is_enabled) {
     Py_RETURN_TRUE;
   } else {
@@ -196,11 +196,12 @@ static PyMethodDef rclpy_logging_methods[] = {
     METH_VARARGS, "Set the severity threshold of a logger."
   },
   {
-    "rclpy_logging_get_logger_effective_threshold", rclpy_logging_get_logger_effective_threshold,
+    "rclpy_logging_get_logger_effective_severity_threshold",
+    rclpy_logging_get_logger_effective_severity_threshold,
     METH_VARARGS, "Get the effective severity threshold of a logger."
   },
   {
-    "rclpy_logging_is_enabled_for", rclpy_logging_is_enabled_for,
+    "rclpy_logging_logger_is_enabled_for", rclpy_logging_logger_is_enabled_for,
     METH_VARARGS, "Determine if a logger is enabled for a severity."
   },
   {

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -29,19 +29,19 @@ rclpy_logging_initialize(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   Py_RETURN_NONE;
 }
 
-/// Get the global severity threshold of the logging system.
+/// Get the default severity threshold of the logging system.
 /**
  * \return severity
  */
 static PyObject *
 rclpy_logging_get_severity_threshold(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
-  int severity = rcutils_logging_get_severity_threshold();
+  int severity = rcutils_logging_get_default_severity_threshold();
 
   return PyLong_FromLong(severity);
 }
 
-/// Set the global severity threshold of the logging system.
+/// Set the default severity threshold of the logging system.
 /**
  *
  * \param[in] severity Threshold to set
@@ -55,7 +55,7 @@ rclpy_logging_set_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args
     return NULL;
   }
 
-  rcutils_logging_set_severity_threshold(severity);
+  rcutils_logging_set_default_severity_threshold(severity);
   Py_RETURN_NONE;
 }
 

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -235,6 +235,12 @@ class TestLogging(unittest.TestCase):
         my_logger = rclpy.logging.get_named_logger('my_logger')
         self.assertEqual('my_logger', my_logger.name)
 
+        with self.assertRaisesRegex(ValueError, 'Child logger name should not be empty'):
+            my_logger_child = my_logger.get_child('')
+
+        with self.assertRaisesRegex(ValueError, 'Child logger name should not be empty'):
+            my_logger_child = my_logger.get_child(None)
+
         my_logger_child = my_logger.get_child('child')
         self.assertEqual(my_logger.name + '.child', my_logger_child.name)
 

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -289,7 +289,7 @@ class TestLogging(unittest.TestCase):
         rclpy.logging.clear_config()
         self.assertNotEqual(LoggingSeverity.WARN, my_logger.get_effective_severity_threshold())
         self.assertEqual(
-            rclpy.logging.root_logger.get_severity_threshold(),
+            rclpy.logging.root_logger.get_effective_severity_threshold(),
             my_logger.get_effective_severity_threshold())
 
 

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -231,8 +231,9 @@ class TestLogging(unittest.TestCase):
             self.assertEqual(message_was_logged, [True] + [False] * 4)
 
     def test_named_logger_hierarchy(self):
+        # Check construction of a root logger, not attached to any parents
         my_logger = rclpy.logging.get_named_logger('my_logger')
-        self.assertEqual(rclpy.logging.root_logger.name + '.my_logger', my_logger.name)
+        self.assertEqual('my_logger', my_logger.name)
 
         my_logger_child = my_logger.get_child('child')
         self.assertEqual(my_logger.name + '.child', my_logger_child.name)

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -32,7 +32,7 @@ class TestLogging(unittest.TestCase):
     def test_logger_severity_threshold(self):
         # We should be able to set the threshold of a nonexistent logger / one that doesn't
         # correspond to a python object, e.g. an RMW internal logger.
-        name = 'my_logger_name'
+        name = 'my_internal_logger_name'
         original_severity = rclpy.logging.get_logger_severity_threshold(name)
         for severity in LoggingSeverity:
             rclpy.logging.set_logger_severity_threshold(name, severity)
@@ -47,10 +47,12 @@ class TestLogging(unittest.TestCase):
         rclpy.logging.root_logger.set_severity_threshold(original_severity)
 
     def test_logger_effective_severity_threshold(self):
-        name = 'my_logger_name'
-        original_severity = rclpy.logging.get_logger_severity_threshold(name)
+        name = 'my_nonexistent_logger_name'
+        self.assertEqual(
+            rclpy.logging.get_default_severity_threshold(),
+            rclpy.logging.get_logger_effective_severity_threshold(name))
 
-        # Check that the effective threshold for a logger with unset severity is the default
+        # Check that the effective threshold for a logger with manually unset severity is default
         rclpy.logging.set_logger_severity_threshold(name, LoggingSeverity.UNSET)
         self.assertEqual(
             rclpy.logging.get_default_severity_threshold(),
@@ -60,7 +62,6 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(
             LoggingSeverity.ERROR,
             rclpy.logging.get_logger_effective_severity_threshold(name))
-        rclpy.logging.set_logger_severity_threshold(name, original_severity)
 
     def test_log_threshold(self):
         rclpy.logging.root_logger.set_severity_threshold(LoggingSeverity.INFO)

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -30,11 +30,37 @@ class TestLogging(unittest.TestCase):
         rclpy.logging.set_default_severity_threshold(original_severity)
 
     def test_logger_severity_threshold(self):
+        # We should be able to set the threshold of a nonexistent logger / one that doesn't
+        # correspond to a python object, e.g. an RMW internal logger.
+        name = 'my_logger_name'
+        original_severity = rclpy.logging.get_logger_severity_threshold(name)
+        for severity in LoggingSeverity:
+            rclpy.logging.set_logger_severity_threshold(name, severity)
+            self.assertEqual(severity, rclpy.logging.get_logger_severity_threshold(name))
+        rclpy.logging.set_logger_severity_threshold(name, original_severity)
+
+    def test_logger_object_severity_threshold(self):
         original_severity = rclpy.logging.root_logger.get_severity_threshold()
         for severity in LoggingSeverity:
             rclpy.logging.root_logger.set_severity_threshold(severity)
             self.assertEqual(severity, rclpy.logging.root_logger.get_severity_threshold())
         rclpy.logging.root_logger.set_severity_threshold(original_severity)
+
+    def test_logger_effective_severity_threshold(self):
+        name = 'my_logger_name'
+        original_severity = rclpy.logging.get_logger_severity_threshold(name)
+
+        # Check that the effective threshold for a logger with unset severity is the default
+        rclpy.logging.set_logger_severity_threshold(name, LoggingSeverity.UNSET)
+        self.assertEqual(
+            rclpy.logging.get_default_severity_threshold(),
+            rclpy.logging.get_logger_effective_severity_threshold(name))
+        # Check that the effective threshold for a logger with set severity
+        rclpy.logging.set_logger_severity_threshold(name, LoggingSeverity.ERROR)
+        self.assertEqual(
+            LoggingSeverity.ERROR,
+            rclpy.logging.get_logger_effective_severity_threshold(name))
+        rclpy.logging.set_logger_severity_threshold(name, original_severity)
 
     def test_log_threshold(self):
         rclpy.logging.root_logger.set_severity_threshold(LoggingSeverity.INFO)

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -267,6 +267,16 @@ class TestLogging(unittest.TestCase):
 
         rclpy.logging.set_default_severity_threshold(original_severity)
 
+    def test_clear_config(self):
+        my_logger = rclpy.logging.get_named_logger('my_temp_logger')
+        my_logger.set_severity_threshold(LoggingSeverity.WARN)
+        self.assertEqual(LoggingSeverity.WARN, my_logger.get_effective_severity_threshold())
+        rclpy.logging.clear_config()
+        self.assertNotEqual(LoggingSeverity.WARN, my_logger.get_effective_severity_threshold())
+        self.assertEqual(
+            rclpy.logging.get_default_severity_threshold(),
+            my_logger.get_effective_severity_threshold())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -231,14 +231,21 @@ class TestLogging(unittest.TestCase):
             self.assertEqual(message_was_logged, [True] + [False] * 4)
 
     def test_named_logger_hierarchy(self):
-        # Check construction of a root logger, not attached to any parents
+        # Check that any logger attached to the root logger gets its severity threshold
+        with self.assertRaisesRegex(ValueError, 'Logger name must not be empty'):
+            my_logger = rclpy.logging.get_named_logger('')
+
         my_logger = rclpy.logging.get_named_logger('my_logger')
         self.assertEqual('my_logger', my_logger.name)
 
-        with self.assertRaisesRegex(ValueError, 'Child logger name should not be empty'):
+        self.assertEqual(
+            rclpy.logging.get_default_severity_threshold(),
+            my_logger.get_effective_severity_threshold())
+
+        with self.assertRaisesRegex(ValueError, 'Child logger name must not be empty'):
             my_logger_child = my_logger.get_child('')
 
-        with self.assertRaisesRegex(ValueError, 'Child logger name should not be empty'):
+        with self.assertRaisesRegex(ValueError, 'Child logger name must not be empty'):
             my_logger_child = my_logger.get_child(None)
 
         my_logger_child = my_logger.get_child('child')

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -22,15 +22,15 @@ from rclpy.logging import LoggingSeverity
 
 class TestLogging(unittest.TestCase):
 
-    def test_severity_threshold(self):
-        original_severity = rclpy.logging.get_severity_threshold()
+    def test_default_severity_threshold(self):
+        original_severity = rclpy.logging.get_default_severity_threshold()
         for severity in LoggingSeverity:
-            rclpy.logging.set_severity_threshold(severity)
-            self.assertEqual(severity, rclpy.logging.get_severity_threshold())
-        rclpy.logging.set_severity_threshold(original_severity)
+            rclpy.logging.set_default_severity_threshold(severity)
+            self.assertEqual(severity, rclpy.logging.get_default_severity_threshold())
+        rclpy.logging.set_default_severity_threshold(original_severity)
 
     def test_log_threshold(self):
-        rclpy.logging.set_severity_threshold(LoggingSeverity.INFO)
+        rclpy.logging.set_default_severity_threshold(LoggingSeverity.INFO)
 
         # Logging below threshold not expected to be logged
         self.assertFalse(rclpy.logging.logdebug('message_debug'))
@@ -167,7 +167,7 @@ class TestLogging(unittest.TestCase):
     def test_named_logger(self):
         my_logger = rclpy.logging.get_named_logger('my_logger')
 
-        rclpy.logging.set_severity_threshold(LoggingSeverity.INFO)
+        rclpy.logging.set_default_severity_threshold(LoggingSeverity.INFO)
         # Test convenience functions
 
         # Logging below threshold not expected to be logged

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -29,8 +29,15 @@ class TestLogging(unittest.TestCase):
             self.assertEqual(severity, rclpy.logging.get_default_severity_threshold())
         rclpy.logging.set_default_severity_threshold(original_severity)
 
+    def test_logger_severity_threshold(self):
+        original_severity = rclpy.logging.root_logger.get_severity_threshold()
+        for severity in LoggingSeverity:
+            rclpy.logging.root_logger.set_severity_threshold(severity)
+            self.assertEqual(severity, rclpy.logging.root_logger.get_severity_threshold())
+        rclpy.logging.root_logger.set_severity_threshold(original_severity)
+
     def test_log_threshold(self):
-        rclpy.logging.set_default_severity_threshold(LoggingSeverity.INFO)
+        rclpy.logging.root_logger.set_severity_threshold(LoggingSeverity.INFO)
 
         # Logging below threshold not expected to be logged
         self.assertFalse(rclpy.logging.logdebug('message_debug'))
@@ -167,7 +174,7 @@ class TestLogging(unittest.TestCase):
     def test_named_logger(self):
         my_logger = rclpy.logging.get_named_logger('my_logger')
 
-        rclpy.logging.set_default_severity_threshold(LoggingSeverity.INFO)
+        my_logger.set_severity_threshold(LoggingSeverity.INFO)
         # Test convenience functions
 
         # Logging below threshold not expected to be logged


### PR DESCRIPTION
connects to ros2/rcutils#57

currently including commits from https://github.com/ros2/rclpy/pull/130; if this PR is ready before https://github.com/ros2/rcutils/pull/57 gets merged then it can replace #130.

This PR exposes the new notions from https://github.com/ros2/rcutils/pull/57:
1. ~there's a default severity threshold,~
1. each logger can have its own severity threshold specified,
1. there's a hierarchy of loggers: I've added a get_child() method on loggers; children inherit the severity threshold of their parent if set (the severity threshold inheritance taken care of by rcutils now that it has a notion of logger hierarchy)
1. all loggers at some point are attached to the root rclpy logger (which is where they get their default severity threshold)

Out of scope:
1. node.get_logger() or any notion of attaching loggers to nodes (waiting on decision in https://github.com/ros2/examples/pull/186)
1. any caching of whether or not loggers are enabled and updating based on notifications when severity levels change