### PR TITLE
TimeSource and support for ROS time

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -51,7 +51,6 @@ class Clock:
     @ros_time_is_active.setter
     def ros_time_is_active(self, enabled):
         # TODO(dhood): Move to ROS_TIME-specific subclass?
-        from rclpy.time import Time
         if self.clock_type != ClockType.ROS_TIME:
             raise RuntimeError('Only valid for clocks using ROS_TIME')
         _rclpy.rclpy_clock_set_ros_time_override_is_enabled(self._clock_handle, enabled)

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -34,14 +34,19 @@ class Clock:
     def __init__(self, *, clock_type=ClockType.SYSTEM_TIME):
         if not isinstance(clock_type, ClockType):
             raise TypeError('Clock type must be a ClockType enum')
-        if clock_type is ClockType.ROS_TIME:
-            raise NotImplementedError
         self._clock_handle = _rclpy.rclpy_create_clock(clock_type)
         self._clock_type = clock_type
 
     @property
     def clock_type(self):
         return self._clock_type
+
+    @property
+    def ros_time_is_active(self):
+        # TODO(dhood): Move to ROS_TIME-specific subclass?
+        if self.clock_type != ClockType.ROS_TIME:
+            raise RuntimeError('Only valid for clocks using ROS_TIME')
+        return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)
 
     def __repr__(self):
         return 'Clock(clock_type={0})'.format(self.clock_type.name)
@@ -53,3 +58,13 @@ class Clock:
         return Time(
             nanoseconds=_rclpy.rclpy_time_point_get_nanoseconds(time_handle),
             clock_type=self.clock_type)
+
+    def set_ros_time_override(self, time):
+        # TODO(dhood): Move to ROS_TIME-specific subclass?
+        from rclpy.time import Time
+        if self.clock_type != ClockType.ROS_TIME:
+            raise RuntimeError('Only valid for clocks using ROS_TIME')
+        if not isinstance(time, Time):
+            TypeError(
+                'Time must be specified as rclpy.time.Time. Received type: {0}'.format(type(time)))
+        _rclpy.rclpy_clock_set_ros_time_override(self._clock_handle, time._time_handle)

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -60,6 +60,9 @@ class Clock:
 
 class ROSClock(Clock):
 
+    def __new__(cls):
+        return super().__new__(Clock, clock_type=ClockType.ROS_TIME)
+
     @property
     def ros_time_is_active(self):
         return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -31,11 +31,16 @@ class ClockType(IntEnum):
 
 class Clock:
 
-    def __init__(self, *, clock_type=ClockType.SYSTEM_TIME):
+    def __new__(cls, *, clock_type=ClockType.SYSTEM_TIME):
         if not isinstance(clock_type, ClockType):
             raise TypeError('Clock type must be a ClockType enum')
+        if clock_type is ClockType.ROS_TIME:
+            self = super().__new__(ROSClock)
+        else:
+            self = super().__new__(cls)
         self._clock_handle = _rclpy.rclpy_create_clock(clock_type)
         self._clock_type = clock_type
+        return self
 
     @property
     def clock_type(self):
@@ -54,9 +59,6 @@ class Clock:
 
 
 class ROSClock(Clock):
-
-    def __init__(self):
-        super(ROSClock, self).__init__(clock_type=ClockType.ROS_TIME)
 
     @property
     def ros_time_is_active(self):

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -41,20 +41,6 @@ class Clock:
     def clock_type(self):
         return self._clock_type
 
-    @property
-    def ros_time_is_active(self):
-        # TODO(dhood): Move to ROS_TIME-specific subclass?
-        if self.clock_type != ClockType.ROS_TIME:
-            raise RuntimeError('Only valid for clocks using ROS_TIME')
-        return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)
-
-    def _set_ros_time_is_active(self, enabled):
-        # This is not public because it is only to be called by a TimeSource managing the Clock
-        # TODO(dhood): Move to ROS_TIME-specific subclass?
-        if self.clock_type != ClockType.ROS_TIME:
-            raise RuntimeError('Only valid for clocks using ROS_TIME')
-        _rclpy.rclpy_clock_set_ros_time_override_is_enabled(self._clock_handle, enabled)
-
     def __repr__(self):
         return 'Clock(clock_type={0})'.format(self.clock_type.name)
 
