### PR TITLE
Get node's logger name from rcl

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -53,8 +53,6 @@ class Node:
 
     def __init__(self, node_name, *, namespace=None):
         self._handle = None
-        # TODO(dhood): get logger name from rcl, use namespace (with slashes converted)
-        self._logger = get_logger(node_name)
         self.publishers = []
         self.subscriptions = []
         self.clients = []
@@ -79,6 +77,7 @@ class Node:
             validate_namespace(namespace)
             # Should not get to this point
             raise RuntimeError('rclpy_create_node failed for unknown reason')
+        self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(self.handle))
 
     @property
     def handle(self):

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -274,6 +274,36 @@ rclpy_get_node_namespace(PyObject * Py_UNUSED(self), PyObject * args)
   return PyUnicode_FromString(node_namespace);
 }
 
+/// Get the name of the logger associated with a node.
+/**
+ * Raises ValueError if pynode is not a node capsule
+ *
+ * \param[in] pynode Capsule pointing to the node to get the logger name of
+ * \return logger_name, or
+ * \return None on failure
+ */
+static PyObject *
+rclpy_get_node_logger_name(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pynode;
+
+  if (!PyArg_ParseTuple(args, "O", &pynode)) {
+    return NULL;
+  }
+
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, "rcl_node_t");
+  if (!node) {
+    return NULL;
+  }
+
+  const char * node_logger_name = rcl_node_get_logger_name(node);
+  if (!node_logger_name) {
+    Py_RETURN_NONE;
+  }
+
+  return PyUnicode_FromString(node_logger_name);
+}
+
 /// Validate a topic name and return error message and index of invalidation.
 /**
  * Does not have to be a fully qualified topic name.
@@ -2582,7 +2612,11 @@ static PyMethodDef rclpy_methods[] = {
   },
   {
     "rclpy_get_node_namespace", rclpy_get_node_namespace, METH_VARARGS,
-    "Get the name of a node."
+    "Get the namespace of a node."
+  },
+  {
+    "rclpy_get_node_logger_name", rclpy_get_node_logger_name, METH_VARARGS,
+    "Get the logger name associated with a node."
   },
   {
     "rclpy_expand_topic_name", rclpy_expand_topic_name, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -286,7 +286,6 @@ static PyObject *
 rclpy_get_node_logger_name(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pynode;
-
   if (!PyArg_ParseTuple(args, "O", &pynode)) {
     return NULL;
   }

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -91,7 +91,7 @@ class TestNode(unittest.TestCase):
 
     def test_node_logger(self):
         node_logger = self.node.get_logger()
-        self.assertEqual(node_logger.name, 'my_node')
+        self.assertEqual(node_logger.name, 'my_ns.my_node')
         node_logger.set_level(rclpy.logging.LoggingSeverity.INFO)
         node_logger.debug('test')
 


### PR DESCRIPTION
connects to ros2/rcl#212

Note that the rclpy logger associated with a node won't be created until after the rcl node is created. I don't see an issue with this because we're not using the logger before that point anyway.