### PR TITLE
Disable 1kHz timer tests on arm

### DIFF
--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -14,6 +14,7 @@
 
 import multiprocessing
 import os
+import platform
 import sys
 import time
 import traceback
@@ -150,8 +151,9 @@ def test_timer_zero_callbacks100hertz():
 
 # TODO(mikaelarguedas) reenable these once timer have consistent behaviour
 # on every platform at high frequency
+# TODO(sloretz) Reenable on arm when executor performance is good enough
 def test_timer_zero_callbacks1000hertz():
-    if os.name == 'nt':
+    if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
     func_launch(func_zero_callback, ['0.001'], 'received callbacks when not expected')
 
@@ -166,7 +168,7 @@ def test_timer_number_callbacks100hertz():
 
 
 def test_timer_number_callbacks1000hertz():
-    if os.name == 'nt':
+    if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
     func_launch(
         func_number_callbacks, ['0.001'], "didn't receive the expected number of callbacks")
@@ -183,7 +185,7 @@ def test_timer_cancel_reset_100hertz():
 
 
 def test_timer_cancel_reset_1000hertz():
-    if os.name == 'nt':
+    if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
     func_launch(
         func_cancel_reset_timer, ['0.001'], "didn't receive the expected number of callbacks")


### PR DESCRIPTION
This pull request disables the 1kHz timer tests on arm. They sometimes fail due to the time it takes for the executor to execute the timer callbacks being slightly too long. That issue will need to be fixed, but this will eliminate the noise in the meantime.

CI (only testing rclpy)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3836)](http://ci.ros2.org/job/ci_linux/3836/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=968)](http://ci.ros2.org/job/ci_linux-aarch64/968/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3172)](http://ci.ros2.org/job/ci_osx/3172/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3917)](http://ci.ros2.org/job/ci_windows/3917/)

  