### PR TITLE
Refactor client for multiple requests

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -54,3 +54,14 @@ def spin(node):
             executor.spin_once()
     finally:
         executor.shutdown()
+
+
+def spin_until_future_complete(node, future):
+    # imported locally to avoid loading extensions on module import
+    from rclpy.executors import SingleThreadedExecutor
+    executor = SingleThreadedExecutor()
+    try:
+        executor.add_node(node)
+        executor.spin_until_future_complete(future)
+    finally:
+        executor.shutdown()

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -57,6 +57,15 @@ def spin(node):
 
 
 def spin_until_future_complete(node, future):
+    """
+    Execute work until the future is complete.
+
+    Callbacks and other work will be executed in a SingleThreadedExecutor until future.done()
+    returns True or rclpy is shutdown.
+
+    :param future: The future object to wait on.
+    :type future: rclpy.task.Future
+    """
     # imported locally to avoid loading extensions on module import
     from rclpy.executors import SingleThreadedExecutor
     executor = SingleThreadedExecutor()

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -16,39 +16,8 @@ import threading
 import time
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.task import Future
 import rclpy.utilities
-
-
-class ResponseThread(threading.Thread):
-
-    def __init__(self, client):
-        threading.Thread.__init__(self)
-        self.client = client
-        self.wait_set = _rclpy.rclpy_get_zero_initialized_wait_set()
-        _rclpy.rclpy_wait_set_init(self.wait_set, 0, 1, 0, 1, 0)
-        _rclpy.rclpy_wait_set_clear_entities('client', self.wait_set)
-        _rclpy.rclpy_wait_set_add_entity(
-            'client', self.wait_set, self.client.client_handle)
-
-    def run(self):
-        [sigint_gc, sigint_gc_handle] = _rclpy.rclpy_get_sigint_guard_condition()
-        _rclpy.rclpy_wait_set_add_entity('guard_condition', self.wait_set, sigint_gc)
-
-        _rclpy.rclpy_wait(self.wait_set, -1)
-
-        guard_condition_ready_list = \
-            _rclpy.rclpy_get_ready_entities('guard_condition', self.wait_set)
-
-        # destroying here to make sure we dont call shutdown before cleaning up
-        _rclpy.rclpy_destroy_entity(sigint_gc)
-        if sigint_gc_handle in guard_condition_ready_list:
-            rclpy.utilities.shutdown()
-            return
-        seq, response = _rclpy.rclpy_take_response(
-            self.client.client_handle,
-            self.client.srv_type.Response)
-        if seq is not None and seq == self.client.sequence_number:
-            self.client.response = response
 
 
 class Client:
@@ -61,15 +30,46 @@ class Client:
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.qos_profile = qos_profile
-        self.sequence_number = 0
-        self.response = None
+        # Key is a sequence number, value is an instance of a Future
+        self._pending_requests = {}
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor
         self._executor_event = False
 
     def call(self, req):
-        self.response = None
-        self.sequence_number = _rclpy.rclpy_send_request(self.client_handle, req)
+        """
+        Make a service request and wait for the result.
+
+        Do not call this method in a callback or a deadlock may occur.
+
+        :param req: The service request
+        :return: The service response
+        """
+        event = threading.Event()
+
+        def unblock(self, future):
+            nonlocal event
+            event.set()
+
+        future = self.call_async(req)
+        future.add_done_callback(unblock)
+
+        event.wait()
+        if future.exception() is not None:
+            raise future.exception()
+        return future.result()
+
+    def call_async(self, req):
+        """
+        Make a service request and asyncronously get the result.
+
+        :return: a Future instance that completes when the request does
+        :rtype: :class:`rclpy.task.Future` instance
+        """
+        sequence_number = _rclpy.rclpy_send_request(self.client_handle, req)
+        future = Future()
+        self._pending_requests[sequence_number] = future
+        return future
 
     def service_is_ready(self):
         return _rclpy.rclpy_service_server_is_available(self.node_handle, self.client_handle)
