### PR TITLE
Node has a reference to its executor

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -17,6 +17,7 @@ import inspect
 import multiprocessing
 from threading import Condition
 from threading import Lock
+from threading import RLock
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.task import Task
@@ -111,7 +112,7 @@ class Executor:
     def __init__(self):
         super().__init__()
         self._nodes = set()
-        self._nodes_lock = Lock()
+        self._nodes_lock = RLock()
         # Tasks to be executed (oldest first) 3-tuple Task, Entity, Node
         self._tasks = []
         self._tasks_lock = Lock()
@@ -182,6 +183,7 @@ class Executor:
         with self._nodes_lock:
             if node not in self._nodes:
                 self._nodes.add(node)
+                node.executor = self
                 # Rebuild the wait set so it includes this new node
                 _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
                 return True


### PR DESCRIPTION
This adds a property `node.executor` which accesses the executor the node has been added to. Internally the node stores the executor as a weak reference to avoid a reference cycle.

The purpose is to allow something with a node reference call executor functions. Specifically I want to make another PR where `TimeSource` calls `node.executor.create_task()` with time jump callbacks.

A nice side effect is `node.executor` enforces that a node has only been added to one executor. This should prevent the same entities from being waited on in multiple wait sets.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5021)](http://ci.ros2.org/job/ci_linux/5021/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1831)](http://ci.ros2.org/job/ci_linux-aarch64/1831/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4177)](http://ci.ros2.org/job/ci_osx/4177/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5032)](http://ci.ros2.org/job/ci_windows/5032/)
