### PR TITLE
call the original signal handler when receiving SIGINT during wait

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -410,9 +410,6 @@ class Executor:
                 clients_ready = _rclpy.rclpy_get_ready_entities('client', wait_set)
                 services_ready = _rclpy.rclpy_get_ready_entities('service', wait_set)
 
-            # Check sigint guard condition
-            if sigint_gc_handle in guards_ready:
-                raise KeyboardInterrupt
             _rclpy.rclpy_destroy_entity(sigint_gc)
 
             # Mark all guards as triggered before yielding any handlers since they're auto-taken

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -25,8 +25,9 @@ from rclpy.utilities import ok
 from rclpy.utilities import timeout_sec_to_nsec
 
 # TODO(wjwwood): make _rclpy_wait(...) thread-safe
-# Executor.spin_once() end's up calling _rclpy_wait(...), which right now is
-# not thread-safe, no matter if differnet wait sets are used or not.
+# Executor.spin_once() ends up calling _rclpy_wait(...), which right now is
+# not thread-safe, no matter if different wait sets are used or not.
+# See, for example, https://github.com/ros2/rclpy/issues/192
 g_wait_set_spinning_lock = Lock()
 g_wait_set_spinning = False
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -34,9 +34,9 @@
 static rcl_guard_condition_t * g_sigint_gc_handle;
 
 #ifdef _WIN32
-  _crt_signal_t g_original_signal_handler = NULL;
+_crt_signal_t g_original_signal_handler = NULL;
 #else
-  sig_t g_original_signal_handler = NULL;
+sig_t g_original_signal_handler = NULL;
 #endif  // _WIN32
 
 /// Catch signals


### PR DESCRIPTION
Fixes ros2/launch#80

Previously we just stored it and restored it after wait woke up.