### PR TITLE
Sleep to workaround race condition in MultiThreadedExecutor test

### DIFF
--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -43,6 +43,8 @@ class TestExecutor(unittest.TestCase):
 
         executor.add_node(self.node)
         executor.spin_once(timeout_sec=1.23)
+        # Sleep for race condition between test cleanup and MultiThreadedExecutor thread pool
+        time.sleep(0.1)
 
         self.node.destroy_timer(tmr)
         return got_callback

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -43,7 +43,8 @@ class TestExecutor(unittest.TestCase):
 
         executor.add_node(self.node)
         executor.spin_once(timeout_sec=1.23)
-        # Sleep for race condition between test cleanup and MultiThreadedExecutor thread pool
+        # TODO(sloretz) redesign test, sleeping to workaround race condition between test cleanup
+        # and MultiThreadedExecutor thread pool
         time.sleep(0.1)
 
         self.node.destroy_timer(tmr)


### PR DESCRIPTION
This adds a sleep to workaround a race condition in `test_multi_threaded_executor_executes`. `MultiThreadedExecutor` runs callbacks in a thread pool. It is possible for `func_execution` to return `False` before the thread pool executes `timer_callback`.

CI with testing set test only rclpy since this only changes a test.
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3835)](http://ci.ros2.org/job/ci_linux/3835/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=966)](http://ci.ros2.org/job/ci_linux-aarch64/966/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3170)](http://ci.ros2.org/job/ci_osx/3170/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3919)](http://ci.ros2.org/job/ci_windows/3919/) (Unstable due to warnings in eProsima Fast-RTPS code, see eProsima/Fast-RTPS#175 )
  
  
  