### PR TITLE
Give nodes a logger

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -16,7 +16,6 @@ import sys
 
 from rclpy.executors import SingleThreadedExecutor as _SingleThreadedExecutor
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-import rclpy.logging  # noqa
 from rclpy.node import Node
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
 from rclpy.utilities import ok

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -16,6 +16,7 @@ import sys
 
 from rclpy.executors import SingleThreadedExecutor as _SingleThreadedExecutor
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+import rclpy.logging  # noqa
 from rclpy.node import Node
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
 from rclpy.utilities import ok

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -20,6 +20,7 @@ from rclpy.exceptions import NoTypeSupportImportedException
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.logging import get_named_logger
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
@@ -52,6 +53,8 @@ class Node:
 
     def __init__(self, node_name, *, namespace=None):
         self._handle = None
+        # TODO(dhood): get logger name from rcl, use namespace (with slashes converted)
+        self._logger = get_named_logger(node_name)
         self.publishers = []
         self.subscriptions = []
         self.clients = []
@@ -90,6 +93,9 @@ class Node:
 
     def get_namespace(self):
         return _rclpy.rclpy_get_node_namespace(self.handle)
+
+    def get_logger(self):
+        return self._logger
 
     def _validate_topic_or_service_name(self, topic_or_service_name, *, is_service=False):
         name = self.get_name()

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -89,6 +89,12 @@ class TestNode(unittest.TestCase):
         # test that it doesn't raise
         self.node.get_node_names()
 
+    def test_node_logger(self):
+        node_logger = self.node.get_logger()
+        self.assertEqual(node_logger.name, 'my_node')
+        node_logger.set_severity_threshold(rclpy.logging.LoggingSeverity.INFO)
+        node_logger.debug('test')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_validate_node_name.py
+++ b/rclpy/test/test_validate_node_name.py
@@ -32,6 +32,9 @@ class TestValidateNodeName(unittest.TestCase):
         # node name must not be empty
         with self.assertRaisesRegex(InvalidNodeNameException, 'must not be empty'):
             validate_node_name('')
+        # node name may not contain '.'
+        with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
+            validate_node_name('invalid_node.')
         # node name may not contain '?'
         with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
             validate_node_name('invalid_node?')


### PR DESCRIPTION
Minimum required to switch demos to using node loggers: logger names are not using namespaces at the moment nor calling to rcl to get their logger name.