### PR TITLE
Remove root logger usage (rclpy.loginfo) and get_severity_threshold()

### DIFF
--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -228,12 +228,6 @@ class RcutilsLogger:
             name = self.name + '.' + name
         return RcutilsLogger(name=name)
 
-    def get_severity_threshold(self):
-        from rclpy.logging import LoggingSeverity
-        severity = LoggingSeverity(
-            _rclpy_logging.rclpy_logging_get_logger_severity_threshold(self.name))
-        return severity
-
     def set_severity_threshold(self, severity):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -34,13 +34,13 @@ class LoggingSeverity(IntEnum):
     FATAL = 50
 
 
-root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()
+_root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()
 
 
 def get_named_logger(name):
     if not name:
         raise ValueError('Logger name must not be empty.')
-    return root_logger.get_child(name)
+    return _root_logger.get_child(name)
 
 
 def initialize():
@@ -74,30 +74,30 @@ def get_logger_effective_severity_threshold(name):
 
 def logdebug(message, **kwargs):
     """Log a message with `DEBUG` severity via :py:classmethod:RcutilsLogger.log:."""
-    return root_logger.log(message, severity=LoggingSeverity.DEBUG, **kwargs)
+    return _root_logger.log(message, severity=LoggingSeverity.DEBUG, **kwargs)
 
 
 def loginfo(message, **kwargs):
     """Log a message with `INFO` severity via :py:classmethod:RcutilsLogger.log:."""
-    return root_logger.log(message, severity=LoggingSeverity.INFO, **kwargs)
+    return _root_logger.log(message, severity=LoggingSeverity.INFO, **kwargs)
 
 
 def logwarn(message, **kwargs):
     """Log a message with `WARN` severity via :py:classmethod:RcutilsLogger.log:."""
-    return root_logger.log(message, severity=LoggingSeverity.WARN, **kwargs)
+    return _root_logger.log(message, severity=LoggingSeverity.WARN, **kwargs)
 
 
 def logerr(message, **kwargs):
     """Log a message with `ERROR` severity via :py:classmethod:RcutilsLogger.log:."""
-    return root_logger.log(message, severity=LoggingSeverity.ERROR, **kwargs)
+    return _root_logger.log(message, severity=LoggingSeverity.ERROR, **kwargs)
 
 
 def logfatal(message, **kwargs):
     """Log a message with `FATAL` severity via :py:classmethod:RcutilsLogger.log:."""
-    return root_logger.log(message, severity=LoggingSeverity.FATAL, **kwargs)
+    return _root_logger.log(message, severity=LoggingSeverity.FATAL, **kwargs)
 
 
 def log(message, severity, **kwargs):
     """Log a message with the specified severity via :py:classmethod:RcutilsLogger.log:."""
     severity = LoggingSeverity(severity)
-    return root_logger.log(message, severity, **kwargs)
+    return _root_logger.log(message, severity, **kwargs)

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -57,11 +57,6 @@ def clear_config():
     initialize()
 
 
-def get_logger_severity_threshold(name):
-    severity = _rclpy_logging.rclpy_logging_get_logger_severity_threshold(name)
-    return LoggingSeverity(severity)
-
-
 def set_logger_severity_threshold(name, severity):
     severity = LoggingSeverity(severity)
     return _rclpy_logging.rclpy_logging_set_logger_severity_threshold(name, severity)

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -37,7 +37,7 @@ class LoggingSeverity(IntEnum):
 _root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()
 
 
-def get_named_logger(name):
+def get_logger(name):
     if not name:
         raise ValueError('Logger name must not be empty.')
     return _root_logger.get_child(name)

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -70,34 +70,3 @@ def set_logger_severity_threshold(name, severity):
 def get_logger_effective_severity_threshold(name):
     severity = _rclpy_logging.rclpy_logging_get_logger_effective_severity_threshold(name)
     return LoggingSeverity(severity)