@@ -66,8 +52,25 @@ class Clock:
             nanoseconds=_rclpy.rclpy_time_point_get_nanoseconds(time_handle),
             clock_type=self.clock_type)
 
+
+class ROSClock(Clock):
+
+    def __init__(self):
+        super(ROSClock, self).__init__(clock_type=ClockType.ROS_TIME)
+
+    @property
+    def ros_time_is_active(self):
+        if self.clock_type != ClockType.ROS_TIME:
+            raise RuntimeError('Only valid for clocks using ROS_TIME')
+        return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)
+
+    def _set_ros_time_is_active(self, enabled):
+        # This is not public because it is only to be called by a TimeSource managing the Clock
+        if self.clock_type != ClockType.ROS_TIME:
+            raise RuntimeError('Only valid for clocks using ROS_TIME')
+        _rclpy.rclpy_clock_set_ros_time_override_is_enabled(self._clock_handle, enabled)
+
     def set_ros_time_override(self, time):
-        # TODO(dhood): Move to ROS_TIME-specific subclass?
         from rclpy.time import Time
         if self.clock_type != ClockType.ROS_TIME:
             raise RuntimeError('Only valid for clocks using ROS_TIME')

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -60,20 +60,14 @@ class ROSClock(Clock):
 
     @property
     def ros_time_is_active(self):
-        if self.clock_type != ClockType.ROS_TIME:
-            raise RuntimeError('Only valid for clocks using ROS_TIME')
         return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)
 
     def _set_ros_time_is_active(self, enabled):
         # This is not public because it is only to be called by a TimeSource managing the Clock
-        if self.clock_type != ClockType.ROS_TIME:
-            raise RuntimeError('Only valid for clocks using ROS_TIME')
         _rclpy.rclpy_clock_set_ros_time_override_is_enabled(self._clock_handle, enabled)
 
     def set_ros_time_override(self, time):
         from rclpy.time import Time
-        if self.clock_type != ClockType.ROS_TIME:
-            raise RuntimeError('Only valid for clocks using ROS_TIME')
         if not isinstance(time, Time):
             TypeError(
                 'Time must be specified as rclpy.time.Time. Received type: {0}'.format(type(time)))

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -48,8 +48,8 @@ class Clock:
             raise RuntimeError('Only valid for clocks using ROS_TIME')
         return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)
 
-    @ros_time_is_active.setter
-    def ros_time_is_active(self, enabled):
+    def _set_ros_time_is_active(self, enabled):
+        # This is not public because it is only to be called by a TimeSource managing the Clock
         # TODO(dhood): Move to ROS_TIME-specific subclass?
         if self.clock_type != ClockType.ROS_TIME:
             raise RuntimeError('Only valid for clocks using ROS_TIME')

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -48,6 +48,14 @@ class Clock:
             raise RuntimeError('Only valid for clocks using ROS_TIME')
         return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(self._clock_handle)
 
+    @ros_time_is_active.setter
+    def ros_time_is_active(self, enabled):
+        # TODO(dhood): Move to ROS_TIME-specific subclass?
+        from rclpy.time import Time
+        if self.clock_type != ClockType.ROS_TIME:
+            raise RuntimeError('Only valid for clocks using ROS_TIME')
+        _rclpy.rclpy_clock_set_ros_time_override_is_enabled(self._clock_handle, enabled)
+
     def __repr__(self):
         return 'Clock(clock_type={0})'.format(self.clock_type.name)
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -14,6 +14,8 @@
 
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.client import Client
+from rclpy.clock import Clock
+from rclpy.clock import ClockType
 from rclpy.constants import S_TO_NS
 from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import NoTypeSupportImportedException
