### PR TITLE
Alternative way of giving timers a clock

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -248,7 +248,7 @@ class Node:
             if tmr.timer_handle == timer.timer_handle:
                 _rclpy.rclpy_destroy_entity(tmr.timer_handle)
                 # TODO(sloretz) Store clocks on node and destroy them separately
-                _rclpy.rclpy_destroy_entity(tmr._clock._clock_handle)
+                _rclpy.rclpy_destroy_entity(tmr.clock._clock_handle)
                 self.timers.remove(tmr)
                 return True
         return False
@@ -282,7 +282,7 @@ class Node:
             tmr = self.timers.pop()
             _rclpy.rclpy_destroy_entity(tmr.timer_handle)
             # TODO(sloretz) Store clocks on node and destroy them separately
-            _rclpy.rclpy_destroy_entity(tmr._clock._clock_handle)
+            _rclpy.rclpy_destroy_entity(tmr.clock._clock_handle)
         while self.guards:
             gc = self.guards.pop()
             _rclpy.rclpy_destroy_entity(gc.guard_handle)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -247,6 +247,8 @@ class Node:
         for tmr in self.timers:
             if tmr.timer_handle == timer.timer_handle:
                 _rclpy.rclpy_destroy_entity(tmr.timer_handle)
+                # TODO(sloretz) Store clocks on node and destroy them separately
+                _rclpy.rclpy_destroy_entity(tmr._clock._clock_handle)
                 self.timers.remove(tmr)
                 return True
         return False
@@ -279,6 +281,8 @@ class Node:
         while self.timers:
             tmr = self.timers.pop()
             _rclpy.rclpy_destroy_entity(tmr.timer_handle)
+            # TODO(sloretz) Store clocks on node and destroy them separately
+            _rclpy.rclpy_destroy_entity(tmr._clock._clock_handle)
         while self.guards:
             gc = self.guards.pop()
             _rclpy.rclpy_destroy_entity(gc.guard_handle)

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rclpy.clock import Clock
+from rclpy.clock import ClockType
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
@@ -19,7 +21,10 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 class WallTimer:
 
     def __init__(self, callback, callback_group, timer_period_ns):
-        [self.timer_handle, self.timer_pointer, _] = _rclpy.rclpy_create_timer(timer_period_ns)
+        # TODO(sloretz) Allow passing clocks in via timer constructor
+        self._clock = Clock(clock_type=ClockType.STEADY_TIME)
+        [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(
+            timer_period_ns, self._clock._clock_handle)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
         self.callback_group = callback_group

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -24,7 +24,7 @@ class WallTimer:
         # TODO(sloretz) Allow passing clocks in via timer constructor
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(
-            timer_period_ns, self._clock._clock_handle)
+            self._clock._clock_handle, timer_period_ns)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
         self.callback_group = callback_group

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -32,6 +32,10 @@ class WallTimer:
         self._executor_event = False
 
     @property
+    def clock(self):
+        return self._clock
+
+    @property
     def timer_period_ns(self):
         val = _rclpy.rclpy_get_timer_period(self.timer_handle)
         self._timer_period_ns = val

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2087,6 +2087,7 @@ rclpy_destroy_entity(PyObject * Py_UNUSED(self), PyObject * args)
   } else if (PyCapsule_IsValid(pyentity, "rcl_clock_t")) {
     PyCapsule_SetDestructor(pyentity, NULL);
     _rclpy_destroy_clock(pyentity);
+    ret = RCL_RET_OK;
   } else if (PyCapsule_IsValid(pyentity, "rcl_guard_condition_t")) {
     rcl_guard_condition_t * guard_condition = (rcl_guard_condition_t *)PyCapsule_GetPointer(
       pyentity, "rcl_guard_condition_t");

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2047,7 +2047,7 @@ _rclpy_destroy_clock(PyObject * pycapsule)
 {
   rcl_clock_t * clock = (rcl_clock_t *)PyCapsule_GetPointer(pycapsule, "rcl_clock_t");
   if (NULL == clock) {
-    // Exception raised
+    // exception was set by PyCapsule_GetPointer
     return;
   }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1180,9 +1180,9 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
  * Raises TypeError if argument of invalid type
  * Raises ValueError if argument cannot be converted to uint64_t
  *
+ * \param[in] clock pycapsule containing an rcl_clock_t
  * \param[in] period_nsec unsigned PyLong object storing the period of the
  *   timer in nanoseconds in a 64-bit unsigned integer
- * \param[in] clock pycapsule containing an rcl_clock_t
  * \return a list of the capsule and the memory address
  * \return NULL on failure
  */
@@ -1192,7 +1192,7 @@ rclpy_create_timer(PyObject * Py_UNUSED(self), PyObject * args)
   unsigned PY_LONG_LONG period_nsec;
   PyObject * pyclock;
 
-  if (!PyArg_ParseTuple(args, "KO", &period_nsec, &pyclock)) {
+  if (!PyArg_ParseTuple(args, "OK", &pyclock, &period_nsec)) {
     return NULL;
   }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2046,6 +2046,11 @@ void
 _rclpy_destroy_clock(PyObject * pycapsule)
 {
   rcl_clock_t * clock = (rcl_clock_t *)PyCapsule_GetPointer(pycapsule, "rcl_clock_t");
+  if (NULL == clock) {
+    // Exception raised
+    return;
+  }
+
   rcl_ret_t ret_clock = rcl_clock_fini(clock);
   PyMem_Free(clock);
   if (ret_clock != RCL_RET_OK) {


### PR DESCRIPTION
I was having trouble putting feedback for ros2/rclpy#211 into words. This passes the clock into `rclpy_create_timer()` instead of it being returned in an unused variable, and makes use of the cleanup code in `_rclpy_destroy_clock()`.