-
-
-def logdebug(message, **kwargs):
-    """Log a message with `DEBUG` severity via :py:classmethod:RcutilsLogger.log:."""
-    return _root_logger.log(message, severity=LoggingSeverity.DEBUG, **kwargs)
-
-
-def loginfo(message, **kwargs):
-    """Log a message with `INFO` severity via :py:classmethod:RcutilsLogger.log:."""
-    return _root_logger.log(message, severity=LoggingSeverity.INFO, **kwargs)
-
-
-def logwarn(message, **kwargs):
-    """Log a message with `WARN` severity via :py:classmethod:RcutilsLogger.log:."""
-    return _root_logger.log(message, severity=LoggingSeverity.WARN, **kwargs)
-
-
-def logerr(message, **kwargs):
-    """Log a message with `ERROR` severity via :py:classmethod:RcutilsLogger.log:."""
-    return _root_logger.log(message, severity=LoggingSeverity.ERROR, **kwargs)
-
-
-def logfatal(message, **kwargs):
-    """Log a message with `FATAL` severity via :py:classmethod:RcutilsLogger.log:."""
-    return _root_logger.log(message, severity=LoggingSeverity.FATAL, **kwargs)
-
-
-def log(message, severity, **kwargs):
-    """Log a message with the specified severity via :py:classmethod:RcutilsLogger.log:."""
-    severity = LoggingSeverity(severity)
-    return _root_logger.log(message, severity, **kwargs)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -20,7 +20,7 @@ from rclpy.exceptions import NoTypeSupportImportedException
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-from rclpy.logging import get_named_logger
+from rclpy.logging import get_logger
 from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
@@ -54,7 +54,7 @@ class Node:
     def __init__(self, node_name, *, namespace=None):
         self._handle = None
         # TODO(dhood): get logger name from rcl, use namespace (with slashes converted)
-        self._logger = get_named_logger(node_name)
+        self._logger = get_logger(node_name)
         self.publishers = []
         self.subscriptions = []
         self.clients = []

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -55,32 +55,6 @@ rclpy_logging_shutdown(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   Py_RETURN_NONE;
 }
 
