### PR TITLE
Reuse ready callbacks generator

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -422,6 +422,7 @@ class Executor:
             self._last_args = args
             self._last_kwargs = kwargs
             self._cb_iter = self._wait_for_ready_callbacks(*args, **kwargs)
+
         try:
             return next(self._cb_iter)
         except StopIteration:


### PR DESCRIPTION
This adds a wrapper around `wait_for_ready_callbacks` that reuses the callback generator when multiple things are ready. It avoids unnecessary wait list construction and waiting. It also prevents one callback (like a very fast timer) from starving other callbacks (similar to ros2/rclcpp#392).

Taken from #140 and improved upon. 

CI (New run after fixing a merge conflict)

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3635)](http://ci.ros2.org/job/ci_linux/3635/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=816)](http://ci.ros2.org/job/ci_linux-aarch64/816/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2969)](http://ci.ros2.org/job/ci_osx/2969/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3729)](http://ci.ros2.org/job/ci_windows/3729/)