### PR TITLE
disable 1kHz test on all platforms

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
   <test_depend>test_msgs</test_depend>

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import multiprocessing
-import os
-import platform
+# TODO(mikaelarguedas) comment back in if we reenable 1kHz test for some platforms
+# import os
+# import platform
 import sys
 import time
 import traceback
@@ -153,9 +154,10 @@ def test_timer_zero_callbacks100hertz():
 # on every platform at high frequency
 # TODO(sloretz) Reenable on arm when executor performance is good enough
 def test_timer_zero_callbacks1000hertz():
-    if os.name == 'nt' or platform.machine() == 'aarch64':
-        raise SkipTest
-    func_launch(func_zero_callback, ['0.001'], 'received callbacks when not expected')
+    # if os.name == 'nt' or platform.machine() == 'aarch64':
+    #     raise SkipTest
+    # func_launch(func_zero_callback, ['0.001'], 'received callbacks when not expected')
+    raise SkipTest
 
 
 def test_timer_number_callbacks10hertz():
@@ -168,10 +170,11 @@ def test_timer_number_callbacks100hertz():
 
 
 def test_timer_number_callbacks1000hertz():
-    if os.name == 'nt' or platform.machine() == 'aarch64':
-        raise SkipTest
-    func_launch(
-        func_number_callbacks, ['0.001'], "didn't receive the expected number of callbacks")
+    # if os.name == 'nt' or platform.machine() == 'aarch64':
+    #     raise SkipTest
+    # func_launch(
+    #     func_number_callbacks, ['0.001'], "didn't receive the expected number of callbacks")
+    raise SkipTest
 
 
 def test_timer_cancel_reset_10hertz():
@@ -185,7 +188,8 @@ def test_timer_cancel_reset_100hertz():
 
 
 def test_timer_cancel_reset_1000hertz():
-    if os.name == 'nt' or platform.machine() == 'aarch64':
-        raise SkipTest
-    func_launch(
-        func_cancel_reset_timer, ['0.001'], "didn't receive the expected number of callbacks")
+    # if os.name == 'nt' or platform.machine() == 'aarch64':
+    #     raise SkipTest
+    # func_launch(
+    #     func_cancel_reset_timer, ['0.001'], "didn't receive the expected number of callbacks")
+    raise SkipTest

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -15,6 +15,7 @@
 import multiprocessing
 import os
 import platform
+import pytest
 import sys
 import time
 import traceback
@@ -152,6 +153,7 @@ def test_timer_zero_callbacks100hertz():
 # TODO(mikaelarguedas) reenable these once timer have consistent behaviour
 # on every platform at high frequency
 # TODO(sloretz) Reenable on arm when executor performance is good enough
+@pytest.mark.skip(reason="1kHz tests are too prone to flakiness")
 def test_timer_zero_callbacks1000hertz():
     if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
@@ -167,6 +169,7 @@ def test_timer_number_callbacks100hertz():
         func_number_callbacks, ['0.01'], "didn't receive the expected number of callbacks")
 
 
+@pytest.mark.skip(reason="1kHz tests are too prone to flakiness")
 def test_timer_number_callbacks1000hertz():
     if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
@@ -184,6 +187,7 @@ def test_timer_cancel_reset_100hertz():
         func_cancel_reset_timer, ['0.01'], "didn't receive the expected number of callbacks")
 
 
+@pytest.mark.skip(reason="1kHz tests are too prone to flakiness")
 def test_timer_cancel_reset_1000hertz():
     if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -153,7 +153,7 @@ def test_timer_zero_callbacks100hertz():
 # TODO(mikaelarguedas) reenable these once timer have consistent behaviour
 # on every platform at high frequency
 # TODO(sloretz) Reenable on arm when executor performance is good enough
-@pytest.mark.skip(reason="1kHz tests are too prone to flakiness")
+@pytest.mark.skip(reason='1kHz tests are too prone to flakiness')
 def test_timer_zero_callbacks1000hertz():
     if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
