### PR TITLE
Futures and coroutines

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -120,7 +120,7 @@ class Executor:
         self._last_args = None
         self._last_kwargs = None
 
-    def create_task(self, callback, *args):
+    def create_task(self, callback, *args, **kwargs):
         """
         Add a callback or coroutine to be executed during :meth:`spin` and return a Future.
 
@@ -130,7 +130,7 @@ class Executor:
         :type callback: callable or coroutine function
         :rtype: :class:`rclpy.task.Future` instance
         """
-        task = Task(callback, *args, executor=self)
+        task = Task(callback, args, kwargs, executor=self)
         with self._tasks_lock:
             self._tasks.append((task, None, None))
         # Task inherits from Future
@@ -283,7 +283,7 @@ class Executor:
                     # callback group can get executed
                     _rclpy.rclpy_trigger_guard_condition(gc)
         task = Task(
-            handler, entity, self._guard_condition, self._is_shutdown, self._work_tracker,
+            handler, (entity, self._guard_condition, self._is_shutdown, self._work_tracker),
             executor=self)
         with self._tasks_lock:
             self._tasks.append((task, entity, node))

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -121,7 +121,7 @@ class Future:
                 executor.create_task(callback, self)
         self._callbacks = []
 
-    def _set_executor(self, executor=None):
+    def _set_executor(self, executor):
         """Set the executor this future is associated with."""
         with self._lock:
             if executor is None:

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -197,7 +197,7 @@ class Task(Future):
             self._lock.release()
 
     def _complete_task(self):
-        """Store result and schedule done callbacks."""
+        """Cleanup after task finished."""
         self._handler = None
         self._args = None
 

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -165,7 +165,9 @@ class Task(Future):
         """
         if self._done or self._executing:
             return
-        with self._lock:
+        if not self._lock.acquire(blocking=False):
+            return
+        try:
             if self._done:
                 return
             self._executing = True
@@ -191,6 +193,8 @@ class Task(Future):
                 self._complete_task()
 
             self._executing = False
+        finally:
+            self._lock.release()
 
     def _complete_task(self):
         """Store result and schedule done callbacks."""

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -39,9 +39,8 @@ class Future:
         # Lock for threadsafety
         self._lock = threading.Lock()
         # An executor to use when scheduling done callbacks
-        self._executor = _fake_weakref
-        if executor is not None:
-            self._executor = weakref.ref(executor)
+        self._executor = None
+        self._set_executor(executor)
 
     def __await__(self):
         # Yield if the task is not finished
@@ -117,11 +116,18 @@ class Future:
             for callback in self._callbacks:
                 executor.create_task(callback, self)
 
+    def _set_executor(self, executor=None):
+        """Set the executor this future is associated with."""
+        if executor is None:
+            self._executor = _fake_weakref
+        else:
+            self._executor = weakref.ref(executor)
+
     def add_done_callback(self, callback):
         """
         Add a callback to be executed when the task is done.
 
