### PR TITLE
Relax the tolerance on throttle + skipfirst timing

### DIFF
--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -105,7 +105,6 @@ class TestLogging(unittest.TestCase):
                 throttle_time_source_type='RCUTILS_STEADY_TIME',
             ))
             time.sleep(0.4)
-        self.assertEqual(message_was_logged, [True, False, False, True, False])
         self.assertEqual(
             message_was_logged, [
                 True,  # t=0, not throttled

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -106,6 +106,14 @@ class TestLogging(unittest.TestCase):
             ))
             time.sleep(0.4)
         self.assertEqual(message_was_logged, [True, False, False, True, False])
+        self.assertEqual(
+            message_was_logged, [
+                True,  # t=0, not throttled
+                False,  # t=0.4, throttled
+                False,  # t=0.8, throttled
+                True,  # t=1.2, not throttled
+                False  # t=1.6, throttled
+            ])
 
     def test_log_skip_first(self):
         message_was_logged = []
@@ -129,8 +137,15 @@ class TestLogging(unittest.TestCase):
                 throttle_duration_sec=1,
                 throttle_time_source_type='RCUTILS_STEADY_TIME',
             ))
-            time.sleep(0.3)
-        self.assertEqual(message_was_logged, [False] * 4 + [True])
+            time.sleep(0.4)
+        self.assertEqual(
+            message_was_logged, [
+                False,  # t=0, not throttled, but skipped because first
+                False,  # t=0.4, throttled
+                False,  # t=0.8, throttled
+                True,  # t=1.2, not throttled
+                False  # t=1.6, throttled
+            ])
 
     def test_log_skip_first_once(self):
         # Because of the ordering of supported_filters, first the skip_first condition will be


### PR DESCRIPTION
Timing was too strict on ARM: http://ci.ros2.org/job/ci_linux-aarch64/740/testReport/junit/rclpy.src.ros2.rclpy.rclpy.test.test_logging/TestLogging/test_log_skip_first_throttle/

followup of https://github.com/ros2/rclpy/pull/144

also added comments to explain the expected output of the throttle tests

CI ARM (not repeated): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=743)](http://ci.ros2.org/job/ci_linux-aarch64/743/)