### PR TITLE
Allow Duration to be negative

### DIFF
--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -19,8 +19,6 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 class Duration:
 
     def __init__(self, *, seconds=0, nanoseconds=0):
-        if seconds < 0:
-            raise ValueError('Seconds value must not be negative')
         if nanoseconds < 0:
             raise ValueError('Nanoseconds value must not be negative')
         total_nanoseconds = int(seconds * 1e9)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3106,21 +3106,16 @@ _rclpy_destroy_duration(PyObject * pycapsule)
  * Raises OverflowError if nanoseconds argument cannot be converted to uint64_t
  *
  * \param[in] nanoseconds unsigned PyLong object storing the nanoseconds value
- *   of the duration in a 64-bit unsigned integer
+ *   of the duration in a 64-bit signed integer
  * \return Capsule of the pointer to the created rcl_duration_t * structure, or
  * \return NULL on failure
  */
 static PyObject *
 rclpy_create_duration(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject * pylong_nanoseconds;
+  PY_LONG_LONG nanoseconds;
 
-  if (!PyArg_ParseTuple(args, "O", &pylong_nanoseconds)) {
-    return NULL;
-  }
-
-  unsigned PY_LONG_LONG nanoseconds = PyLong_AsUnsignedLongLong(pylong_nanoseconds);
-  if (PyErr_Occurred()) {
+  if (!PyArg_ParseTuple(args, "L", &nanoseconds)) {
     return NULL;
   }
 
@@ -3159,7 +3154,7 @@ rclpy_duration_get_nanoseconds(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  return PyLong_FromUnsignedLongLong(duration->nanoseconds);
+  return PyLong_FromLongLong(duration->nanoseconds);
 }
 
 /// Create a clock

--- a/rclpy/test/test_time.py
+++ b/rclpy/test/test_time.py
@@ -55,9 +55,14 @@ class TestTime(unittest.TestCase):
         duration = Duration(nanoseconds=2**63 - 1)
         assert duration.nanoseconds == 2**63 - 1
 
-        duration = Duration(seconds=-1)
+        assert Duration(seconds=-1).nanoseconds == -1 * 1000 * 1000 * 1000
         with self.assertRaises(ValueError):
             duration = Duration(nanoseconds=-1)
+
+        assert Duration(seconds=-2**63 / 1e9).nanoseconds == -2**63
+        with self.assertRaises(OverflowError):
+            # Much smaller number because float to integer conversion of seconds is imprecise
+            duration = Duration(seconds=-2**63 / 1e9 - 1)
 
     def test_time_operators(self):
         time1 = Time(nanoseconds=1, clock_type=ClockType.STEADY_TIME)

--- a/rclpy/test/test_time.py
+++ b/rclpy/test/test_time.py
@@ -51,12 +51,11 @@ class TestTime(unittest.TestCase):
         assert duration.nanoseconds == 1500000000
 
         with self.assertRaises(OverflowError):
-            duration = Duration(nanoseconds=2**64)
-        duration = Duration(nanoseconds=2**64 - 1)
-        assert duration.nanoseconds == 2**64 - 1
+            duration = Duration(nanoseconds=2**63)
+        duration = Duration(nanoseconds=2**63 - 1)
+        assert duration.nanoseconds == 2**63 - 1
 
-        with self.assertRaises(ValueError):
-            duration = Duration(seconds=-1)
+        duration = Duration(seconds=-1)
         with self.assertRaises(ValueError):
             duration = Duration(nanoseconds=-1)
 
@@ -81,7 +80,7 @@ class TestTime(unittest.TestCase):
         assert time2.clock_type == ClockType.STEADY_TIME
 
         with self.assertRaises(OverflowError):
-            Duration(nanoseconds=2**64 - 1) + Time(nanoseconds=1)
+            Duration(nanoseconds=1) + Time(nanoseconds=2**64 - 1)
 
         with self.assertRaises(ValueError):
             Time(nanoseconds=1) - Duration(nanoseconds=2)


### PR DESCRIPTION
This allows `Duration` instances to be negative as talked about in ros2/rclcpp#525. `Time` is unchanged and cannot have negative values in this PR.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5029)](http://ci.ros2.org/job/ci_linux/5029/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1836)](http://ci.ros2.org/job/ci_linux-aarch64/1836/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4182)](http://ci.ros2.org/job/ci_osx/4182/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5037)](http://ci.ros2.org/job/ci_windows/5037/)