### PR TITLE
 Relax the tolerance on throttle timing

### DIFF
--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -104,8 +104,8 @@ class TestLogging(unittest.TestCase):
                 throttle_duration_sec=1,
                 throttle_time_source_type='RCUTILS_STEADY_TIME',
             ))
-            time.sleep(0.3)
-        self.assertEqual(message_was_logged, [True] + [False] * 3 + [True])
+            time.sleep(0.4)
+        self.assertEqual(message_was_logged, [True, False, False, True, False])
 
     def test_log_skip_first(self):
         message_was_logged = []


### PR DESCRIPTION
Too strict on ARM debug repeated: http://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/267/

Repeating rclpy tests (manually excluding the flaky `test_timer.py`) 50 times on ARM debug: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=736)](http://ci.ros2.org/job/ci_linux-aarch64/736/)