### PR TITLE
Clear rcutils error on failure

### DIFF
--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -16,7 +16,6 @@
 
 #include <rcutils/error_handling.h>
 #include <rcutils/logging.h>
-#include <rcutils/logging_macros.h>
 #include <rcutils/time.h>
 
 /// Initialize the logging system.

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -14,6 +14,7 @@
 
 #include <Python.h>
 
+#include <rcutils/error_handling.h>
 #include <rcutils/logging.h>
 #include <rcutils/logging_macros.h>
 #include <rcutils/time.h>
@@ -30,6 +31,7 @@ rclpy_logging_initialize(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   if (ret != RCUTILS_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to initialize logging system, return code: %d\n", ret);
+    rcutils_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -48,6 +50,7 @@ rclpy_logging_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   if (ret != RCUTILS_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
       "Failed to shutdown logging system, return code: %d\n", ret);
+    rcutils_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -73,6 +76,7 @@ rclpy_logging_get_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject
     PyErr_Format(PyExc_RuntimeError,
       "Failed to get severity threshold for logger \"%s\", return code: %d\n",
       name, severity);
+    rcutils_reset_error();
     return NULL;
   }
   return PyLong_FromLong(severity);
@@ -100,6 +104,7 @@ rclpy_logging_set_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject
     PyErr_Format(PyExc_RuntimeError,
       "Failed to set severity threshold \"%d\" for logger \"%s\", return code: %d\n",
       severity, name, ret);
+    rcutils_reset_error();
     return NULL;
   }
   Py_RETURN_NONE;
@@ -128,6 +133,7 @@ rclpy_logging_get_logger_effective_severity_threshold(PyObject * Py_UNUSED(self)
     PyErr_Format(PyExc_RuntimeError,
       "Failed to get effective severity threshold for logger \"%s\", return code: %d\n",
       name, severity);
+    rcutils_reset_error();
     return NULL;
   }
   return PyLong_FromLong(severity);


### PR DESCRIPTION
rcutils logging sets error messages on failure as of ros2/rcutils#65

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3652)](http://ci.ros2.org/job/ci_linux/3652/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=832)](http://ci.ros2.org/job/ci_linux-aarch64/832/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2989)](http://ci.ros2.org/job/ci_osx/2989/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3754)](http://ci.ros2.org/job/ci_windows/3754/)