### PR TITLE
Fix executor.remove_node()

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -188,7 +188,7 @@ class Executor:
         """Stop managing this node's callbacks."""
         with self._nodes_lock:
             try:
-                self._nodes.add(node)
+                self._nodes.remove(node)
             except KeyError:
                 pass
             else:

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -57,6 +57,29 @@ class TestExecutor(unittest.TestCase):
         finally:
             executor.shutdown()
 
+    def test_remove_node(self):
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor()
+
+        got_callback = False
+
+        def timer_callback():
+            nonlocal got_callback
+            got_callback = True
+
+        try:
+            tmr = self.node.create_timer(0.1, timer_callback)
+            try:
+                executor.add_node(self.node)
+                executor.remove_node(self.node)
+                executor.spin_once(timeout_sec=0.2)
+            finally:
+                self.node.destroy_timer(tmr)
+        finally:
+            executor.shutdown()
+
+        assert not got_callback
+
     def test_multi_threaded_executor_executes(self):
         self.assertIsNotNone(self.node.handle)
         executor = MultiThreadedExecutor()


### PR DESCRIPTION
`executor.remove_node()` was adding the node to `executor._nodes` instead of removing it. This PR fixes the function and adds a unit test.