### PR TITLE
Callbacks when time jumps

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -152,6 +152,9 @@ class Clock:
         A callback takes a single argument of an instance of :class:`rclpy.clock.TimeJump`.
         A callback should execute as quick as possible and must not block when called.
 
+        Callbacks must not raise an exception.
+        If a callback raises then no time jump callbacks added after it will be called.
+
         :param threshold: Criteria for activating time jump.
         :param pre_callback: Callback to be called before new time is set.
         :param post_callback: Callback to be called after new time is set accepting

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -14,6 +14,8 @@
 
 from enum import IntEnum
 
+import weakref
+
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
@@ -29,6 +31,61 @@ class ClockType(IntEnum):
     STEADY_TIME = 3
 
 
+class ClockChange(IntEnum):
+
+    # The time type before and after the jump is ROS_TIME
+    ROS_TIME_NO_CHANGE = 1
+    # The time type switched to ROS_TIME from SYSTEM_TIME
+    ROS_TIME_ACTIVATED = 2
+    # The time type switched to SYSTEM_TIME from ROS_TIME
+    ROS_TIME_DEACTIVATED = 3
+    # The time type before and after the jump is SYSTEM_TIME
+    SYSTEM_TIME_NO_CHANGE = 4
+
+
+class JumpThreshold:
+
+    def __init__(self, *, min_forward, min_backward, on_clock_change=True):
+        """
+        Initialize an instance of JumpThreshold.
+
+        :param min_forward: Minimum jump forwards to be considered exceeded, or None.
+        :param min_backward: Negative duration indicating minimum jump backwards to be considered
+                             exceeded, or None.
+        :param on_clock_change: True to make a callback happen when ROS_TIME is activated
+                                or deactivated.
+        """
+        self.min_forward = min_forward
+        self.min_backward = min_backward
+        self.on_clock_change = on_clock_change
+
+    def exceeded(self, jump_info):
+        """Return true if the time jump should trigger a callback with this threshold."""
+        clock_type_changes = (ClockChange.ROS_TIME_ACTIVATED, ClockChange.ROS_TIME_DEACTIVATED)
+        if self.on_clock_change and jump_info.clock_change in clock_type_changes:
+            return True
+        elif self.min_forward is not None and jump_info.delta >= self.min_forward:
+            return True
+        elif self.min_backward is not None and jump_info.delta <= self.min_backward:
+            return True
+        return False
+
+
+class JumpHandler:
+
+    def __init__(self, *, threshold, pre_callback, post_callback):
+        """
+        Initialize an instance of JumpHandler.
+
+        :param threshold: Criteria for activating time jump.
+        :param pre_callback: Callback to be called before new time is set.
+        :param post_callback: Callback to be called after new time is set.
+        """
+        self.threshold = threshold
+        self.pre_callback = pre_callback
+        self.post_callback = post_callback
+
+
 class Clock:
 
     def __new__(cls, *, clock_type=ClockType.SYSTEM_TIME):
@@ -40,6 +97,7 @@ class Clock:
             self = super().__new__(cls)
         self._clock_handle = _rclpy.rclpy_create_clock(clock_type)
         self._clock_type = clock_type
+        self._active_jump_handlers = []
         return self
 
     @property
@@ -56,6 +114,43 @@ class Clock:
         return Time(
             nanoseconds=_rclpy.rclpy_time_point_get_nanoseconds(time_handle),
             clock_type=self.clock_type)