-/// Get the severity threshold of a logger.
-/**
- * \param[in] name Fully-qualified name of logger.
- * \return The logger severity threshold if it has been set, or
- * \return `RCUTILS_LOG_SEVERITY_UNSET` if it is unset, or
- * \return NULL on failure
- */
-static PyObject *
-rclpy_logging_get_logger_severity_threshold(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  const char * name;
-  if (!PyArg_ParseTuple(args, "s", &name)) {
-    return NULL;
-  }
-  int severity = rcutils_logging_get_logger_severity_threshold(name);
-
-  if (severity < 0) {
-    PyErr_Format(PyExc_RuntimeError,
-      "Failed to get severity threshold for logger \"%s\", return code: %d\n",
-      name, severity);
-    rcutils_reset_error();
-    return NULL;
-  }
-  return PyLong_FromLong(severity);
-}
-
 /// Set the severity threshold of a logger.
 /**
  *
@@ -204,10 +178,6 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_shutdown", rclpy_logging_shutdown, METH_NOARGS,
     "Shutdown the logging system."
-  },
-  {
-    "rclpy_logging_get_logger_severity_threshold", rclpy_logging_get_logger_severity_threshold,
-    METH_VARARGS, "Get the severity threshold of a logger."
   },
   {
     "rclpy_logging_set_logger_severity_threshold", rclpy_logging_set_logger_severity_threshold,

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -40,7 +40,7 @@ class TestLogging(unittest.TestCase):
         rclpy.logging.set_logger_severity_threshold(name, original_severity)
 
     def test_logger_object_severity_threshold(self):
-        logger = rclpy.logging.get_named_logger('test_logger')
+        logger = rclpy.logging.get_logger('test_logger')
         for severity in LoggingSeverity:
             logger.set_severity_threshold(severity)
             self.assertEqual(severity, logger.get_severity_threshold())
@@ -212,7 +212,7 @@ class TestLogging(unittest.TestCase):
                 )
 
     def test_named_logger(self):
-        my_logger = rclpy.logging.get_named_logger('my_logger')
+        my_logger = rclpy.logging.get_logger('my_logger')
 
         my_logger.set_severity_threshold(LoggingSeverity.INFO)
         # Test convenience functions
@@ -246,9 +246,9 @@ class TestLogging(unittest.TestCase):
     def test_named_logger_hierarchy(self):
         # Create a logger that implicitly is a child of the un-named root logger
         with self.assertRaisesRegex(ValueError, 'Logger name must not be empty'):
-            my_logger = rclpy.logging.get_named_logger('')
+            my_logger = rclpy.logging.get_logger('')
 
-        my_logger = rclpy.logging.get_named_logger('my_logger')
+        my_logger = rclpy.logging.get_logger('my_logger')
         self.assertEqual('my_logger', my_logger.name)
 
         # Check that any logger gets the severity threshold of the root logger by default
@@ -296,7 +296,7 @@ class TestLogging(unittest.TestCase):
         rclpy.logging._root_logger.set_severity_threshold(original_severity)
 
     def test_clear_config(self):
-        my_logger = rclpy.logging.get_named_logger('my_temp_logger')
+        my_logger = rclpy.logging.get_logger('my_temp_logger')
         my_logger.set_severity_threshold(LoggingSeverity.WARN)
         self.assertEqual(LoggingSeverity.WARN, my_logger.get_effective_severity_threshold())
         rclpy.logging.clear_config()

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -66,18 +66,18 @@ class TestLogging(unittest.TestCase):
         rclpy.logging._root_logger.set_severity_threshold(LoggingSeverity.INFO)
 
         # Logging below threshold not expected to be logged
-        self.assertFalse(rclpy.logging.logdebug('message_debug'))
+        self.assertFalse(rclpy.logging._root_logger.debug('message_debug'))
 
         # Logging at or above threshold expected to be logged
-        self.assertTrue(rclpy.logging.loginfo('message_info'))
-        self.assertTrue(rclpy.logging.logwarn('message_warn'))
-        self.assertTrue(rclpy.logging.logerr('message_err'))
-        self.assertTrue(rclpy.logging.logfatal('message_fatal'))
+        self.assertTrue(rclpy.logging._root_logger.info('message_info'))
+        self.assertTrue(rclpy.logging._root_logger.warn('message_warn'))
+        self.assertTrue(rclpy.logging._root_logger.error('message_error'))
+        self.assertTrue(rclpy.logging._root_logger.fatal('message_fatal'))
 
     def test_log_once(self):
         message_was_logged = []
         for i in range(5):
-            message_was_logged.append(rclpy.logging.log(
+            message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 once=True,
@@ -87,7 +87,7 @@ class TestLogging(unittest.TestCase):
         # If the argument is specified as false it shouldn't impact the logging.
         message_was_logged = []
         for i in range(5):
-            message_was_logged.append(rclpy.logging.log(
+            message_was_logged.append(rclpy.logging._root_logger.log(
                 'message2_' + inspect.stack()[0][3] + '_false_' + str(i),
                 LoggingSeverity.INFO,
                 once=False,
@@ -97,7 +97,7 @@ class TestLogging(unittest.TestCase):
     def test_log_throttle(self):
         message_was_logged = []
         for i in range(5):
-            message_was_logged.append(rclpy.logging.log(
+            message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 throttle_duration_sec=1,
@@ -116,7 +116,7 @@ class TestLogging(unittest.TestCase):
     def test_log_skip_first(self):
         message_was_logged = []
         for i in range(5):
-            message_was_logged.append(rclpy.logging.log(
+            message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 skip_first=True,
@@ -128,7 +128,7 @@ class TestLogging(unittest.TestCase):
         # evaluated/updated, then the skip_first condition
         message_was_logged = []
         for i in range(5):
-            message_was_logged.append(rclpy.logging.log(
+            message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 skip_first=True,
@@ -150,7 +150,7 @@ class TestLogging(unittest.TestCase):
         # evaluated/updated, then the once condition
         message_was_logged = []
         for i in range(5):
-            message_was_logged.append(rclpy.logging.log(
+            message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 once=True,
@@ -162,14 +162,14 @@ class TestLogging(unittest.TestCase):
     def test_log_arguments(self):
         # Check half-specified filter not allowed if a required parameter is missing
         with self.assertRaisesRegex(TypeError, 'required parameter .* not specified'):
-            rclpy.logging.log(
+            rclpy.logging._root_logger.log(
                 'message',
                 LoggingSeverity.INFO,
                 throttle_time_source_type='RCUTILS_STEADY_TIME',
             )
 
         # Check half-specified filter is allowed if an optional parameter is missing
-        rclpy.logging.log(
+        rclpy.logging._root_logger.log(
             'message',
             LoggingSeverity.INFO,
             throttle_duration_sec=0.1,
@@ -177,7 +177,7 @@ class TestLogging(unittest.TestCase):
 
         # Check unused kwarg is not allowed
         with self.assertRaisesRegex(TypeError, 'parameter .* is not one of the recognized'):
-            rclpy.logging.log(
+            rclpy.logging._root_logger.log(
                 'message',
                 LoggingSeverity.INFO,
                 name='my_name',
@@ -190,7 +190,7 @@ class TestLogging(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'parameters cannot be changed between'):
             # Start at 1 because a throttle_duration_sec of 0 causes the filter to be ignored.
             for i in range(1, 3):
-                rclpy.logging.log(
+                rclpy.logging._root_logger.log(
                     'message_' + inspect.stack()[0][3] + '_' + str(i),
                     LoggingSeverity.INFO,
                     throttle_duration_sec=i,
@@ -198,7 +198,7 @@ class TestLogging(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'name cannot be changed between'):
             for i in range(2):
-                rclpy.logging.log(
+                rclpy.logging._root_logger.log(
                     'message_' + inspect.stack()[0][3] + '_' + str(i),
                     LoggingSeverity.INFO,
                     name='name_' + str(i),
@@ -206,7 +206,7 @@ class TestLogging(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'severity cannot be changed between'):
             for severity in LoggingSeverity:
-                rclpy.logging.log(
+                rclpy.logging._root_logger.log(
                     'message_' + inspect.stack()[0][3] + '_' + str(severity),
                     severity,
                 )

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -23,11 +23,11 @@ from rclpy.logging import LoggingSeverity
 class TestLogging(unittest.TestCase):
 
     def test_root_logger_severity_threshold(self):
-        original_severity = rclpy.logging.root_logger.get_severity_threshold()
+        original_severity = rclpy.logging._root_logger.get_severity_threshold()
         for severity in LoggingSeverity:
-            rclpy.logging.root_logger.set_severity_threshold(severity)
-            self.assertEqual(severity, rclpy.logging.root_logger.get_severity_threshold())
-        rclpy.logging.root_logger.set_severity_threshold(original_severity)
+            rclpy.logging._root_logger.set_severity_threshold(severity)
+            self.assertEqual(severity, rclpy.logging._root_logger.get_severity_threshold())
+        rclpy.logging._root_logger.set_severity_threshold(original_severity)
 
     def test_logger_severity_threshold(self):
         # We should be able to set the threshold of a nonexistent logger / one that doesn't
@@ -48,13 +48,13 @@ class TestLogging(unittest.TestCase):
     def test_logger_effective_severity_threshold(self):
         name = 'my_nonexistent_logger_name'
         self.assertEqual(
-            rclpy.logging.root_logger.get_severity_threshold(),
+            rclpy.logging._root_logger.get_severity_threshold(),
             rclpy.logging.get_logger_effective_severity_threshold(name))
 
         # Check that the effective threshold for a logger with manually unset severity is default
         rclpy.logging.set_logger_severity_threshold(name, LoggingSeverity.UNSET)
         self.assertEqual(
-            rclpy.logging.root_logger.get_severity_threshold(),
+            rclpy.logging._root_logger.get_severity_threshold(),
             rclpy.logging.get_logger_effective_severity_threshold(name))
         # Check that the effective threshold for a logger with set severity
         rclpy.logging.set_logger_severity_threshold(name, LoggingSeverity.ERROR)
@@ -63,7 +63,7 @@ class TestLogging(unittest.TestCase):
             rclpy.logging.get_logger_effective_severity_threshold(name))
 
     def test_log_threshold(self):
-        rclpy.logging.root_logger.set_severity_threshold(LoggingSeverity.INFO)
+        rclpy.logging._root_logger.set_severity_threshold(LoggingSeverity.INFO)
 
         # Logging below threshold not expected to be logged
         self.assertFalse(rclpy.logging.logdebug('message_debug'))
@@ -232,7 +232,7 @@ class TestLogging(unittest.TestCase):
                 severity=LoggingSeverity.DEBUG)
 
         # Check that this logger's context is independent of the root logger's context
-        loggers = [my_logger, rclpy.logging.root_logger]
+        loggers = [my_logger, rclpy.logging._root_logger]
         for logger in loggers:
             message_was_logged = []
             for i in range(5):
@@ -253,7 +253,7 @@ class TestLogging(unittest.TestCase):
 
         # Check that any logger gets the severity threshold of the root logger by default
         self.assertEqual(
-            rclpy.logging.root_logger.get_severity_threshold(),
+            rclpy.logging._root_logger.get_severity_threshold(),
             my_logger.get_effective_severity_threshold())
 
         with self.assertRaisesRegex(ValueError, 'Child logger name must not be empty'):
@@ -265,9 +265,9 @@ class TestLogging(unittest.TestCase):
         my_logger_child = my_logger.get_child('child')
         self.assertEqual(my_logger.name + '.child', my_logger_child.name)
 
-        original_severity = rclpy.logging.root_logger.get_severity_threshold()
+        original_severity = rclpy.logging._root_logger.get_severity_threshold()
         default_severity = LoggingSeverity.INFO
-        rclpy.logging.root_logger.set_severity_threshold(default_severity)
+        rclpy.logging._root_logger.set_severity_threshold(default_severity)
 
         # Check that children get the default severity if parent's threshold is unset
         self.assertEqual(default_severity, my_logger.get_effective_severity_threshold())
@@ -293,7 +293,7 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(my_logger_severity, my_logger.get_effective_severity_threshold())
         self.assertEqual(my_logger_severity, my_logger_child.get_effective_severity_threshold())
 
-        rclpy.logging.root_logger.set_severity_threshold(original_severity)
+        rclpy.logging._root_logger.set_severity_threshold(original_severity)
 
     def test_clear_config(self):
         my_logger = rclpy.logging.get_named_logger('my_temp_logger')
@@ -302,7 +302,7 @@ class TestLogging(unittest.TestCase):
         rclpy.logging.clear_config()
         self.assertNotEqual(LoggingSeverity.WARN, my_logger.get_effective_severity_threshold())
         self.assertEqual(
-            rclpy.logging.root_logger.get_effective_severity_threshold(),
+            rclpy.logging._root_logger.get_effective_severity_threshold(),
             my_logger.get_effective_severity_threshold())
 
 

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -40,11 +40,10 @@ class TestLogging(unittest.TestCase):
         rclpy.logging.set_logger_severity_threshold(name, original_severity)
 
     def test_logger_object_severity_threshold(self):
-        original_severity = rclpy.logging.root_logger.get_severity_threshold()
+        logger = rclpy.logging.get_named_logger('test_logger')
         for severity in LoggingSeverity:
-            rclpy.logging.root_logger.set_severity_threshold(severity)
-            self.assertEqual(severity, rclpy.logging.root_logger.get_severity_threshold())
-        rclpy.logging.root_logger.set_severity_threshold(original_severity)
+            logger.set_severity_threshold(severity)
+            self.assertEqual(severity, logger.get_severity_threshold())
 
     def test_logger_effective_severity_threshold(self):
         name = 'my_nonexistent_logger_name'


### PR DESCRIPTION
In light of the upcoming supported release I want to remove some things that have been bothering me about the logging API.

## Remove `rclpy.loginfo()`
We decided that in rclcpp users should be "forced" to create a named logger to make a call, so that they think about the hierarchy etc. Because of this I have removed the convenience functions `rclpy.loginfo` etc on the root logger (now "private") to match.

I did not remove the root logger completely: user-created loggers still attach to the root logger because the root logger's name, though it's currently empty, will encapsulate prefix conventions should they ever be introduced.
https://github.com/ros2/rclpy/commit/10cea411b37530eee92e8b352df771e2705a02ab
https://github.com/ros2/rclpy/commit/6d67190b698dbd979b4e5037eee422fb709d8171

## Rename `get_named_logger to get_logger()`
Matches python logging module; the "named" part is redundant.
https://github.com/ros2/rclpy/commit/4531c89b6d19cc64a75cf14eb290bae9f955266b

## Remove `logger.get_severity_threshold()`
- A logger can have its severity explicitly set with `logger.set_severity_threshold()`.
- By default loggers have `UNSET` severity threshold, which causes them to inherit their parent's severity threshold: resolved via `get_effective_severity_threshold()`
- Users almost always want to call `logger.get_effective_severity_threshold()`/`logger.is_enabled_for()`. However, a few times I have accidentally called `logger.get_severity_threshold()` which usually returns `UNSET`.

=> I've removed `get_severity_threshold()` (python logging module doesn't have it) because, except for test purposes, I can't imagine why someone would want to know whether the severity of a logger was explicitly set to X or if it just resolved to X. We lose information but I users will be less likely to trip over the similarly named methods.
https://github.com/ros2/rclpy/commit/217f1c3ab2f690b38289777c0d52fd9d8475bbf1

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3654)](http://ci.ros2.org/job/ci_linux/3654/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=834)](http://ci.ros2.org/job/ci_linux-aarch64/834/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2991)](http://ci.ros2.org/job/ci_osx/2991/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3760)](http://ci.ros2.org/job/ci_windows/3760/)