@@ -169,7 +169,7 @@ def test_timer_number_callbacks100hertz():
         func_number_callbacks, ['0.01'], "didn't receive the expected number of callbacks")
 
 
-@pytest.mark.skip(reason="1kHz tests are too prone to flakiness")
+@pytest.mark.skip(reason='1kHz tests are too prone to flakiness')
 def test_timer_number_callbacks1000hertz():
     if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest
@@ -187,7 +187,7 @@ def test_timer_cancel_reset_100hertz():
         func_cancel_reset_timer, ['0.01'], "didn't receive the expected number of callbacks")
 
 
-@pytest.mark.skip(reason="1kHz tests are too prone to flakiness")
+@pytest.mark.skip(reason='1kHz tests are too prone to flakiness')
 def test_timer_cancel_reset_1000hertz():
     if os.name == 'nt' or platform.machine() == 'aarch64':
         raise SkipTest

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import multiprocessing
-# TODO(mikaelarguedas) comment back in if we reenable 1kHz test for some platforms
-# import os
-# import platform
+import os
+import platform
 import sys
 import time
 import traceback
@@ -154,10 +153,9 @@ def test_timer_zero_callbacks100hertz():
 # on every platform at high frequency
 # TODO(sloretz) Reenable on arm when executor performance is good enough
 def test_timer_zero_callbacks1000hertz():
-    # if os.name == 'nt' or platform.machine() == 'aarch64':
-    #     raise SkipTest
-    # func_launch(func_zero_callback, ['0.001'], 'received callbacks when not expected')
-    raise SkipTest
+    if os.name == 'nt' or platform.machine() == 'aarch64':
+        raise SkipTest
+    func_launch(func_zero_callback, ['0.001'], 'received callbacks when not expected')
 
 
 def test_timer_number_callbacks10hertz():
@@ -170,11 +168,10 @@ def test_timer_number_callbacks100hertz():
 
 
 def test_timer_number_callbacks1000hertz():
-    # if os.name == 'nt' or platform.machine() == 'aarch64':
-    #     raise SkipTest
-    # func_launch(
-    #     func_number_callbacks, ['0.001'], "didn't receive the expected number of callbacks")
-    raise SkipTest
+    if os.name == 'nt' or platform.machine() == 'aarch64':
+        raise SkipTest
+    func_launch(
+        func_number_callbacks, ['0.001'], "didn't receive the expected number of callbacks")
 
 
 def test_timer_cancel_reset_10hertz():
@@ -188,8 +185,7 @@ def test_timer_cancel_reset_100hertz():
 
 
 def test_timer_cancel_reset_1000hertz():
-    # if os.name == 'nt' or platform.machine() == 'aarch64':
-    #     raise SkipTest
-    # func_launch(
-    #     func_cancel_reset_timer, ['0.001'], "didn't receive the expected number of callbacks")
-    raise SkipTest
+    if os.name == 'nt' or platform.machine() == 'aarch64':
+        raise SkipTest
+    func_launch(
+        func_cancel_reset_timer, ['0.001'], "didn't receive the expected number of callbacks")

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -15,11 +15,12 @@
 import multiprocessing
 import os
 import platform
-import pytest
 import sys
 import time
 import traceback
 from unittest.case import SkipTest
+
+import pytest
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor


### PR DESCRIPTION
these tests fail more and more often on all platforms (e.g. [here](https://ci.ros2.org/view/nightly/job/nightly_osx_repeated/1216/testReport/junit/rclpy.test/test_timer/test_timer_cancel_reset_1000hertz/))

Disabling the 1kHz test on all platforms for now until we decide how to refactor them
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5045)](http://ci.ros2.org/job/ci_linux/5045/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1842)](http://ci.ros2.org/job/ci_linux-aarch64/1842/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4189)](http://ci.ros2.org/job/ci_osx/4189/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5042)](http://ci.ros2.org/job/ci_windows/5042/)