### PR TITLE
Fix memory leaks

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2281,9 +2281,14 @@ rclpy_destroy_wait_set(PyObject * Py_UNUSED(self), PyObject * args)
   const rcl_ ## ENTITY_TYPE ## _t ** struct_ptr = wait_set->ENTITY_TYPE ## s; \
   for (idx = 0; idx < idx_max; idx ++) { \
     if (struct_ptr[idx]) { \
-      PyList_Append( \
-        entity_ready_list, \
-        PyLong_FromUnsignedLongLong((uint64_t) & struct_ptr[idx]->impl)); \
+      PyObject* obj = PyLong_FromUnsignedLongLong((uint64_t) & struct_ptr[idx]->impl); \
+      if (obj) { \
+        PyList_Append(entity_ready_list, obj); \
+        Py_DECREF(obj); \
+      } else { \
+        Py_DECREF(entity_ready_list); \
+        return NULL; \
+      } \
     } \
   } \
   return entity_ready_list;
@@ -2413,6 +2418,7 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
     "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
 
   void * taken_msg = convert_from_py(pymsg);
+  Py_DECREF(pymsg);
   if (!taken_msg) {
     // the function has set the Python error
     return NULL;


### PR DESCRIPTION
This fixes two memory leaks in rclpy.
Python Object reference count was not decreased where it is needed.