@@ -25,6 +27,7 @@ from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default, qos_profile_services_default
 from rclpy.service import Service
 from rclpy.subscription import Subscription
+from rclpy.time_source import TimeSource
 from rclpy.timer import WallTimer
 from rclpy.utilities import ok
 from rclpy.validate_full_topic_name import validate_full_topic_name
@@ -80,6 +83,11 @@ class Node:
             raise RuntimeError('rclpy_create_node failed for unknown reason')
         self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(self.handle))
 
+        # Clock that has support for ROS time (uses sim time if parameter has been set on the node)
+        self._clock = Clock(clock_type=ClockType.ROS_TIME)
+        self._time_source = TimeSource(node=self)
+        self._time_source.attach_clock(self._clock)
+
     @property
     def handle(self):
         return self._handle
@@ -93,6 +101,9 @@ class Node:
 
     def get_namespace(self):
         return _rclpy.rclpy_get_node_namespace(self.handle)
+
+    def get_clock(self):
+        return self._clock
 
     def get_logger(self):
         return self._logger

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -14,8 +14,7 @@
 
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.client import Client
-from rclpy.clock import Clock
-from rclpy.clock import ClockType
+from rclpy.clock import ROSClock
 from rclpy.constants import S_TO_NS
 from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import NoTypeSupportImportedException
@@ -83,8 +82,9 @@ class Node:
             raise RuntimeError('rclpy_create_node failed for unknown reason')
         self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(self.handle))
 
-        # Clock that has support for ROS time (uses sim time if parameter has been set on the node)
-        self._clock = Clock(clock_type=ClockType.ROS_TIME)
+        # Clock that has support for ROS time.
+        # TODO(dhood): use sim time if parameter has been set on the node.
+        self._clock = ROSClock()
         self._time_source = TimeSource(node=self)
         self._time_source.attach_clock(self._clock)
 

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -39,7 +39,7 @@ class TimeSource:
     def ros_time_is_active(self, enabled):
         self._ros_time_is_active = enabled
         for clock in self._associated_clocks:
-            clock.ros_time_is_active = True
+            clock._set_ros_time_is_active(True)
 
     def _subscribe_to_clock_topic(self):
         if self._clock_sub is not None and self._node is not None:
@@ -76,7 +76,7 @@ class TimeSource:
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
         if self._last_time_set is not None:
             self._set_clock(self._last_time_set, clock)
-        clock.ros_time_is_active = self.ros_time_is_active
+        clock._set_ros_time_is_active(self.ros_time_is_active)
         self._associated_clocks.append(clock)
 
     def clock_callback(self, msg):

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -1,0 +1,78 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtin_interfaces.msg
+from rclpy.clock import Clock
+from rclpy.clock import ClockType
+from rclpy.node import Node
+from rclpy.time import Time
+
+CLOCK_TOPIC = '/clock'
+
+
+class TimeSource:
+
+    def __init__(self, *, node=None):
+        self._clock_sub = None
+        self._node = None
+        self._associated_clocks = []
+        self._last_time_set = None
+        if node is not None:
+            self.attach_node(node)
+
+    def attach_node(self, node):
+        if not isinstance(node, Node):
+            raise TypeError('Node must be of type rclpy.node.Node')
+        # Remove an existing node.
+        if self._node is not None:
+            self.detach_node()
+
+        # Create a subscription to the clock topic using the node.
+        self._clock_sub = node.create_subscription(
+            builtin_interfaces.msg.Time,
+            CLOCK_TOPIC,
+            self.clock_callback
+        )
+        self._node = node
+
+    def detach_node(self):
+        # Remove the subscription to the clock topic.
+        if self._clock_sub is not None:
+            if self._node is None:
+                print('Unable to destroy previously created clock subscription')
+            else:
+                self._node.destroy_subscription(self._clock_sub)
+        self._clock_sub = None
+        self._node = None
+
+    def attach_clock(self, clock):
+        if not isinstance(clock, Clock):
+            raise TypeError('Clock must be of type rclpy.clock.Clock')
+        if not clock.clock_type == ClockType.ROS_TIME:
+            raise ValueError('Only clocks with type ROS_TIME can be attached.')
+        if self._last_time_set is not None:
+            self._set_clock(self._last_time_set, clock)
+        self._associated_clocks.append(clock)
+
+    def clock_callback(self, msg):
+        # Cache the last message in case a new clock is attached.
+        time_from_msg = Time.from_msg(msg)
+        self._last_time_set = time_from_msg
+        for clock in self._associated_clocks:
+            self._set_clock(time_from_msg, clock)
+
+    def _set_clock(self, time, clock):
+        # TODO(dhood): clock jump notifications
+        # if clock.ros_time_is_active:
+        clock.set_ros_time_override(time)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -39,10 +39,12 @@ class TimeSource:
     def ros_time_is_active(self, enabled):
         self._ros_time_is_active = enabled
         for clock in self._associated_clocks:
-            clock._set_ros_time_is_active(True)
+            clock._set_ros_time_is_active(enabled)
+        if enabled:
+            self._subscribe_to_clock_topic()
 
     def _subscribe_to_clock_topic(self):
-        if self._clock_sub is not None and self._node is not None:
+        if self._clock_sub is None and self._node is not None:
             self._clock_sub = self._node.create_subscription(
                 builtin_interfaces.msg.Time,
                 CLOCK_TOPIC,
@@ -57,7 +59,8 @@ class TimeSource:
         if self._node is not None:
             self.detach_node()
         self._node = node
-        self._subscribe_to_clock_topic()
+        if self.ros_time_is_active:
+            self._subscribe_to_clock_topic()
 
     def detach_node(self):
         # Remove the subscription to the clock topic.

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -15,6 +15,7 @@
 import builtin_interfaces.msg
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
+from rclpy.clock import ROSClock
 from rclpy.time import Time
 
 CLOCK_TOPIC = '/clock'
@@ -76,6 +77,8 @@ class TimeSource:
             raise TypeError('Clock must be of type rclpy.clock.Clock')
         if not clock.clock_type == ClockType.ROS_TIME:
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
+        # "Cast" to ROSClock subclass so ROS time methods can be used.
+        clock.__class__ = ROSClock
         if self._last_time_set is not None:
             self._set_clock(self._last_time_set, clock)
         clock._set_ros_time_is_active(self.ros_time_is_active)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -66,9 +66,8 @@ class TimeSource:
         # Remove the subscription to the clock topic.
         if self._clock_sub is not None:
             if self._node is None:
-                print('Unable to destroy previously created clock subscription')
-            else:
-                self._node.destroy_subscription(self._clock_sub)
+                raise RuntimeError('Unable to destroy previously created clock subscription')
+            self._node.destroy_subscription(self._clock_sub)
         self._clock_sub = None
         self._node = None
 

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -15,7 +15,6 @@
 import builtin_interfaces.msg
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
-from rclpy.node import Node
 from rclpy.time import Time
 
 CLOCK_TOPIC = '/clock'
@@ -32,6 +31,7 @@ class TimeSource:
             self.attach_node(node)
 
     def attach_node(self, node):
+        from rclpy.node import Node
         if not isinstance(node, Node):
             raise TypeError('Node must be of type rclpy.node.Node')
         # Remove an existing node.

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -74,5 +74,5 @@ class TimeSource:
 
     def _set_clock(self, time, clock):
         # TODO(dhood): clock jump notifications
-        # if clock.ros_time_is_active:
-        clock.set_ros_time_override(time)
+        if clock.ros_time_is_active:
+            clock.set_ros_time_override(time)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import builtin_interfaces.msg
-from rclpy.clock import Clock
-from rclpy.clock import ClockType
 from rclpy.clock import ROSClock
 from rclpy.time import Time
 
@@ -73,12 +71,8 @@ class TimeSource:
         self._node = None
 
     def attach_clock(self, clock):
-        if not isinstance(clock, Clock):
-            raise TypeError('Clock must be of type rclpy.clock.Clock')
-        if not clock.clock_type == ClockType.ROS_TIME:
+        if not isinstance(clock, ROSClock):
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
-        # "Cast" to ROSClock subclass so ROS time methods can be used.
-        clock.__class__ = ROSClock
         if self._last_time_set is not None:
             self._set_clock(self._last_time_set, clock)
         clock._set_ros_time_is_active(self.ros_time_is_active)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3304,8 +3304,8 @@ static PyObject *
 rclpy_clock_set_ros_time_override_is_enabled(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pyclock;
-  PyObject * pyenabled;
-  if (!PyArg_ParseTuple(args, "OO", &pyclock, &pyenabled)) {
+  bool enabled;
+  if (!PyArg_ParseTuple(args, "Op", &pyclock, &enabled)) {
     return NULL;
   }
 
@@ -3314,8 +3314,6 @@ rclpy_clock_set_ros_time_override_is_enabled(PyObject * Py_UNUSED(self), PyObjec
   if (!clock) {
     return NULL;
   }
-
-  bool enabled = PyObject_IsTrue(pyenabled);
 
   rcl_ret_t ret;
   if (enabled) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3304,7 +3304,7 @@ static PyObject *
 rclpy_clock_set_ros_time_override_is_enabled(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pyclock;
-  bool enabled;
+  int enabled;
   if (!PyArg_ParseTuple(args, "Op", &pyclock, &enabled)) {
     return NULL;
   }

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -17,6 +17,7 @@ import unittest
 
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
+from rclpy.clock import ROSClock
 from rclpy.time import Time
 
 
@@ -28,12 +29,14 @@ class TestClock(unittest.TestCase):
         with self.assertRaises(TypeError):
             clock = Clock(clock_type='STEADY_TIME')
 
-        clock = Clock(clock_type=ClockType.ROS_TIME)
-        assert clock.clock_type == ClockType.ROS_TIME
         clock = Clock(clock_type=ClockType.STEADY_TIME)
         assert clock.clock_type == ClockType.STEADY_TIME
         clock = Clock(clock_type=ClockType.SYSTEM_TIME)
         assert clock.clock_type == ClockType.SYSTEM_TIME
+        # A subclass ROSClock is returned if ROS_TIME is specified.
+        clock = Clock(clock_type=ClockType.ROS_TIME)
+        assert clock.clock_type == ClockType.ROS_TIME
+        assert isinstance(clock, ROSClock)
 
     def test_clock_now(self):
         # System time should be roughly equal to time.time()

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -38,6 +38,10 @@ class TestClock(unittest.TestCase):
         assert clock.clock_type == ClockType.ROS_TIME
         assert isinstance(clock, ROSClock)
 
+        # Direct instantiation of a ROSClock is also possible.
+        clock = ROSClock()
+        assert clock.clock_type == ClockType.ROS_TIME
+
     def test_clock_now(self):
         # System time should be roughly equal to time.time()
         # There will still be differences between them, with the bound depending on the scheduler.

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -28,8 +28,8 @@ class TestClock(unittest.TestCase):
         with self.assertRaises(TypeError):
             clock = Clock(clock_type='STEADY_TIME')
 
-        with self.assertRaises(NotImplementedError):
-            clock = Clock(clock_type=ClockType.ROS_TIME)
+        clock = Clock(clock_type=ClockType.ROS_TIME)
+        assert clock.clock_type == ClockType.ROS_TIME
         clock = Clock(clock_type=ClockType.STEADY_TIME)
         assert clock.clock_type == ClockType.STEADY_TIME
         clock = Clock(clock_type=ClockType.SYSTEM_TIME)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -16,6 +16,7 @@ import unittest
 
 from rcl_interfaces.srv import GetParameters
 import rclpy
+from rclpy.clock import ClockType
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
 from test_msgs.msg import Primitives
@@ -42,6 +43,7 @@ class TestNode(unittest.TestCase):
             self.node.handle = 'garbage'
         self.assertEqual(self.node.get_name(), TEST_NODE)
         self.assertEqual(self.node.get_namespace(), TEST_NAMESPACE)
+        self.assertEqual(self.node.get_clock().clock_type, ClockType.ROS_TIME)
 
     def test_create_publisher(self):
         self.node.create_publisher(Primitives, 'chatter')

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -50,8 +50,7 @@ class TestTimeSource(unittest.TestCase):
         time_source.attach_clock(clock)
 
         # When using sim time, ROS time should look like the messages received on /clock
-        # Receiving messages will currently cause the clock to have ROS time override enabled
-        # TODO(dhood): Remove the automatic use of sim time.
+        clock.ros_time_is_active = True
 
         # Publish to the clock topic
         clock_pub = self.node.create_publisher(builtin_interfaces.msg.Time, CLOCK_TOPIC)

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -53,11 +53,7 @@ class TestTimeSource(unittest.TestCase):
         # ROSClock is a specialization of Clock with ROS time methods.
         time_source.attach_clock(ROSClock())
 
-        # A clock of type ROS_TIME can be attached. It will be converted to a ROSClock for storage.
-        time_source.attach_clock(Clock(clock_type=ClockType.ROS_TIME))
-
-        assert all((isinstance(clock, ROSClock) for clock in time_source._associated_clocks))
-
+        # Other clock types are not supported.
         with self.assertRaises(ValueError):
             time_source.attach_clock(Clock(clock_type=ClockType.SYSTEM_TIME))
 

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -70,6 +70,7 @@ class TestTimeSource(unittest.TestCase):
         clock2._set_ros_time_is_active(True)
         time_source.attach_clock(clock2)
         self.assertFalse(clock2.ros_time_is_active)
+        assert time_source._clock_sub is None
 
     def test_time_source_using_sim_time(self):
         time_source = TimeSource(node=self.node)
@@ -83,6 +84,9 @@ class TestTimeSource(unittest.TestCase):
         time_source.ros_time_is_active = True
         self.assertTrue(time_source.ros_time_is_active)
         self.assertTrue(clock.ros_time_is_active)
+
+        # A subscriber should have been created
+        assert time_source._clock_sub is not None
 
         # When using sim time, ROS time should look like the messages received on /clock
         self.publish_clock_messages()

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -50,6 +50,7 @@ class TestTimeSource(unittest.TestCase):
         time_source = TimeSource(node=self.node)
         clock = Clock(clock_type=ClockType.ROS_TIME)
         time_source.attach_clock(clock)
+        self.assertFalse(clock.ros_time_is_active)
 
         # When not using sim time, ROS time should look like system time
         now = clock.now()
@@ -67,9 +68,11 @@ class TestTimeSource(unittest.TestCase):
         clock = Clock(clock_type=ClockType.ROS_TIME)
         time_source.attach_clock(clock)
 
-        # When using sim time, ROS time should look like the messages received on /clock
+        # Check attribute getting/setting
         clock.ros_time_is_active = True
+        self.assertTrue(clock.ros_time_is_active)
 
+        # When using sim time, ROS time should look like the messages received on /clock
         self.publish_clock_messages()
         assert clock.now() > Time(seconds=0, clock_type=ClockType.ROS_TIME)
         assert clock.now() <= Time(seconds=5, clock_type=ClockType.ROS_TIME)

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -92,3 +92,17 @@ class TestTimeSource(unittest.TestCase):
         self.publish_clock_messages()
         assert clock.now() > Time(seconds=0, clock_type=ClockType.ROS_TIME)
         assert clock.now() <= Time(seconds=5, clock_type=ClockType.ROS_TIME)
+
+        # Check that attached clocks get the cached message
+        clock2 = Clock(clock_type=ClockType.ROS_TIME)
+        time_source.attach_clock(clock2)
+        assert clock2.now() > Time(seconds=0, clock_type=ClockType.ROS_TIME)
+        assert clock2.now() <= Time(seconds=5, clock_type=ClockType.ROS_TIME)
+
+        # Check detaching the node
+        time_source.detach_node()
+        node2 = rclpy.create_node('TestTimeSource2', namespace='/rclpy')
+        time_source.attach_node(node2)
+        node2.destroy_node()
+        assert time_source._node == node2
+        assert time_source._clock_sub is not None

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -67,10 +67,9 @@ class TestTimeSource(unittest.TestCase):
         # source managing it.
         self.assertFalse(time_source.ros_time_is_active)
         clock2 = Clock(clock_type=ClockType.ROS_TIME)
-        clock2.ros_time_is_active = True
+        clock2._set_ros_time_is_active(True)
         time_source.attach_clock(clock2)
         self.assertFalse(clock2.ros_time_is_active)
-        
 
     def test_time_source_using_sim_time(self):
         time_source = TimeSource(node=self.node)

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+
+import builtin_interfaces.msg
+import rclpy
+from rclpy.clock import Clock
+from rclpy.clock import ClockType
+from rclpy.time import Time
+from rclpy.time_source import CLOCK_TOPIC
+from rclpy.time_source import TimeSource
+
+
+class TestTimeSource(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = rclpy.create_node('TestTimeSource', namespace='/rclpy')
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_time_source_not_using_sim_time(self):
+        time_source = TimeSource(node=self.node)
+        clock = Clock(clock_type=ClockType.ROS_TIME)
+        time_source.attach_clock(clock)
+
+        # When not using sim time, ROS time should look like system time
+        now = clock.now()
+        system_now = Clock(clock_type=ClockType.SYSTEM_TIME).now()
+        assert (system_now.nanoseconds - now.nanoseconds) < 1e9
+
+    def test_time_source_using_sim_time(self):
+        time_source = TimeSource(node=self.node)
+        clock = Clock(clock_type=ClockType.ROS_TIME)
+        time_source.attach_clock(clock)
+
+        # When using sim time, ROS time should look like the messages received on /clock
+        # Receiving messages will currently cause the clock to have ROS time override enabled
+        # TODO(dhood): Remove the automatic use of sim time.
+
+        # Publish to the clock topic
+        clock_pub = self.node.create_publisher(builtin_interfaces.msg.Time, CLOCK_TOPIC)
+        cycle_count = 0
+        time_msg = builtin_interfaces.msg.Time()
+        while rclpy.ok() and cycle_count < 5:
+            time_msg.sec = cycle_count
+            clock_pub.publish(time_msg)
+            cycle_count += 1
+            rclpy.spin_once(self.node, timeout_sec=1)
+            # TODO(dhood): use rate once available
+            time.sleep(1)
+        assert clock.now() > Time(seconds=0, clock_type=ClockType.ROS_TIME)
+        assert clock.now() <= Time(seconds=5, clock_type=ClockType.ROS_TIME)


### PR DESCRIPTION
Connects to ros2/rclpy#186

Requires ros2/rcl#274

Gives nodes a clock of type ROS_TIME which will reflect the time received on `/clock` topic if the Time Source has had use of ROS time activated. Since parameters aren't available in python yet, there's no support for the `use_sim_time` parameter, but the Time Source can have ROS time activated manually by calling `time_source.ros_time_is_active = True`.

Support for clock jump notifiers not targeted for this PR.