### PR TITLE
reenable 100Hz timer test on windows

### DIFF
--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -144,14 +144,12 @@ def test_timer_zero_callbacks10hertz():
     func_launch(func_zero_callback, ['0.1'], 'received callbacks when not expected')
 
 
-# TODO(mikaelarguedas) reenable these once timer have consistent behaviour
-# on every platform at high frequency
 def test_timer_zero_callbacks100hertz():
-    if os.name == 'nt':
-        raise SkipTest
     func_launch(func_zero_callback, ['0.01'], 'received callbacks when not expected')
 
 
+# TODO(mikaelarguedas) reenable these once timer have consistent behaviour
+# on every platform at high frequency
 def test_timer_zero_callbacks1000hertz():
     if os.name == 'nt':
         raise SkipTest
@@ -163,8 +161,6 @@ def test_timer_number_callbacks10hertz():
 
 
 def test_timer_number_callbacks100hertz():
-    if os.name == 'nt':
-        raise SkipTest
     func_launch(
         func_number_callbacks, ['0.01'], "didn't receive the expected number of callbacks")
 
@@ -182,8 +178,6 @@ def test_timer_cancel_reset_10hertz():
 
 
 def test_timer_cancel_reset_100hertz():
-    if os.name == 'nt':
-        raise SkipTest
     func_launch(
         func_cancel_reset_timer, ['0.01'], "didn't receive the expected number of callbacks")
 


### PR DESCRIPTION
now that we have better time resolution on windows these tests can be restored.

Unfortunately the 1kHz timer tests still fail and have to stay disabled.

* Windows (rclpy tests ranusing --retest-until-fail 50) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3653)](http://ci.ros2.org/job/ci_windows/3653/)
