### PR TITLE
Check for the client error code, not server

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2186,7 +2186,7 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
   rcl_ret_t ret = rcl_take_response(client, header, taken_response);
   PyMem_Free(header);
 
-  if (ret != RCL_RET_SERVICE_TAKE_FAILED) {
+  if (ret != RCL_RET_CLIENT_TAKE_FAILED) {
     PyObject * pyconvert_to_py = PyObject_GetAttrString(pyresponse_type, "_CONVERT_TO_PY");
 
     typedef PyObject *(* convert_to_py_signature)(void *);


### PR DESCRIPTION
Equivalent of https://github.com/ros2/rclcpp/pull/373

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3514)](http://ci.ros2.org/job/ci_linux/3514/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=737)](http://ci.ros2.org/job/ci_linux-aarch64/737/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2845)](http://ci.ros2.org/job/ci_osx/2845/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3573)](http://ci.ros2.org/job/ci_windows/3573/)