-        :param callback: a callback to be run when the task completes.
+        :param callback: a callback taking the future as an agrument to be run when completed
         """
         if self._done:
             executor = self._executor()

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -1,0 +1,207 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import threading
+import weakref
+
+
+def _fake_weakref():
+    """Return None when called to simulate a weak reference that has been garbage collected."""
+    return None
+
+
+class Future:
+    """Represent the outcome of a task in the future."""
+
+    def __init__(self, *, executor=None):
+        # true if the task is done or cancelled
+        self._done = False
+        # true if the task is cancelled
+        self._cancelled = False
+        # the final return value of the handler
+        self._result = None
+        # An exception raised by the handler when called
+        self._exception = None
+        # callbacks to be scheduled after this task completes
+        self._callbacks = []
+        # Lock for threadsafety
+        self._lock = threading.Lock()
+        # An executor to use when scheduling done callbacks
+        self._executor = _fake_weakref
+        if executor is not None:
+            self._executor = weakref.ref(executor)
+
+    def __await__(self):
+        # Yield if the task is not finished
+        while not self._done:
+            yield
+        return self._result
+
+    def cancel(self):
+        """Request cancellation of the running task if it is not done already."""
+        if not self._done:
+            self._cancelled = True
+
+    def cancelled(self):
+        """
+        Indicate if the task has been cancelled.
+
+        :return: True if the task was cancelled
+        :rtype: bool
+        """
+        return self._cancelled
+
+    def done(self):
+        """
+        Indicate if the task has finished executing.
+
+        :return: True if the task is finished or raised while it was executing
+        :rtype: bool
+        """
+        return self._done
+
+    def result(self):
+        """
+        Get the result of a done task.
+
+        :return: The result set by the task
+        """
+        return self._result
+
+    def exception(self):
+        """
+        Get an exception raised by a done task.
+
+        :return: The exception raised by the task
+        """
+        return self._exception
+
+    def set_result(self, result):
+        """
+        Set the result returned by a task.
+
+        :param result: The output of a long running task.
+        """
+        self._result = result
+        self._done = True
+        self._cancelled = False
+        self._schedule_done_callbacks()
+
+    def set_exception(self, exception):
+        """
+        Set the exception raised by the task.
+
+        :param result: The output of a long running task.
+        """
+        self._exception = exception
+        self._done = True
+        self._cancelled = False
+        self._schedule_done_callbacks()
+
+    def _schedule_done_callbacks(self):
+        """Schedule done callbacks on the executor if possible."""
+        executor = self._executor()
+        if executor is not None:
+            for callback in self._callbacks:
+                executor.create_task(callback, self)
+
+    def add_done_callback(self, callback):
+        """
+        Add a callback to be executed when the task is done.
+
+        :param callback: a callback to be run when the task completes.
+        """
+        if self._done:
+            executor = self._executor()
+            if executor is not None:
+                executor.create_task(callback, self)
+        else:
+            with self._lock:
+                self._callbacks.append(callback)
+
+
+class Task(Future):
+    """
+    Execute a function or coroutine.
+
+    This executes either a normal function or a coroutine to completion. On completion it creates
+    tasks for any 'done' callbacks.
+
+    This class should only be instantiated by :class:`rclpy.executors.Executor`.
+    """
+
+    def __init__(self, handler, *args, executor=None):
+        super().__init__(executor=executor)
+        # _handler is either a normal function or a coroutine
+        self._handler = handler
+        # Arguments passed into the function
+        self._args = args
+        if inspect.iscoroutinefunction(handler):
+            self._handler = handler(*args)
+            self._args = None
+        # True while the task is being executed
+        self._executing = False
+
+    def __call__(self):
+        """
+        Run or resume a task.
+
+        This attempts to execute a handler. If the handler is a coroutine it will attempt to
+        await it. If there are done callbacks it will schedule them with the executor.
+
+        The return value of the handler is stored as the task result.
+        """
+        if self._done or self._executing:
+            return
+        with self._lock:
+            if self._done:
+                return
+            self._executing = True
+
+            if inspect.iscoroutine(self._handler):
+                # Execute a coroutine
+                try:
+                    self._handler.send(None)
+                except StopIteration as e:
+                    # The coroutine finished; store the result
+                    self._handler.close()
+                    self.set_result(e.value)
+                    self._complete_task()
+                except Exception as e:
+                    self.set_exception(e)
+                    self._complete_task()
+            else:
+                # Execute a normal function
+                try:
+                    self.set_result(self._handler(*self._args))
+                except Exception as e:
+                    self.set_exception(e)
+                self._complete_task()
+
+            self._executing = False
+
+    def _complete_task(self):
+        """Store result and schedule done callbacks."""
+        self._handler = None
+        self._args = None
+
+    def executing(self):
+        """
+        Check if the task is currently being executed.
+
+        :return: True if the task is currently executing.
+        :rtype: bool
+        """
+        return self._executing

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -52,6 +52,7 @@ class Future:
         """Request cancellation of the running task if it is not done already."""
         if not self._done:
             self._cancelled = True
+        self._schedule_done_callbacks()
 
     def cancelled(self):
         """

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -31,30 +31,22 @@ class DummyExecutor:
 class TestTask(unittest.TestCase):
 
     def test_task_normal_callable(self):
-        called = False
 
         def func():
-            nonlocal called
-            called = True
             return 'Sentinel Result'
 
         t = Task(func)
         t()
-        self.assertTrue(called)
         self.assertTrue(t.done())
         self.assertEqual('Sentinel Result', t.result())
 
     def test_task_lambda(self):
-        called = False
 
         def func():
-            nonlocal called
-            called = True
             return 'Sentinel Result'
 
         t = Task(lambda: func())
         t()