@@ -85,10 +85,3 @@ class Client:
             timeout_sec -= sleep_time
 
         return self.service_is_ready()
-
-    # TODO(mikaelarguedas) this function can only be used if nobody is spinning
-    # need to be updated once guard_conditions are supported
-    def wait_for_future(self):
-        thread1 = ResponseThread(self)
-        thread1.start()
-        thread1.join()

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -83,6 +83,9 @@ class Client:
         :rtype: :class:`rclpy.task.Future` instance
         """
         sequence_number = _rclpy.rclpy_send_request(self.client_handle, req)
+        if sequence_number in self._pending_requests:
+            raise RuntimeError("Sequence (%r) conflicts with pending request" % sequence_number)
+
         future = Future()
         self._pending_requests[sequence_number] = future
 

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -84,7 +84,7 @@ class Client:
         """
         sequence_number = _rclpy.rclpy_send_request(self.client_handle, req)
         if sequence_number in self._pending_requests:
-            raise RuntimeError("Sequence (%r) conflicts with pending request" % sequence_number)
+            raise RuntimeError('Sequence (%r) conflicts with pending request' % sequence_number)
 
         future = Future()
         self._pending_requests[sequence_number] = future

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -47,7 +47,7 @@ class Client:
         """
         event = threading.Event()
 
-        def unblock(self, future):
+        def unblock(future):
             nonlocal event
             event.set()
 
@@ -69,6 +69,13 @@ class Client:
         sequence_number = _rclpy.rclpy_send_request(self.client_handle, req)
         future = Future()
         self._pending_requests[sequence_number] = future
+
+        def remove_pending_request(future):
+            nonlocal self, sequence_number
+            del self._pending_requests[sequence_number]
+
+        future.add_done_callback(remove_pending_request)
+
         return future
 
     def service_is_ready(self):

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -191,6 +191,11 @@ class Executor:
         while ok():
             self.spin_once()
 
+    def spin_until_future_complete(self, future):
+        """Execute until a given future is done."""
+        while ok() and not future.done():
+            self.spin_once()
+
     def spin_once(self, timeout_sec=None):
         """
         Wait for and execute a single callback.

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -222,11 +222,15 @@ class Executor:
 
     async def _execute_client(self, client, seq_and_response):
         sequence, response = seq_and_response
-        if sequence is not None and sequence == client.sequence_number:
-            # clients spawn their own thread to wait for a response in the
-            # wait_for_future function. Users can either use this mechanism or monitor
-            # the content of client.response to check if a response has been received
-            client.response = response
+        if sequence is not None:
+            try:
+                future = client._pending_requests[sequence]
+            except IndexError:
+                # The request was cancelled
+                pass
+            else:
+                future._set_executor(self)
+                future.set_result(response)
 
     def _take_service(self, srv):
         request_and_header = _rclpy.rclpy_take_request(


### PR DESCRIPTION
Opening a PR for feedback. This uses the `Future` class added in pull request #166 to allow simultaneous requests from the same client (part of #123). It is implemented like [option 3 in this comment](https://github.com/ros2/rclpy/issues/58#issuecomment-344697128).

Specifically any ideas about `call`? This new version should not be called inside a callback because it would deadlock a `SingleThreadedExecutor`. It also is not very useful outside because an executor would need to be running in another thread for the client response to be taken from rcl.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3902)](http://ci.ros2.org/job/ci_linux/3902/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1020)](http://ci.ros2.org/job/ci_linux-aarch64/1020/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3225)](http://ci.ros2.org/job/ci_osx/3225/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3995)](http://ci.ros2.org/job/ci_windows/3995/)
    * Unrelated failing test (timeout): `projectroot.test_api_srv_composition_client_first__rmw_fastrtps_cpp`
        * Also timed out on `nightly_win_deb` http://ci.ros2.org/view/nightly/job/nightly_win_deb/764
        * However, it passed in `nightly_win_rep` http://ci.ros2.org/view/nightly/job/nightly_win_rel/705