### PR TITLE
Added timeout_sec_to_nsec utility

### DIFF
--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -14,6 +14,9 @@
 
 import threading
 
+from rclpy.constants import S_TO_NS
+
+
 g_shutdown_lock = threading.Lock()
 
 
@@ -44,3 +47,23 @@ def get_rmw_implementation_identifier():
     # imported locally to avoid loading extensions on module import
     from rclpy.impl.implementation_singleton import rclpy_implementation
     return rclpy_implementation.rclpy_get_rmw_implementation_identifier()
+
+
+def timeout_sec_to_nsec(timeout_sec):
+    """
+    Convert timeout in seconds to rcl compatible timeout in nanoseconds.
+
+    Python tends to use floating point numbers in seconds for timeouts. This utility converts a
+    python-style timeout to an integer in nanoseconds that can be used by rcl_wait.
+
+    :param timeout_sec: Seconds to wait. Block forever if None or negative. Don't wait if < 1ns
+    :type timeout_sec: float or None
+    :rtype: int
+    :returns: rcl_wait compatible timeout in nanoseconds
+    """
+    if timeout_sec is None or timeout_sec < 0:
+        # Block forever
+        return -1
+    else:
+        # wait for given time
+        return int(float(timeout_sec) * S_TO_NS)

--- a/rclpy/test/test_utilities.py
+++ b/rclpy/test/test_utilities.py
@@ -24,6 +24,7 @@ class TestUtilities(unittest.TestCase):
         self.assertGreater(0, rclpy.utilities.timeout_sec_to_nsec(None))
         self.assertGreater(0, rclpy.utilities.timeout_sec_to_nsec(-1))
         self.assertEqual(0, rclpy.utilities.timeout_sec_to_nsec(0))
+        self.assertEqual(0, rclpy.utilities.timeout_sec_to_nsec(0.5 / S_TO_NS))
         self.assertEqual(int(1.5 * S_TO_NS), rclpy.utilities.timeout_sec_to_nsec(1.5))
 
 

--- a/rclpy/test/test_utilities.py
+++ b/rclpy/test/test_utilities.py
@@ -1,0 +1,31 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.constants import S_TO_NS
+import rclpy.utilities
+
+
+class TestUtilities(unittest.TestCase):
+
+    def test_timeout_sec_to_nsec(self):
+        self.assertGreater(0, rclpy.utilities.timeout_sec_to_nsec(None))
+        self.assertGreater(0, rclpy.utilities.timeout_sec_to_nsec(-1))
+        self.assertEqual(0, rclpy.utilities.timeout_sec_to_nsec(0))
+        self.assertEqual(int(1.5 * S_TO_NS), rclpy.utilities.timeout_sec_to_nsec(1.5))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Taken from #140 / #127. It adds a utility for converting timeouts from seconds to nanoseconds for rcl_wait. Additionally executor timeouts now block if None or negative and are only non-blocking if the timeout is zero.

CI

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3632)](http://ci.ros2.org/job/ci_linux/3632/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=814)](http://ci.ros2.org/job/ci_linux-aarch64/814/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2963)](http://ci.ros2.org/job/ci_osx/2963/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3726)](http://ci.ros2.org/job/ci_windows/3726/)