### PR TITLE
Allow duration to be initialized with negative nanoseconds

### DIFF
--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -19,8 +19,6 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 class Duration:
 
     def __init__(self, *, seconds=0, nanoseconds=0):
-        if nanoseconds < 0:
-            raise ValueError('Nanoseconds value must not be negative')
         total_nanoseconds = int(seconds * 1e9)
         total_nanoseconds += int(nanoseconds)
         try:

--- a/rclpy/test/test_time.py
+++ b/rclpy/test/test_time.py
@@ -56,13 +56,16 @@ class TestTime(unittest.TestCase):
         assert duration.nanoseconds == 2**63 - 1
 
         assert Duration(seconds=-1).nanoseconds == -1 * 1000 * 1000 * 1000
-        with self.assertRaises(ValueError):
-            duration = Duration(nanoseconds=-1)
+        assert Duration(nanoseconds=-1).nanoseconds == -1
 
         assert Duration(seconds=-2**63 / 1e9).nanoseconds == -2**63
         with self.assertRaises(OverflowError):
             # Much smaller number because float to integer conversion of seconds is imprecise
             duration = Duration(seconds=-2**63 / 1e9 - 1)
+
+        assert Duration(nanoseconds=-2**63).nanoseconds == -2**63
+        with self.assertRaises(OverflowError):
+            Duration(nanoseconds=-2**63 - 1)
 
     def test_time_operators(self):
         time1 = Time(nanoseconds=1, clock_type=ClockType.STEADY_TIME)
@@ -95,9 +98,8 @@ class TestTime(unittest.TestCase):
         assert isinstance(diff, Duration)
         assert diff.nanoseconds == 1
 
-        # Subtraction can't result in a negative duration
-        with self.assertRaises(ValueError):
-            Time(nanoseconds=1) - Time(nanoseconds=2)
+        # Subtraction resulting in a negative duration
+        assert (Time(nanoseconds=1) - Time(nanoseconds=2)).nanoseconds == -1
 
         # Subtraction of times with different clock types
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Allow a `Duration` to be initialized with a negative value for nanoseconds. This allows two `Time` instances being subtracted to initialize negative duration without converting the result to floating point seconds.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5032)](http://ci.ros2.org/job/ci_linux/5032/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1839)](http://ci.ros2.org/job/ci_linux-aarch64/1839/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4185)](http://ci.ros2.org/job/ci_osx/4185/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5040)](http://ci.ros2.org/job/ci_windows/5040/)