-        self.assertTrue(called)
         self.assertTrue(t.done())
         self.assertEqual('Sentinel Result', t.result())
 

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -159,7 +159,7 @@ class TestTask(unittest.TestCase):
         def func(arg):
             return arg
 
-        t = Task(func, arg_in)
+        t = Task(func, args=(arg_in,))
         t()
         self.assertEqual('Sentinel Arg', t.result())
 
@@ -169,7 +169,27 @@ class TestTask(unittest.TestCase):
         async def coro(arg):
             return arg
 
-        t = Task(coro, arg_in)
+        t = Task(coro, args=(arg_in,))
+        t()
+        self.assertEqual('Sentinel Arg', t.result())
+
+    def test_task_normal_callable_kwargs(self):
+        arg_in = 'Sentinel Arg'
+
+        def func(kwarg=None):
+            return kwarg
+
+        t = Task(func, kwargs={'kwarg': arg_in})
+        t()
+        self.assertEqual('Sentinel Arg', t.result())
+
+    def test_coroutine_kwargs(self):
+        arg_in = 'Sentinel Arg'
+
+        async def coro(kwarg=None):
+            return kwarg
+
+        t = Task(coro, kwargs={'kwarg': arg_in})
         t()
         self.assertEqual('Sentinel Arg', t.result())
 

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -218,6 +218,27 @@ class TestFuture(unittest.TestCase):
         except StopIteration as e:
             self.assertEqual('Sentinel Result', e.value)
 
