### PR TITLE
executor.add_node() returns a bool

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -180,9 +180,12 @@ class Executor:
         :rtype: bool
         """
         with self._nodes_lock:
-            self._nodes.add(node)
-            # Rebuild the wait set so it includes this new node
-            _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+            if node not in self._nodes:
+                self._nodes.add(node)
+                # Rebuild the wait set so it includes this new node
+                _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+                return True
+            return False
 
     def remove_node(self, node):
         """Stop managing this node's callbacks."""

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -40,7 +40,7 @@ class TestExecutor(unittest.TestCase):
 
         tmr = self.node.create_timer(0.1, timer_callback)
 
-        executor.add_node(self.node)
+        assert executor.add_node(self.node)
         executor.spin_once(timeout_sec=1.23)
         # TODO(sloretz) redesign test, sleeping to workaround race condition between test cleanup
         # and MultiThreadedExecutor thread pool
@@ -229,6 +229,12 @@ class TestExecutor(unittest.TestCase):
         trigger.do_yield = False
         rclpy.spin_once(self.node, timeout_sec=0)
         self.assertTrue(did_return)
+
+    def test_executor_add_node(self):
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor()
+        assert executor.add_node(self.node)
+        assert not executor.add_node(self.node)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The documentation for `executor.add_node()` says it returns `True` if the node was added; however it currently just returns `None`. This fixes the function, and also makes it so the guard condition to rebuild the waitset is only triggered if the node really was added.