### PR TITLE
Make rclpy.spin*() use a persistent executor

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -66,7 +66,7 @@ def spin_once(node, *, timeout_sec=None):
     if the global executor has a partially completed coroutine.
 
     :param node: A node to add to the executor to check for work.
-    :param timeout_sec: Maximum time in seconds to wait for work.
+    :param timeout_sec: Seconds to wait. Block forever if None or negative. Don't wait if 0
     :return: Always returns None regardless whether work executes or timeout expires.
     :rtype: None
     """

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -16,7 +16,7 @@ import sys
 
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
 from rclpy.utilities import ok
-from rclpy.utilities import shutdown  # noqa
+from rclpy.utilities import shutdown as _shutdown
 from rclpy.utilities import try_shutdown  # noqa
 
 
@@ -27,6 +27,28 @@ def init(*, args=None):
         args if args is not None else sys.argv)
 
 
+# The global spin functions need an executor to do the work
+# A persistent executor can re-run async tasks that yielded in rclpy.spin*().
+__executor = None
+
+
+def get_global_executor():
+    global __executor
+    if __executor is None:
+        # imported locally to avoid loading extensions on module import
+        from rclpy.executors import SingleThreadedExecutor
+        __executor = SingleThreadedExecutor()
+    return __executor
+
+
+def shutdown():
+    global __executor
+    if __executor is not None:
+        __executor.shutdown()
+        __executor = None
+    _shutdown()
+
+
 def create_node(node_name, *, namespace=None):
     # imported locally to avoid loading extensions on module import
     from rclpy.node import Node
@@ -34,26 +56,22 @@ def create_node(node_name, *, namespace=None):
 
 
 def spin_once(node, *, timeout_sec=None):
-    # imported locally to avoid loading extensions on module import
-    from rclpy.executors import SingleThreadedExecutor
-    executor = SingleThreadedExecutor()
+    executor = get_global_executor()
     try:
         executor.add_node(node)
         executor.spin_once(timeout_sec=timeout_sec)
     finally:
-        executor.shutdown()
+        executor.remove_node(node)
 
 
 def spin(node):
-    # imported locally to avoid loading extensions on module import
-    from rclpy.executors import SingleThreadedExecutor
-    executor = SingleThreadedExecutor()
+    executor = get_global_executor()
     try:
         executor.add_node(node)
         while ok():
             executor.spin_once()
     finally:
-        executor.shutdown()
+        executor.remove_node(node)
 
 
 def spin_until_future_complete(node, future):
@@ -66,11 +84,9 @@ def spin_until_future_complete(node, future):
     :param future: The future object to wait on.
     :type future: rclpy.task.Future
     """
-    # imported locally to avoid loading extensions on module import
-    from rclpy.executors import SingleThreadedExecutor
-    executor = SingleThreadedExecutor()
+    executor = get_global_executor()
     try:
         executor.add_node(node)
         executor.spin_until_future_complete(future)
     finally:
-        executor.shutdown()
+        executor.remove_node(node)

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -56,6 +56,20 @@ def create_node(node_name, *, namespace=None):
 
 
 def spin_once(node, *, timeout_sec=None):
+    """
+    Execute one item of work or wait until timeout expires.
+
+    One callback will be executed in a SingleThreadedExecutor as long as that
+    callback is ready before the timeout expires.
+
+    It is possible the work done may be for a node other than the one passed to this method
+    if the global executor has a partially completed coroutine.
+
+    :param node: A node to add to the executor to check for work.
+    :param timeout_sec: Maximum time in seconds to wait for work.
+    :return: Always returns None regardless whether work executes or timeout expires.
+    :rtype: None
+    """
     executor = get_global_executor()
     try:
         executor.add_node(node)
@@ -65,6 +79,16 @@ def spin_once(node, *, timeout_sec=None):
 
 
 def spin(node):
+    """
+    Execute work blocking until the library is shutdown.
+
+    Callbacks will be executed in a SingleThreadedExecutor until shutdown() is called.
+    This method blocks.
+
+    :param node: A node to add to the executor to check for work.
+    :return: Always returns None regardless whether work executes or timeout expires.
+    :rtype: None
+    """
     executor = get_global_executor()
     try:
         executor.add_node(node)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -177,6 +177,17 @@ class Executor:
             # Rebuild the wait set so it includes this new node
             _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
 
+    def remove_node(self, node):
+        """Stop managing this node's callbacks."""
+        with self._nodes_lock:
+            try:
+                self._nodes.add(node)
+            except KeyError:
+                pass
+            else:
+                # Rebuild the wait set so it doesn't include this node
+                _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+
     def get_nodes(self):
         """
         Return nodes which have been added to this executor.


### PR DESCRIPTION
This fixes a bug where coroutine callbacks that yield while being handled in `rclpy.spin_once()` never get executed again. The task is stored in the executor, but the executor is thrown away after spinning.

This PR makes the global methods reuse an executor. The test checks that a task which yields during `rclpy.spin_once()` gets resumed on a second invocation.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3935)](http://ci.ros2.org/job/ci_linux/3935/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1053)](http://ci.ros2.org/job/ci_linux-aarch64/1053/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3262)](http://ci.ros2.org/job/ci_osx/3262/)
    * Unrelated failure in `rcl.TestGetNodeNames__rmw_fastrtps_cpp.test_rcl_get_node_names`
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4033)](http://ci.ros2.org/job/ci_windows/4033/)
    *  false positive cmake warning ros2/build_cop#79 caused by race condition due to `--parallel`