### PR TITLE
rclpy_take_response checks sequence number

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -44,11 +44,11 @@ class ResponseThread(threading.Thread):
         if sigint_gc_handle in guard_condition_ready_list:
             rclpy.utilities.shutdown()
             return
-        seq_and_response = _rclpy.rclpy_take_response(
+        seq, response = _rclpy.rclpy_take_response(
             self.client.client_handle,
             self.client.srv_type.Response)
-        if seq_and_response and seq_and_response[0] == self.client.sequence_number:
-            self.client.response = seq_and_response[1]
+        if seq is not None and seq == self.client.sequence_number:
+            self.client.response = response
 
 
 class Client:

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -44,12 +44,11 @@ class ResponseThread(threading.Thread):
         if sigint_gc_handle in guard_condition_ready_list:
             rclpy.utilities.shutdown()
             return
-        response = _rclpy.rclpy_take_response(
+        seq_and_response = _rclpy.rclpy_take_response(
             self.client.client_handle,
-            self.client.srv_type.Response,
-            self.client.sequence_number)
-        if response:
-            self.client.response = response
+            self.client.srv_type.Response)
+        if seq_and_response and seq_and_response[0] == self.client.sequence_number:
+            self.client.response = seq_and_response[1]
 
 
 class Client:

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -218,12 +218,15 @@ class Executor:
             await await_or_execute(sub.callback, msg)
 
     def _take_client(self, client):
-        response = _rclpy.rclpy_take_response(
-            client.client_handle, client.srv_type.Response, client.sequence_number)
-        return response
+        seq_and_response = _rclpy.rclpy_take_response(
+            client.client_handle, client.srv_type.Response)
+        if seq_and_response:
+            return seq_and_response
+        return None, None
 
-    async def _execute_client(self, client, response):
-        if response:
+    async def _execute_client(self, client, seq_and_response):
+        sequence, response = seq_and_response
+        if sequence is not None and sequence == client.sequence_number:
             # clients spawn their own thread to wait for a response in the
             # wait_for_future function. Users can either use this mechanism or monitor
             # the content of client.response to check if a response has been received

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -218,11 +218,7 @@ class Executor:
             await await_or_execute(sub.callback, msg)
 
     def _take_client(self, client):
-        seq_and_response = _rclpy.rclpy_take_response(
-            client.client_handle, client.srv_type.Response)
-        if seq_and_response:
-            return seq_and_response
-        return None, None
+        return _rclpy.rclpy_take_response(client.client_handle, client.srv_type.Response)
 
     async def _execute_client(self, client, seq_and_response):
         sequence, response = seq_and_response

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2164,7 +2164,7 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
  *
  * \param[in] pyclient Capsule pointing to the client to process the response
  * \param[in] pyresponse_type Instance of the message type to take
- * \return 2-tuple sequence number and received response or None if there is no response to take
+ * \return 2-tuple sequence number and received response or None, None if there is no response
  */
 static PyObject *
 rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
@@ -2212,6 +2212,12 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
   int64_t sequence = header->sequence_number;
   PyMem_Free(header);
 
+  // Create the tuple to return
+  PyObject * pytuple = PyTuple_New(2);
+  if (!pytuple) {
+    return NULL;
+  }
+
   if (ret != RCL_RET_CLIENT_TAKE_FAILED) {
     PyObject * pyconvert_to_py = PyObject_GetAttrString(pyresponse_type, "_CONVERT_TO_PY");
 
@@ -2223,27 +2229,25 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
     destroy_ros_message(taken_response);
     if (!pytaken_response) {
       // the function has set the Python error
+      Py_DECREF(pytuple);
       return NULL;
     }
 
-    // Create the tuple to return
     PyObject * pysequence = PyLong_FromLongLong(sequence);
     if (!pysequence) {
       Py_DECREF(pytaken_response);
-      return NULL;
-    }
-    PyObject * pytuple = PyTuple_New(2);
-    if (!pytuple) {
-      Py_DECREF(pysequence);
-      Py_DECREF(pytaken_response);
+      Py_DECREF(pytuple);
       return NULL;
     }
     PyTuple_SET_ITEM(pytuple, 0, pysequence);
     PyTuple_SET_ITEM(pytuple, 1, pytaken_response);
     return pytuple;
   }
-  // if take_response failed, just do nothing
-  Py_RETURN_NONE;
+  Py_INCREF(Py_None);
+  PyTuple_SET_ITEM(pytuple, 0, Py_None);
+  Py_INCREF(Py_None);
+  PyTuple_SET_ITEM(pytuple, 1, Py_None);
+  return pytuple;
 }
 
 /// Status of the the client library


### PR DESCRIPTION
This fixes a bug where rclpy_take_response ignores the sequence number in a struct populated by rcl_take_response. This becomes important once the client supports multiple outstanding requests (#170).

connects to ros2/rcl#205

CI (with  e260ce6)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3883)](http://ci.ros2.org/job/ci_linux/3883/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1002)](http://ci.ros2.org/job/ci_linux-aarch64/1002/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3209)](http://ci.ros2.org/job/ci_osx/3209/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3972)](http://ci.ros2.org/job/ci_windows/3972/)
  
  