### PR TITLE
Node accepts command line args and can ignore global args

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -49,10 +49,22 @@ def shutdown():
     _shutdown()
 
 
-def create_node(node_name, *, namespace=None):
+def create_node(node_name, *, cli_args=None, namespace=None, use_global_arguments=True):
+    """
+    Create an instance of :class:`rclpy.node.Node`.
+
+    :param node_name: A unique name to give to this node
+    :param cli_args: A list of strings of command line args to be used only by this node.
+    :param namespace: The namespace to which relative topic and service names will be prefixed.
+    :param use_global_arguments: False if the node should ignore process-wide command line args.
+    :return: An instance of a node
+    :rtype: :class:`rclpy.node.Node`
+    """
     # imported locally to avoid loading extensions on module import
     from rclpy.node import Node
-    return Node(node_name, namespace=namespace)
+    return Node(
+        node_name, cli_args=cli_args, namespace=namespace,
+        use_global_arguments=use_global_arguments)
 
 
 def spin_once(node, *, timeout_sec=None):

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -51,7 +51,7 @@ def check_for_type_support(msg_type):
 
 class Node:
 
-    def __init__(self, node_name, *, namespace=None):
+    def __init__(self, node_name, *, cli_args=None, namespace=None, use_global_arguments=True):
         self._handle = None
         self.publishers = []
         self.subscriptions = []
@@ -65,7 +65,8 @@ class Node:
         if not ok():
             raise NotInitializedException('cannot create node')
         try:
-            self._handle = _rclpy.rclpy_create_node(node_name, namespace)
+            self._handle = _rclpy.rclpy_create_node(
+                node_name, namespace, cli_args, use_global_arguments)
         except ValueError:
             # these will raise more specific errors if the name or namespace is bad
             validate_node_name(node_name)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -96,5 +96,29 @@ class TestNode(unittest.TestCase):
         node_logger.debug('test')
 
 
+class TestCreateNode(unittest.TestCase):
+
+    def test_use_global_arguments(self):
+        rclpy.init(args=['process_name', '__node:=global_node_name'])
+        try:
+            node1 = rclpy.create_node('my_node', namespace='/my_ns', use_global_arguments=True)
+            node2 = rclpy.create_node('my_node', namespace='/my_ns', use_global_arguments=False)
+            self.assertEqual('global_node_name', node1.get_name())
+            self.assertEqual('my_node', node2.get_name())
+            node1.destroy_node()
+            node2.destroy_node()
+        finally:
+            rclpy.shutdown()
+
+    def test_node_arguments(self):
+        rclpy.init()
+        try:
+            node = rclpy.create_node('my_node', namespace='/my_ns', cli_args=['__ns:=/foo/bar'])
+            self.assertEqual('/foo/bar', node.get_namespace())
+            node.destroy_node()
+        finally:
+            rclpy.shutdown()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds `cli_args` and `use_global_arguments` as keyword arguments to the node constructor.

I moved code from `remove_ros_arguments()` that created a c-array from a python sequence of strings into separate functions so I could reuse it. The downside is the c-strings in the array are now copied where before a pointer to the string was borrowed. I think reusing code is preferable to avoiding a copy in this case because removing ros arguments or creating a node is probably an infrequent task.

In progress while CI runs
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4300)](http://ci.ros2.org/job/ci_linux/4300/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1301)](http://ci.ros2.org/job/ci_linux-aarch64/1301/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3531)](http://ci.ros2.org/job/ci_osx/3531/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4379)](http://ci.ros2.org/job/ci_windows/4379/)