+
+    def get_triggered_callback_handlers(self, jump_info):
+        """Yield time jump callbacks that would be triggered by the given jump info."""
+        to_remove = []
+        for idx, handler_weakref in enumerate(self._active_jump_handlers):
+            handler = handler_weakref()
+            if handler is None:
+                to_remove.append(idx)
+            elif handler.threshold.exceeded(jump_info):
+                yield handler
+        # Remove invalid jump handlers
+        for idx in reversed(to_remove):
+            del self._active_jump_handlers[idx]
+
+    def create_jump_callback(self, threshold, *, pre_callback=None, post_callback=None):
+        """
+        Create callback handler for clock time jumps.
+
+        The callbacks must remain valid as long as the returned JumpHandler is valid.
+        A callback takes a single argument of an instance of :class:`rclpy.time_source.TimeJump`.
+        A callback should execute as quick as possible and must not block when called.
+
+        :param threshold: Criteria for activating time jump.
+        :param pre_callback: Callback to be called before new time is set.
+        :param post_callback: Callback to be called after new time is set.
+        :rtype: :class:`rclpy.clock.JumpHandler`
+        """
+        if pre_callback is None and post_callback is None:
+            raise ValueError('One of pre_callback or post_callback must be callable')
+        if pre_callback is not None and not callable(pre_callback):
+            raise ValueError('pre_callback must be callable if given')
+        if post_callback is not None and not callable(post_callback):
+            raise ValueError('post_callback must be callable if given')
+        handler = JumpHandler(
+            threshold=threshold, pre_callback=pre_callback, post_callback=post_callback)
+        self._active_jump_handlers.append(weakref.ref(handler))
+        return handler
 
 
 class ROSClock(Clock):

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -156,25 +156,25 @@ class Clock:
         :param post_callback: Callback to be called after new time is set accepting
         :rtype: :class:`rclpy.clock.JumpHandler`
         """
-        original_callback = post_callback
-
-        def callback_shim(jump_dict):
-            nonlocal original_callback
-            clock_change = None
-            if 'RCL_ROS_TIME_NO_CHANGE' == jump_dict['clock_change']:
-                clock_change = ClockChange.ROS_TIME_NO_CHANGE
-            elif 'RCL_ROS_TIME_ACTIVATED' == jump_dict['clock_change']:
-                clock_change = ClockChange.ROS_TIME_ACTIVATED
-            elif 'RCL_ROS_TIME_DEACTIVATED' == jump_dict['clock_change']:
-                clock_change = ClockChange.ROS_TIME_DEACTIVATED
-            elif 'RCL_SYSTEM_TIME_NO_CHANGE' == jump_dict['clock_change']:
-                clock_change = ClockChange.SYSTEM_TIME_NO_CHANGE
-            else:
-                raise ValueError('Unknown clock jump type ' + repr(clock_change))
-            duration = Duration(nanoseconds=jump_dict['delta'])
-            original_callback(TimeJump(clock_change, duration))
-
         if post_callback is not None and callable(post_callback):
+            original_callback = post_callback
+
+            def callback_shim(jump_dict):
+                nonlocal original_callback
+                clock_change = None
+                if 'RCL_ROS_TIME_NO_CHANGE' == jump_dict['clock_change']:
+                    clock_change = ClockChange.ROS_TIME_NO_CHANGE
+                elif 'RCL_ROS_TIME_ACTIVATED' == jump_dict['clock_change']:
+                    clock_change = ClockChange.ROS_TIME_ACTIVATED
+                elif 'RCL_ROS_TIME_DEACTIVATED' == jump_dict['clock_change']:
+                    clock_change = ClockChange.ROS_TIME_DEACTIVATED
+                elif 'RCL_SYSTEM_TIME_NO_CHANGE' == jump_dict['clock_change']:
+                    clock_change = ClockChange.SYSTEM_TIME_NO_CHANGE
+                else:
+                    raise ValueError('Unknown clock jump type ' + repr(clock_change))
+                duration = Duration(nanoseconds=jump_dict['delta'])
+                original_callback(TimeJump(clock_change, duration))
+
             post_callback = callback_shim
 
         handler = JumpHandle(

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -177,10 +177,9 @@ class Clock:
 
             post_callback = callback_shim
 
-        handler = JumpHandle(
+        return JumpHandle(
             clock=self._clock_handle, threshold=threshold, pre_callback=pre_callback,
             post_callback=post_callback)
-        return handler
 
 
 class ROSClock(Clock):

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -148,10 +148,7 @@ class Clock:
         Create callback handler for clock time jumps.
 
         The callbacks must remain valid as long as the returned JumpHandler is valid.
-        A callback takes a single argument of an instance of :class:`rclpy.clock.TimeJump`.
         A callback should execute as quick as possible and must not block when called.
-
-        Callbacks must not raise an exception.
         If a callback raises then no time jump callbacks added after it will be called.
 
         :param threshold: Criteria for activating time jump.

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -33,13 +33,13 @@ class ClockType(IntEnum):
 
 class ClockChange(IntEnum):
 
-    # The time type before and after the jump is ROS_TIME
+    # ROS time is active and will continue to be active
     ROS_TIME_NO_CHANGE = 1
-    # The time type switched to ROS_TIME from SYSTEM_TIME
+    # ROS time is being activated
     ROS_TIME_ACTIVATED = 2
-    # The time type switched to SYSTEM_TIME from ROS_TIME
+    # ROS TIME is being deactivated, the clock will report system time after the jump
     ROS_TIME_DEACTIVATED = 3
-    # The time type before and after the jump is SYSTEM_TIME
+    # ROS time is inactive and the clock will keep reporting system time
     SYSTEM_TIME_NO_CHANGE = 4
 
 

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -65,7 +65,6 @@ class TimeJump:
     def __init__(self, clock_change, delta):
         if not isinstance(clock_change, ClockChange):
             raise TypeError('clock_change must be an instance of rclpy.clock.ClockChange')
-        # Access through read only properties because same instance is given to all clock callbacks
         self._clock_change = clock_change
         self._delta = delta
 

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -44,8 +44,7 @@ class TimeSource:
         if enabled:
             self._subscribe_to_clock_topic()
         for clock in self._associated_clocks:
-            # Set time and trigger any time jump callbacks on clock change
-            self._set_clock(self._last_time_set, clock)
+            clock._set_ros_time_is_active(enabled)
 
     def _subscribe_to_clock_topic(self):
         if self._clock_sub is None and self._node is not None:
@@ -79,7 +78,7 @@ class TimeSource:
         if not isinstance(clock, ROSClock):
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
 
-        self._set_clock(self._last_time_set, clock)
+        clock.set_ros_time_override(self._last_time_set)
         clock._set_ros_time_is_active(self.ros_time_is_active)
         self._associated_clocks.append(clock)
 
@@ -88,8 +87,4 @@ class TimeSource:
         time_from_msg = Time.from_msg(msg)
         self._last_time_set = time_from_msg
         for clock in self._associated_clocks:
-            self._set_clock(time_from_msg, clock)
-
-    def _set_clock(self, time, clock):
-        clock._set_ros_time_is_active(self.ros_time_is_active)
-        clock.set_ros_time_override(time)
+            clock.set_ros_time_override(time_from_msg)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -80,12 +80,12 @@ class TimeSource:
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
 
         self._set_clock(self._last_time_set, clock)
-
+        clock._set_ros_time_is_active(self.ros_time_is_active)
         self._associated_clocks.append(clock)
 
     def clock_callback(self, msg):
-        time_from_msg = Time.from_msg(msg)
         # Cache the last message in case a new clock is attached.
+        time_from_msg = Time.from_msg(msg)
         self._last_time_set = time_from_msg
         for clock in self._associated_clocks:
             self._set_clock(time_from_msg, clock)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -41,10 +41,10 @@ class TimeSource:
         if self._ros_time_is_active == enabled:
             return
         self._ros_time_is_active = enabled
-        if enabled:
-            self._subscribe_to_clock_topic()
         for clock in self._associated_clocks:
             clock._set_ros_time_is_active(enabled)
+        if enabled:
+            self._subscribe_to_clock_topic()
 
     def _subscribe_to_clock_topic(self):
         if self._clock_sub is None and self._node is not None:

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -13,10 +13,31 @@
 # limitations under the License.
 
 import builtin_interfaces.msg
+from rclpy.clock import ClockChange
+from rclpy.clock import ClockType
 from rclpy.clock import ROSClock
+from rclpy.duration import Duration
 from rclpy.time import Time
 
 CLOCK_TOPIC = '/clock'
+
+
+class TimeJump:
+
+    def __init__(self, clock_change, delta):
+        if not isinstance(clock_change, ClockChange):
+            raise TypeError('clock_change must be an instance of rclpy.clock.ClockChange')
+        # Access through read only properties because same instance is given to all clock callbacks
+        self._clock_change = clock_change
+        self._delta = delta
+
+    @property
+    def clock_change(self):
+        return self._clock_change
+
+    @property
+    def delta(self):
+        return self._delta
 
 
 class TimeSource:
@@ -25,7 +46,8 @@ class TimeSource:
         self._clock_sub = None
         self._node = None
         self._associated_clocks = []
-        self._last_time_set = None
+        # Zero time is a special value that means time is uninitialzied
+        self._last_time_set = Time(clock_type=ClockType.ROS_TIME)
         self._ros_time_is_active = False
         if node is not None:
             self.attach_node(node)
@@ -36,11 +58,16 @@ class TimeSource:
 
     @ros_time_is_active.setter
     def ros_time_is_active(self, enabled):
+        if self._ros_time_is_active == enabled:
+            return
         self._ros_time_is_active = enabled
-        for clock in self._associated_clocks:
-            clock._set_ros_time_is_active(enabled)
+        clock_change = ClockChange.ROS_TIME_DEACTIVATED
         if enabled:
+            clock_change = ClockChange.ROS_TIME_ACTIVATED
             self._subscribe_to_clock_topic()
+        for clock in self._associated_clocks:
+            # Set time and trigger any time jump callbacks on clock change
+            self._set_clock(self._last_time_set, clock, TimeJump(clock_change, Duration()))
 
     def _subscribe_to_clock_topic(self):
         if self._clock_sub is None and self._node is not None:
@@ -73,18 +100,35 @@ class TimeSource:
     def attach_clock(self, clock):
         if not isinstance(clock, ROSClock):
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
-        if self._last_time_set is not None:
-            self._set_clock(self._last_time_set, clock)
-        clock._set_ros_time_is_active(self.ros_time_is_active)
+
+        jump_info = None
+        if self.ros_time_is_active:
+            jump_info = TimeJump(ClockChange.ROS_TIME_NO_CHANGE, Duration())
+        else:
+            jump_info = TimeJump(ClockChange.SYSTEM_TIME_NO_CHANGE, Duration())
+        self._set_clock(self._last_time_set, clock, jump_info)
+
         self._associated_clocks.append(clock)
 
     def clock_callback(self, msg):
-        # Cache the last message in case a new clock is attached.
         time_from_msg = Time.from_msg(msg)
+        jump_info = TimeJump(ClockChange.ROS_TIME_NO_CHANGE, time_from_msg - self._last_time_set)
+        # Cache the last message in case a new clock is attached.
         self._last_time_set = time_from_msg
-        for clock in self._associated_clocks:
-            self._set_clock(time_from_msg, clock)
+        # Only notify clocks of new time if ROS time is active
+        if self.ros_time_is_active:
+            for clock in self._associated_clocks:
+                self._set_clock(time_from_msg, clock, jump_info)
 
-    def _set_clock(self, time, clock):
-        # TODO(dhood): clock jump notifications
+    def _set_clock(self, time, clock, jump_info):
+        # Must not call pre jump handlers in executor because they are required to complete
+        # before the clock time changes
+        jump_handlers = tuple(clock.get_triggered_callback_handlers(jump_info))
+        for jump_handler in jump_handlers:
+            if jump_handler.pre_callback is not None:
+                jump_handler.pre_callback(jump_info)
+        clock._set_ros_time_is_active(self.ros_time_is_active)
         clock.set_ros_time_override(time)
+        for jump_handler in jump_handlers:
+            if jump_handler.post_callback is not None:
+                jump_handler.post_callback(jump_info)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -13,31 +13,11 @@
 # limitations under the License.
 
 import builtin_interfaces.msg
-from rclpy.clock import ClockChange
 from rclpy.clock import ClockType
 from rclpy.clock import ROSClock
-from rclpy.duration import Duration
 from rclpy.time import Time
 
 CLOCK_TOPIC = '/clock'
-
-
-class TimeJump:
-
-    def __init__(self, clock_change, delta):
-        if not isinstance(clock_change, ClockChange):
-            raise TypeError('clock_change must be an instance of rclpy.clock.ClockChange')
-        # Access through read only properties because same instance is given to all clock callbacks
-        self._clock_change = clock_change
-        self._delta = delta
-
-    @property
-    def clock_change(self):
-        return self._clock_change
-
-    @property
-    def delta(self):
-        return self._delta
 
 
 class TimeSource:
@@ -61,13 +41,11 @@ class TimeSource:
         if self._ros_time_is_active == enabled:
             return
         self._ros_time_is_active = enabled
-        clock_change = ClockChange.ROS_TIME_DEACTIVATED
         if enabled:
-            clock_change = ClockChange.ROS_TIME_ACTIVATED
             self._subscribe_to_clock_topic()
         for clock in self._associated_clocks:
             # Set time and trigger any time jump callbacks on clock change
-            self._set_clock(self._last_time_set, clock, TimeJump(clock_change, Duration()))
+            self._set_clock(self._last_time_set, clock)
 
     def _subscribe_to_clock_topic(self):
         if self._clock_sub is None and self._node is not None:
@@ -101,34 +79,17 @@ class TimeSource:
         if not isinstance(clock, ROSClock):
             raise ValueError('Only clocks with type ROS_TIME can be attached.')
 
-        jump_info = None
-        if self.ros_time_is_active:
-            jump_info = TimeJump(ClockChange.ROS_TIME_NO_CHANGE, Duration())
-        else:
-            jump_info = TimeJump(ClockChange.SYSTEM_TIME_NO_CHANGE, Duration())
-        self._set_clock(self._last_time_set, clock, jump_info)
+        self._set_clock(self._last_time_set, clock)
 
         self._associated_clocks.append(clock)
 
     def clock_callback(self, msg):
         time_from_msg = Time.from_msg(msg)
-        jump_info = TimeJump(ClockChange.ROS_TIME_NO_CHANGE, time_from_msg - self._last_time_set)
         # Cache the last message in case a new clock is attached.
         self._last_time_set = time_from_msg
-        # Only notify clocks of new time if ROS time is active
-        if self.ros_time_is_active:
-            for clock in self._associated_clocks:
-                self._set_clock(time_from_msg, clock, jump_info)
+        for clock in self._associated_clocks:
+            self._set_clock(time_from_msg, clock)
 
-    def _set_clock(self, time, clock, jump_info):
-        # Must not call pre jump handlers in executor because they are required to complete
-        # before the clock time changes
-        jump_handlers = tuple(clock.get_triggered_callback_handlers(jump_info))
-        for jump_handler in jump_handlers:
-            if jump_handler.pre_callback is not None:
-                jump_handler.pre_callback(jump_info)
+    def _set_clock(self, time, clock):
         clock._set_ros_time_is_active(self.ros_time_is_active)
         clock.set_ros_time_override(time)
-        for jump_handler in jump_handlers:
-            if jump_handler.post_callback is not None:
-                jump_handler.post_callback(jump_info)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3405,7 +3405,7 @@ _rclpy_on_time_jump(
         clock_change = "RCL_SYSTEM_TIME_NO_CHANGE";
         break;
       default:
-        PyErr_Format(PyExc_RuntimeError, "Unknown time jump type");
+        PyErr_Format(PyExc_RuntimeError, "Unknown time jump type %d", time_jump->clock_change);
         Py_DECREF(pycallback);
         return;
     }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3825,7 +3825,7 @@ static PyMethodDef rclpy_methods[] = {
 
   {
     "rclpy_remove_clock_callback", rclpy_remove_clock_callback, METH_VARARGS,
-    "remove a time jump callback from a clock."
+    "Remove a time jump callback from a clock."
   },
 
   {NULL, NULL, 0, NULL}  /* sentinel */

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3351,6 +3351,143 @@ rclpy_clock_set_ros_time_override(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_NONE;
 }
 
+/// Called when a time jump occurs.
+void
+_rclpy_on_time_jump(
+  const struct rcl_time_jump_t * time_jump,
+  bool before_jump,
+  void * user_data)
+{
+  PyObject * pyjump_handle = user_data;
+  if (before_jump) {
+    // Call pre jump callback with no arguments
+    PyObject * pycallback = PyObject_GetAttrString(pyjump_handle, "_pre_callback");
+    if (NULL == pycallback) {
+      return;
+    }
+    PyObject_CallObject(pycallback, NULL);
+    Py_DECREF(pycallback);
+  } else {
+    // Call post jump callback with JumpInfo as an argument
+    PyObject * pycallback = PyObject_GetAttrString(pyjump_handle, "_post_callback");
+    if (NULL == pycallback) {
+      return;
+    }
+    // Build python dictionary with time jump info
+    int clock_changed = time_jump.clock_change == RCL_ROS_TIME_ACTIVATED ||
+      time_jump.clock_change == RCL_ROS_TIME_DEACTIVATED;
+    Py_LONG_LONG delta = time_jump.delta.nanoseconds;
+    PyObject * pyjump_info = Py_BuildValue(
+      "{zpzL}", "clock_source_changed", clock_changed, "delta", delta);
+    if (NULL == pyjump_info) {
+      Py_DECREF(pycallback);
+      return;
+    }
+    PyObject * pyargs = PyTuple_Pack(1, pyjump_info);
+    if (NULL == pyargs) {
+      Py_DECREF(pyjump_info);
+      Py_DECREF(pycallback);
+      return;
+    }
+    PyObject_CallObject(pycallback, pyargs);
+    Py_DECREF(pyjump_info);
+    Py_DECREF(pyargs);
+    Py_DECREF(pycallback);
+  }
+}
+
+/// Add a time jump callback to a clock.
+/**
+ * On failure, an exception is raised and NULL is returned if:
+ *
+ * Raises ValueError if pyclock is not a clock capsule, or
+ * any argument is invalid
+ * Raises RuntimeError if the callback cannot be added
+ *
+ * \param[in] pyclock Capsule pointing to the clock to set
+ * \param[in] pyjump_handle Instance of rclpy.clock.JumpHandle
+ * \param[in] on_clock_change True if callback should be called when ROS time is toggled
+ * \param[in] min_forward minimum nanoseconds to trigger forward jump callback
+ * \param[in] min_backward minimum negative nanoseconds to trigger backward jump callback
+ * \return NULL on failure
+ *         None on success
+ */
+static PyObject *
+rclpy_add_clock_callback(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pyclock;
+  PyObject * pyjump_handle;
+  int on_clock_change;
+  PY_LONG_LONG min_forward;
+  PY_LONG_LONG min_backward;
+  if (!PyArg_ParseTuple(args, "OOpLL", &pyclock, &pyjump_handle, &on_clock_change, &min_forward,
+    &min_backward))
+  {
+    return NULL;
+  }
+
+  rcl_clock_t * clock = (rcl_clock_t *)PyCapsule_GetPointer(
+    pyclock, "rcl_clock_t");
+  if (!clock) {
+    return NULL;
+  }
+
+  rcl_jump_threshold_t threshold;
+  threshold.on_clock_change = on_clock_change;
+  threshold.min_forward.nanoseconds = min_forward;
+  threshold.min_backward.nanoseconds = min_backward;
+
+  rcl_ret_t ret = rcl_clock_add_jump_callback(
+    clock, threshold, _rclpy_on_time_jump, pyjump_handle);
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to add time jump callback: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+/// Remove a time jump callback from a clock.
+/**
+ * On failure, an exception is raised and NULL is returned if:
+ *
+ * Raises ValueError if pyclock is not a clock capsule, or
+ * any argument is invalid
+ * Raises RuntimeError if the callback cannot be added
+ *
+ * \param[in] pyclock Capsule pointing to the clock to set
+ * \param[in] pyjump_handle Instance of rclpy.clock.JumpHandle
+ * \return NULL on failure
+ *         None on success
+ */
+static PyObject *
+rclpy_remove_clock_callback(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pyclock;
+  PyObject * pyjump_handle;
+  if (!PyArg_ParseTuple(args, "OO", &pyclock, &pyjump_handle))
+  {
+    return NULL;
+  }
+
+  rcl_clock_t * clock = (rcl_clock_t *)PyCapsule_GetPointer(
+    pyclock, "rcl_clock_t");
+  if (!clock) {
+    return NULL;
+  }
+
+  rcl_ret_t ret = rcl_clock_remove_jump_callback(
+    clock, _rclpy_on_time_jump, pyjump_handle);
+  if (ret != RCL_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to remove time jump callback: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
 /// Define the public methods of this module
 static PyMethodDef rclpy_methods[] = {
   {
@@ -3646,6 +3783,16 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_clock_set_ros_time_override", rclpy_clock_set_ros_time_override, METH_VARARGS,
     "Set the current time of a clock using ROS time."
+  },
+
+  {
+    "rclpy_add_clock_callback", rclpy_add_clock_callback, METH_VARARGS,
+    "Add a time jump callback to a clock."
+  },
+
+  {
+    "rclpy_remove_clock_callback", rclpy_remove_clock_callback, METH_VARARGS,
+    "remove a time jump callback from a clock."
   },
 
   {NULL, NULL, 0, NULL}  /* sentinel */

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -156,8 +156,8 @@ class TestClock(unittest.TestCase):
         post_callback1.assert_not_called()
         pre_callback2.assert_called()
         post_callback2.assert_called()
-        pre_callback2.assert_called()
-        post_callback2.assert_called()
+        pre_callback3.assert_called()
+        post_callback3.assert_called()
 
         pre_callback1.reset_mock()
         post_callback1.reset_mock()
@@ -171,8 +171,8 @@ class TestClock(unittest.TestCase):
         post_callback1.assert_not_called()
         pre_callback2.assert_not_called()
         post_callback2.assert_not_called()
-        pre_callback2.assert_not_called()
-        post_callback2.assert_not_called()
+        pre_callback3.assert_not_called()
+        post_callback3.assert_not_called()
 
         handler1.unregister()
         handler2.unregister()

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -17,7 +17,6 @@ import unittest
 from unittest.mock import Mock
 
 from rclpy.clock import Clock
-from rclpy.clock import ClockChange
 from rclpy.clock import ClockType
 from rclpy.clock import JumpThreshold
 from rclpy.clock import ROSClock
@@ -124,32 +123,57 @@ class TestClock(unittest.TestCase):
         pre_callback2.assert_not_called()
         post_callback2.assert_not_called()
 
-        # avoid flake8 warnings about unused variables
-        del handler1
-        del handler2
+        handler1.unregister()
+        handler2.unregister()
 
+    def test_triggered_clock_change_callbacks(self):
+        one_second = Duration(seconds=1)
+        negative_one_second = Duration(seconds=-1)
 
-#    def test_triggered_clock_change_callbacks(self):
-#        one_second = Duration(seconds=1)
-#        negative_one_second = Duration(seconds=-1)
-#
-#        threshold1 = JumpThreshold(
-#            min_forward=one_second, min_backward=negative_one_second, on_clock_change=False)
-#        threshold2 = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
-#        threshold3 = JumpThreshold(
-#            min_forward=one_second, min_backward=negative_one_second, on_clock_change=True)
-#
-#        clock_change1 = TimeJump(ClockChange.ROS_TIME_ACTIVATED, Duration())
-#        clock_change2 = TimeJump(ClockChange.ROS_TIME_DEACTIVATED, Duration())
-#        no_change1 = TimeJump(ClockChange.ROS_TIME_NO_CHANGE, Duration())
-#        no_change2 = TimeJump(ClockChange.SYSTEM_TIME_NO_CHANGE, Duration())
-#
-#        clock = ROSClock()
-#        handler1 = clock.create_jump_callback(threshold1, pre_callback=do_nothing)  # noqa
-#        handler2 = clock.create_jump_callback(threshold2, pre_callback=do_nothing)
-#        handler3 = clock.create_jump_callback(threshold3, pre_callback=do_nothing)
-#
-#        assert [handler2, handler3] == list(clock.get_triggered_callback_handlers(clock_change1))
-#        assert [handler2, handler3] == list(clock.get_triggered_callback_handlers(clock_change2))
-#        assert [] == list(clock.get_triggered_callback_handlers(no_change1))
-#        assert [] == list(clock.get_triggered_callback_handlers(no_change2))
+        threshold1 = JumpThreshold(
+            min_forward=one_second, min_backward=negative_one_second, on_clock_change=False)
+        threshold2 = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
+        threshold3 = JumpThreshold(
+            min_forward=one_second, min_backward=negative_one_second, on_clock_change=True)
+
+        pre_callback1 = Mock()
+        post_callback1 = Mock()
+        pre_callback2 = Mock()
+        post_callback2 = Mock()
+        pre_callback3 = Mock()
+        post_callback3 = Mock()
+
+        clock = ROSClock()
+        handler1 = clock.create_jump_callback(
+            threshold1, pre_callback=pre_callback1, post_callback=post_callback1)
+        handler2 = clock.create_jump_callback(
+            threshold2, pre_callback=pre_callback2, post_callback=post_callback2)
+        handler3 = clock.create_jump_callback(
+            threshold3, pre_callback=pre_callback3, post_callback=post_callback3)
+
+        clock._set_ros_time_is_active(True)
+        pre_callback1.assert_not_called()
+        post_callback1.assert_not_called()
+        pre_callback2.assert_called()
+        post_callback2.assert_called()
+        pre_callback2.assert_called()
+        post_callback2.assert_called()
+
+        pre_callback1.reset_mock()
+        post_callback1.reset_mock()
+        pre_callback2.reset_mock()
+        post_callback2.reset_mock()
+        pre_callback3.reset_mock()
+        post_callback3.reset_mock()
+
+        clock._set_ros_time_is_active(True)
+        pre_callback1.assert_not_called()
+        post_callback1.assert_not_called()
+        pre_callback2.assert_not_called()
+        post_callback2.assert_not_called()
+        pre_callback2.assert_not_called()
+        post_callback2.assert_not_called()
+
+        handler1.unregister()
+        handler2.unregister()
+        handler3.unregister()

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -149,7 +149,7 @@ class TestTimeSource(unittest.TestCase):
         post_cb = Mock()
         threshold = JumpThreshold(
             min_forward=Duration(seconds=0.5), min_backward=None, on_clock_change=False)
-        handler = clock.create_jump_callback(  # noqa
+        handler = clock.create_jump_callback(
             threshold, pre_callback=pre_cb, post_callback=post_cb)
 
         self.publish_clock_messages()
@@ -157,6 +157,7 @@ class TestTimeSource(unittest.TestCase):
         pre_cb.assert_called()
         post_cb.assert_called()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_NO_CHANGE
+        handler.unregister()
 
     def test_backwards_jump(self):
         time_source = TimeSource(node=self.node)
@@ -168,7 +169,7 @@ class TestTimeSource(unittest.TestCase):
         post_cb = Mock()
         threshold = JumpThreshold(
             min_forward=None, min_backward=Duration(seconds=-0.5), on_clock_change=False)
-        handler = clock.create_jump_callback(  # noqa
+        handler = clock.create_jump_callback(
             threshold, pre_callback=pre_cb, post_callback=post_cb)
 
         self.publish_reversed_clock_messages()
@@ -176,6 +177,7 @@ class TestTimeSource(unittest.TestCase):
         pre_cb.assert_called()
         post_cb.assert_called()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_NO_CHANGE
+        handler.unregister()
 
     def test_clock_change(self):
         time_source = TimeSource(node=self.node)
@@ -186,7 +188,7 @@ class TestTimeSource(unittest.TestCase):
         pre_cb = Mock()
         post_cb = Mock()
         threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
-        handler = clock.create_jump_callback(  # noqa
+        handler = clock.create_jump_callback(
             threshold, pre_callback=pre_cb, post_callback=post_cb)
 
         time_source.ros_time_is_active = False
@@ -201,6 +203,7 @@ class TestTimeSource(unittest.TestCase):
         pre_cb.assert_called()
         post_cb.assert_called()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_ACTIVATED
+        handler.unregister()
 
     def test_no_pre_callback(self):
         time_source = TimeSource(node=self.node)
@@ -210,12 +213,13 @@ class TestTimeSource(unittest.TestCase):
 
         post_cb = Mock()
         threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
-        handler = clock.create_jump_callback(  # noqa
+        handler = clock.create_jump_callback(
             threshold, pre_callback=None, post_callback=post_cb)
 
         time_source.ros_time_is_active = False
         post_cb.assert_called_once()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_DEACTIVATED
+        handler.unregister()
 
     def test_no_post_callback(self):
         time_source = TimeSource(node=self.node)
@@ -225,8 +229,9 @@ class TestTimeSource(unittest.TestCase):
 
         pre_cb = Mock()
         threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
-        handler = clock.create_jump_callback(  # noqa
+        handler = clock.create_jump_callback(
             threshold, pre_callback=pre_cb, post_callback=None)
 
         time_source.ros_time_is_active = False
         pre_cb.assert_called_once()
+        handler.unregister()


### PR DESCRIPTION
This adds callbacks when ROSTime jumps. The implementation closely mimics the implementation in `rclcpp`.

Time jump callbacks use the `rcl_clock_t` time jump callbacks. Python code is called in the callbacks using `PyObject_CallObject()`.

Requires ros2/rcl#284