### PR TITLE
protect against ImportError.path being None

### DIFF
--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -32,7 +32,7 @@ import os
 try:
     rclpy_implementation = importlib.import_module('._rclpy', package='rclpy')
 except ImportError as e:
-    if os.path.isfile(e.path):
+    if e.path is not None and os.path.isfile(e.path):
         e.msg += \
             "\nThe C extension '%s' failed to be imported while being present on the system." \
             " Please refer to '%s' for possible solutions" % \


### PR DESCRIPTION
Error looks something like:

```
  File "C:\path\to\ws\install\Lib\site-packages\rclpy\impl\implementation_singleton.py", line 35, in <module>
    if os.path.isfile(e.path):
  File "C:\Python36\lib\genericpath.py", line 30, in isfile
    st = os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```