+    def test_cancel_schedules_callbacks(self):
+        executor = DummyExecutor()
+        f = Future(executor=executor)
+        f.add_done_callback(lambda f: None)
+        f.cancel()
+        self.assertTrue(executor.done_callbacks)
+
+    def test_set_result_schedules_callbacks(self):
+        executor = DummyExecutor()
+        f = Future(executor=executor)
+        f.add_done_callback(lambda f: None)
+        f.set_result('Anything')
+        self.assertTrue(executor.done_callbacks)
+
+    def test_set_exception_schedules_callbacks(self):
+        executor = DummyExecutor()
+        f = Future(executor=executor)
+        f.add_done_callback(lambda f: None)
+        f.set_exception('Anything')
+        self.assertTrue(executor.done_callbacks)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -1,0 +1,231 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest
+
+from rclpy.task import Future
+from rclpy.task import Task
+
+
+class DummyExecutor:
+
+    def __init__(self):
+        self.done_callbacks = []
+
+    def create_task(self, cb, *args):
+        self.done_callbacks.append((cb, args))
+
+
+class TestTask(unittest.TestCase):
+
+    def test_task_normal_callable(self):
+        called = False
+
+        def func():
+            nonlocal called
+            called = True
+            return 'Sentinel Result'
+
+        t = Task(func)
+        t()
+        self.assertTrue(called)
+        self.assertTrue(t.done())
+        self.assertEqual('Sentinel Result', t.result())
+
+    def test_task_lambda(self):
+        called = False
+
+        def func():
+            nonlocal called
+            called = True
+            return 'Sentinel Result'
+
+        t = Task(lambda: func())
+        t()
+        self.assertTrue(called)
+        self.assertTrue(t.done())
+        self.assertEqual('Sentinel Result', t.result())
+
+    def test_coroutine(self):
+        called1 = False
+        called2 = False
+
+        async def coro():
+            nonlocal called1
+            nonlocal called2
+            called1 = True
+            await asyncio.sleep(0)
+            called2 = True
+            return 'Sentinel Result'
+
+        t = Task(coro)
+        t()
+        self.assertTrue(called1)
+        self.assertFalse(called2)
+
+        called1 = False
+        t()
+        self.assertFalse(called1)
+        self.assertTrue(called2)
+        self.assertTrue(t.done())
+        self.assertEqual('Sentinel Result', t.result())
+
+    def test_done_callback_scheduled(self):
+        executor = DummyExecutor()
+
+        t = Task(lambda: None, executor=executor)
+        t.add_done_callback('Sentinel Value')
+        t()
+        self.assertTrue(t.done())
+        self.assertEqual(1, len(executor.done_callbacks))
+        self.assertEqual('Sentinel Value', executor.done_callbacks[0][0])
+        args = executor.done_callbacks[0][1]
+        self.assertEqual(1, len(args))
+        self.assertEqual(t, args[0])
+
+    def test_done_task_done_callback_scheduled(self):
+        executor = DummyExecutor()
+
+        t = Task(lambda: None, executor=executor)
+        t()
+        self.assertTrue(t.done())
+        t.add_done_callback('Sentinel Value')
+        self.assertEqual(1, len(executor.done_callbacks))
+        self.assertEqual('Sentinel Value', executor.done_callbacks[0][0])
+        args = executor.done_callbacks[0][1]
+        self.assertEqual(1, len(args))
+        self.assertEqual(t, args[0])
+
+    def test_done_task_called(self):
+        called = False
+
+        def func():
+            nonlocal called
+            called = True
+
+        t = Task(func)
+        t()
+        self.assertTrue(called)
+        self.assertTrue(t.done())
+        called = False
+        t()
+        self.assertFalse(called)
+        self.assertTrue(t.done())
+
+    def test_cancelled(self):
+        t = Task(lambda: None)
+        t.cancel()
+        self.assertTrue(t.cancelled())
+
+    def test_done_task_cancelled(self):
+        t = Task(lambda: None)
+        t()
+        t.cancel()
+        self.assertFalse(t.cancelled())
+
+    def test_exception(self):
+
+        def func():
+            e = Exception()
+            e.sentinel_value = 'Sentinel Exception'
+            raise e
+
+        t = Task(func)
+        t()
+        self.assertTrue(t.done())
+        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)
+        self.assertEqual(None, t.result())
+
+    def test_coroutine_exception(self):
+
+        async def coro():
+            e = Exception()
+            e.sentinel_value = 'Sentinel Exception'
+            raise e
+
+        t = Task(coro)
+        t()
+        self.assertTrue(t.done())
+        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)
+        self.assertEqual(None, t.result())
+
+    def test_task_normal_callable_args(self):
+        arg_in = 'Sentinel Arg'
+
+        def func(arg):
+            return arg
+
+        t = Task(func, arg_in)
+        t()
+        self.assertEqual('Sentinel Arg', t.result())
+
+    def test_coroutine_args(self):
+        arg_in = 'Sentinel Arg'
+
+        async def coro(arg):
+            return arg
+
+        t = Task(coro, arg_in)
+        t()
+        self.assertEqual('Sentinel Arg', t.result())
+
+    def test_executing(self):
+        t = Task(lambda: None)
+        self.assertFalse(t.executing())
+
+
+class TestFuture(unittest.TestCase):
+
+    def test_cancelled(self):
+        f = Future()
+        f.cancel()
+        self.assertTrue(f.cancelled())
+
+    def test_done(self):
+        f = Future()
+        self.assertFalse(f.done())
+        f.set_result(None)
+        self.assertTrue(f.done())
+
+    def test_set_result(self):
+        f = Future()
+        f.set_result('Sentinel Result')
+        self.assertEqual('Sentinel Result', f.result())
+        self.assertTrue(f.done())
+
+    def test_set_exception(self):
+        f = Future()
+        f.set_exception('Sentinel Exception')
+        self.assertEqual('Sentinel Exception', f.exception())
+        self.assertTrue(f.done())
+
+    def test_await(self):
+        f = Future()
+
+        async def coro():
+            nonlocal f
+            return await f
+
+        c = coro()
+        c.send(None)
+        f.set_result('Sentinel Result')
+        try:
+            c.send(None)
+        except StopIteration as e:
+            self.assertEqual('Sentinel Result', e.value)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds coroutine support to the executor and is part of service feature parity #123 and `wait_for_service` without a `GraphListener` #58.

Any callback can now be a coroutine function (`async def`). If the callback is a coroutine and it becomes blocked the executor will move on and resume executing it later. The details of this are handled in the class `Task` which is a class very similar to [asyncio.Task](https://docs.python.org/3/library/asyncio-task.html#task). `asyncio` can't be used directly because it is not thread safe.

This PR also adds a `Future` class that represents the result of a stored task. It is not used in this PR, but an example of using it is in #170.

**CI** ( with 5f2cb1eb6cc451acbe0bb58b93672ebe224b45e6)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3878)](http://ci.ros2.org/job/ci_linux/3878/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=998)](http://ci.ros2.org/job/ci_linux-aarch64/998/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3204)](http://ci.ros2.org/job/ci_osx/3204/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3955)](http://ci.ros2.org/job/ci_windows/3955/)
  
  
  
  
  