### PR TITLE
Add client.service_is_ready

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import threading
+import time
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 import rclpy.utilities
@@ -70,6 +71,23 @@ class Client:
     def call(self, req):
         self.response = None
         self.sequence_number = _rclpy.rclpy_send_request(self.client_handle, req)
+
+    def service_is_ready(self):
+        return _rclpy.rclpy_service_server_is_available(self.node_handle, self.client_handle)
+
+    def wait_for_service(self, timeout_sec=None):
+        # TODO(sloretz) Return as soon as the service is available
+        # This is a temporary implementation. The sleep time is arbitrary.
+        sleep_time = 0.25
+        while (
+            rclpy.utilities.ok() and not self.service_is_ready() and
+            (timeout_sec is None or timeout_sec > 0.0)
+        ):
+            time.sleep(sleep_time)
+            if timeout_sec is not None:
+                timeout_sec -= sleep_time
+
+        return self.service_is_ready()
 
     # TODO(mikaelarguedas) this function can only be used if nobody is spinning
     # need to be updated once guard_conditions are supported

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -79,13 +79,11 @@ class Client:
         # TODO(sloretz) Return as soon as the service is available
         # This is a temporary implementation. The sleep time is arbitrary.
         sleep_time = 0.25
-        while (
-            rclpy.utilities.ok() and not self.service_is_ready() and
-            (timeout_sec is None or timeout_sec > 0.0)
-        ):
+        if timeout_sec is None:
+            timeout_sec = float('inf')
+        while rclpy.utilities.ok() and not self.service_is_ready() and timeout_sec > 0.0:
             time.sleep(sleep_time)
-            if timeout_sec is not None:
-                timeout_sec -= sleep_time
+            timeout_sec -= sleep_time
 
         return self.service_is_ready()
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1519,6 +1519,49 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_NONE;
 }
 
+/// Check if a service server is available
+/**
+ * Raises ValueError if the arguments are not capsules
+ *
+ * \param[in] pynode Capsule pointing to the node the entity belongs to
+ * \param[in] pyclient Capsule pointing to the client
+ * \return True if the service server is available
+ */
+static PyObject *
+rclpy_service_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pynode;
+  PyObject * pyclient;
+
+  if (!PyArg_ParseTuple(args, "OO", &pynode, &pyclient)) {
+    return NULL;
+  }
+
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, "rcl_node_t");
+  if (!node) {
+    return NULL;
+  }
+  rcl_client_t * client = (rcl_client_t *)PyCapsule_GetPointer(pyclient, "rcl_client_t");
+  if (!client) {
+    return NULL;
+  }
+
+  bool is_ready;
+  rcl_ret_t ret = rcl_service_server_is_available(node, client, &is_ready);
+
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to check service availability: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+    return NULL;
+  }
+
+  if (is_ready) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+}
+
 /// Destroy an entity attached to a node
 /**
  * Entity type must be one of ["subscription", "publisher", "client", "service"].
@@ -2635,6 +2678,11 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_send_response", rclpy_send_response, METH_VARARGS,
     "Send a response."
+  },
+
+  {
+    "rclpy_service_server_is_available", rclpy_service_server_is_available, METH_VARARGS,
+    "Return true if the service server is available."
   },
 
   {

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -1,0 +1,62 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+
+from rcl_interfaces.srv import GetParameters
+import rclpy
+
+
+# TODO(sloretz) Reduce fudge once wait_for_service uses node graph events
+TIME_FUDGE = 0.3
+
+
+class TestClient(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('TestClient')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_wait_for_service_5sec(self):
+        cli = self.node.create_client(GetParameters, 'get/parameters')
+        try:
+            start = time.monotonic()
+            cli.wait_for_service(timeout_sec=5.0)
+            end = time.monotonic()
+            self.assertGreater(5.0, end - start - TIME_FUDGE)
+            self.assertLess(5.0, end - start + TIME_FUDGE)
+        finally:
+            self.node.destroy_client(cli)
+
+    def test_wait_for_service_nowait(self):
+        cli = self.node.create_client(GetParameters, 'get/parameters')
+        try:
+            start = time.monotonic()
+            cli.wait_for_service(timeout_sec=0)
+            end = time.monotonic()
+            self.assertGreater(0, end - start - TIME_FUDGE)
+            self.assertLess(0, end - start + TIME_FUDGE)
+        finally:
+            self.node.destroy_client(cli)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -57,6 +57,19 @@ class TestClient(unittest.TestCase):
         finally:
             self.node.destroy_client(cli)
 
+    def test_wait_for_service_exists(self):
+        cli = self.node.create_client(GetParameters, 'test_wfs_exists')
+        srv = self.node.create_service(GetParameters, 'test_wfs_exists', lambda request: None)
+        try:
+            start = time.monotonic()
+            self.assertTrue(cli.wait_for_service(timeout_sec=1.0))
+            end = time.monotonic()
+            self.assertGreater(0, end - start - TIME_FUDGE)
+            self.assertLess(0, end - start + TIME_FUDGE)
+        finally:
+            self.node.destroy_client(cli)
+            self.node.destroy_service(srv)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -39,7 +39,7 @@ class TestClient(unittest.TestCase):
         cli = self.node.create_client(GetParameters, 'get/parameters')
         try:
             start = time.monotonic()
-            cli.wait_for_service(timeout_sec=5.0)
+            self.assertFalse(cli.wait_for_service(timeout_sec=5.0))
             end = time.monotonic()
             self.assertGreater(5.0, end - start - TIME_FUDGE)
             self.assertLess(5.0, end - start + TIME_FUDGE)
@@ -50,7 +50,7 @@ class TestClient(unittest.TestCase):
         cli = self.node.create_client(GetParameters, 'get/parameters')
         try:
             start = time.monotonic()
-            cli.wait_for_service(timeout_sec=0)
+            self.assertFalse(cli.wait_for_service(timeout_sec=0))
             end = time.monotonic()
             self.assertGreater(0, end - start - TIME_FUDGE)
             self.assertLess(0, end - start + TIME_FUDGE)


### PR DESCRIPTION
This adds a method `service_is_ready` to the client, [same as rclcpp](https://github.com/ros2/rclcpp/blob/c70f2f145239ca4dfe86c6d806f331602a0e5c68/rclcpp/include/rclcpp/client.hpp#L81). 

It also adds a temporary implementation of `wait_for_service`. It is not an acceptable implementation long term. Including it allows merging ros2/demos#182, ros2/examples#185, and ros2/system_tests#244.

CI (4th run with 111a4cb6da8b682448950abf5e858205412cb7b6 )
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3638)](http://ci.ros2.org/job/ci_linux/3638/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=819)](http://ci.ros2.org/job/ci_linux-aarch64/819/) (Flaky 1kHz python timer tests failed).
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2971)](http://ci.ros2.org/job/ci_osx/2971/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3732)](http://ci.ros2.org/job/ci_windows/3732/)