### PR TITLE
Avoid unexpected free to null

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -498,7 +498,7 @@ rclpy_get_validation_error_for_node_name(PyObject * Py_UNUSED(self), PyObject * 
 static char *
 _expand_topic_name_with_exceptions(const char * topic, const char * node, const char * namespace)
 {
-  char * expanded_topic;
+  char * expanded_topic = NULL;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcutils_allocator_t rcutils_allocator = rcutils_get_default_allocator();
   rcutils_string_map_t substitutions_map = rcutils_get_zero_initialized_string_map();
@@ -546,7 +546,9 @@ _expand_topic_name_with_exceptions(const char * topic, const char * node, const 
   if (rcutils_ret != RCUTILS_RET_OK) {
     PyErr_Format(PyExc_RuntimeError, "%s", rcutils_get_error_string_safe());
     rcutils_reset_error();
-    allocator.deallocate(expanded_topic, allocator.state);
+    if (expanded_topic) {
+      allocator.deallocate(expanded_topic, allocator.state);
+    }
     return NULL;
   }
   if (ret != RCL_RET_OK) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -546,9 +546,7 @@ _expand_topic_name_with_exceptions(const char * topic, const char * node, const 
   if (rcutils_ret != RCUTILS_RET_OK) {
     PyErr_Format(PyExc_RuntimeError, "%s", rcutils_get_error_string_safe());
     rcutils_reset_error();
-    if (expanded_topic) {
-      allocator.deallocate(expanded_topic, allocator.state);
-    }
+    allocator.deallocate(expanded_topic, allocator.state);
     return NULL;
   }
   if (ret != RCL_RET_OK) {


### PR DESCRIPTION
the `expanded_topic` is possible to be `NULL` from
`rcl_expand_topic_name()` and then the free is problematic

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>