### PR TITLE
use test_msgs instead of std_msgs

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -27,7 +27,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
-  <test_depend>std_msgs</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclpy/test/test_callback_group.py
+++ b/rclpy/test/test_callback_group.py
@@ -18,7 +18,7 @@ from rcl_interfaces.srv import GetParameters
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.callback_groups import ReentrantCallbackGroup
-from std_msgs.msg import String
+from test_msgs.msg import Primitives
 
 
 class TestCallbackGroup(unittest.TestCase):
@@ -70,10 +70,10 @@ class TestCallbackGroup(unittest.TestCase):
         self.assertTrue(group.has_entity(tmr2))
 
     def test_create_subscription_with_group(self):
-        sub1 = self.node.create_subscription(String, 'chatter', lambda msg: print(msg))
+        sub1 = self.node.create_subscription(Primitives, 'chatter', lambda msg: print(msg))
         group = ReentrantCallbackGroup()
         sub2 = self.node.create_subscription(
-            String, 'chatter', lambda msg: print(msg), callback_group=group)
+            Primitives, 'chatter', lambda msg: print(msg), callback_group=group)
 
         self.assertFalse(group.has_entity(sub1))
         self.assertTrue(group.has_entity(sub2))

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -98,7 +98,7 @@ def func_destroy_timers():
 
 def func_destroy_entities():
     import rclpy
-    from std_msgs.msg import Int16, Float32, String, UInt8
+    from test_msgs.msg import Primitives
     rclpy.init()
 
     node = rclpy.create_node('test_node4')
@@ -106,14 +106,16 @@ def func_destroy_entities():
     timer = node.create_timer(0.1, None)
     timer  # noqa
     assert 1 == len(node.timers)
-    pub1 = node.create_publisher(Int16, 'pub1_topic')
+    pub1 = node.create_publisher(Primitives, 'pub1_topic')
     assert 1 == len(node.publishers)
-    pub2 = node.create_publisher(Float32, 'pub2_topic')
+    pub2 = node.create_publisher(Primitives, 'pub2_topic')
     pub2  # noqa
     assert 2 == len(node.publishers)
-    sub1 = node.create_subscription(String, 'sub1_topic', lambda msg: print('Received %r' % msg))
+    sub1 = node.create_subscription(
+        Primitives, 'sub1_topic', lambda msg: print('Received %r' % msg))
     assert 1 == len(node.subscriptions)
-    sub2 = node.create_subscription(UInt8, 'sub2_topic', lambda msg: print('Received %r' % msg))
+    sub2 = node.create_subscription(
+        Primitives, 'sub2_topic', lambda msg: print('Received %r' % msg))
     sub2  # noqa
     assert 2 == len(node.subscriptions)
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -18,7 +18,7 @@ from rcl_interfaces.srv import GetParameters
 import rclpy
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
-from std_msgs.msg import String
+from test_msgs.msg import Primitives
 
 TEST_NODE = 'my_node'
 TEST_NAMESPACE = '/my_ns'
@@ -44,22 +44,22 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_namespace(), TEST_NAMESPACE)
 
     def test_create_publisher(self):
-        self.node.create_publisher(String, 'chatter')
+        self.node.create_publisher(Primitives, 'chatter')
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
-            self.node.create_publisher(String, 'chatter?')
+            self.node.create_publisher(Primitives, 'chatter?')
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
-            self.node.create_publisher(String, '/chatter/42_is_the_answer')
+            self.node.create_publisher(Primitives, '/chatter/42_is_the_answer')
         with self.assertRaisesRegex(ValueError, 'unknown substitution'):
-            self.node.create_publisher(String, 'chatter/{bad_sub}')
+            self.node.create_publisher(Primitives, 'chatter/{bad_sub}')
 
     def test_create_subscription(self):
-        self.node.create_subscription(String, 'chatter', lambda msg: print(msg))
+        self.node.create_subscription(Primitives, 'chatter', lambda msg: print(msg))
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
-            self.node.create_subscription(String, 'chatter?', lambda msg: print(msg))
+            self.node.create_subscription(Primitives, 'chatter?', lambda msg: print(msg))
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
-            self.node.create_subscription(String, '/chatter/42ish', lambda msg: print(msg))
+            self.node.create_subscription(Primitives, '/chatter/42ish', lambda msg: print(msg))
         with self.assertRaisesRegex(ValueError, 'unknown substitution'):
-            self.node.create_subscription(String, 'foo/{bad_sub}', lambda msg: print(msg))
+            self.node.create_subscription(Primitives, 'foo/{bad_sub}', lambda msg: print(msg))
 
     def test_create_client(self):
         self.node.create_client(GetParameters, 'get/parameters')
@@ -99,15 +99,15 @@ class TestNode(unittest.TestCase):
         self.assertEqual(0, self.node.count_publishers(fq_topic_name))
         self.assertEqual(0, self.node.count_subscribers(fq_topic_name))
 
-        self.node.create_publisher(String, short_topic_name)
+        self.node.create_publisher(Primitives, short_topic_name)
         self.assertEqual(1, self.node.count_publishers(short_topic_name))
         self.assertEqual(1, self.node.count_publishers(fq_topic_name))
 
-        self.node.create_subscription(String, short_topic_name, lambda msg: print(msg))
+        self.node.create_subscription(Primitives, short_topic_name, lambda msg: print(msg))
         self.assertEqual(1, self.node.count_subscribers(short_topic_name))
         self.assertEqual(1, self.node.count_subscribers(fq_topic_name))
 
-        self.node.create_subscription(String, short_topic_name, lambda msg: print(msg))
+        self.node.create_subscription(Primitives, short_topic_name, lambda msg: print(msg))
         self.assertEqual(2, self.node.count_subscribers(short_topic_name))
         self.assertEqual(2, self.node.count_subscribers(fq_topic_name))
 


### PR DESCRIPTION
To be backported in bouncy https://github.com/ros2/ros2/issues/537

Allows to release the `rclpy` repo without needing to release `common_interfaces` first

Connects to https://github.com/ros2/rcl/pull/270
CI at https://github.com/ros2/rcl/pull/270#issue-201414918