### PR TITLE
Take initial parameters from parameters yaml files and constructor arguments.

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rcl REQUIRED)
+find_package(rcl_yaml_param_parser REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
@@ -77,6 +78,7 @@ add_library(
 configure_python_c_extension_library(rclpy)
 ament_target_dependencies(rclpy
   "rcl"
+  "rcl_yaml_param_parser"
   "rcutils"
 )
 

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -19,6 +19,7 @@
 
   <depend>rmw_implementation</depend>
   <depend>rcl</depend>
+  <depend>rcl_yaml_param_parser</depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -51,7 +51,7 @@ def shutdown():
 
 def create_node(
     node_name, *, cli_args=None, namespace=None, use_global_arguments=True,
-    start_parameter_services=True
+    start_parameter_services=True, initial_parameters=None
 ):
     """
     Create an instance of :class:`rclpy.node.Node`.
@@ -60,6 +60,8 @@ def create_node(
     :param cli_args: A list of strings of command line args to be used only by this node.
     :param namespace: The namespace to which relative topic and service names will be prefixed.
     :param use_global_arguments: False if the node should ignore process-wide command line args.
+    :param start_parameter_services: False if the node should not create parameter services.
+    :param initial_parameters: A list fo rclpy.parameter.Parameters to be set during node creation.
     :return: An instance of a node
     :rtype: :class:`rclpy.node.Node`
     """
@@ -68,7 +70,8 @@ def create_node(
     return Node(
         node_name, cli_args=cli_args, namespace=namespace,
         use_global_arguments=use_global_arguments,
-        start_parameter_services=start_parameter_services)
+        start_parameter_services=start_parameter_services,
+        initial_parameters=initial_parameters)
 
 
 def spin_once(node, *, timeout_sec=None):

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -61,7 +61,7 @@ def create_node(
     :param namespace: The namespace to which relative topic and service names will be prefixed.
     :param use_global_arguments: False if the node should ignore process-wide command line args.
     :param start_parameter_services: False if the node should not create parameter services.
-    :param initial_parameters: A list fo rclpy.parameter.Parameters to be set during node creation.
+    :param initial_parameters: A list of rclpy.parameter.Parameters to be set during node creation.
     :return: An instance of a node
     :rtype: :class:`rclpy.node.Node`
     """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -104,15 +104,6 @@ class Node:
         self._parameter_event_publisher = self.create_publisher(
             ParameterEvent, 'parameter_events', qos_profile=qos_profile_parameter_events)
 
-        for param in _rclpy.rclpy_get_node_parameters(Parameter, self.handle):
-            self._parameters[param.name] = param
-        for param in initial_parameters:
-            if not isinstance(param, Parameter):
-                raise TypeError(
-                    'initial_parameters must be a list of {}'.format(repr(Parameter))
-                )
-            self._parameters[param.name] = param
-
         node_parameters = _rclpy.rclpy_get_node_parameters(Parameter, self.handle)
         # Combine parameters from params files with those from the node constructor and
         # use the set_parameters_atomically API so a parameter event is published.

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -61,7 +61,7 @@ class Node:
 
     def __init__(
         self, node_name, *, cli_args=None, namespace=None, use_global_arguments=True,
-        start_parameter_services=True, initial_parameters=[]
+        start_parameter_services=True, initial_parameters=None
     ):
         self._handle = None
         self._parameters = {}
@@ -112,6 +112,13 @@ class Node:
                     'initial_parameters must be a list of {}'.format(repr(Parameter))
                 )
             self._parameters[param.name] = param
+
+        node_parameters = _rclpy.rclpy_get_node_parameters(Parameter, self.handle)
+        # use the set_parameters API so parameter events are publish.
+        if node_parameters:
+            self.set_parameters(node_parameters)
+        if initial_parameters is not None:
+            self.set_parameters(initial_parameters)
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -115,15 +115,10 @@ class Node:
 
         node_parameters = _rclpy.rclpy_get_node_parameters(Parameter, self.handle)
         # Combine parameters from params files with those from the node constructor and
-        # use the set_parameters API so parameter events are published.
-        if node_parameters and initial_parameters:
-            params_by_name = {p.name: p for p in node_parameters}
-            params_by_name.update({p.name: p for p in initial_parameters})
-            self.set_parameters(params_by_name.values())
-        elif node_parameters:
-            self.set_parameters(node_parameters)
-        elif initial_parameters:
-            self.set_parameters(initial_parameters)
+        # use the set_parameters_atomically API so a parameter event is published.
+        if initial_parameters is not None:
+            node_parameters.update({p.name: p for p in initial_parameters})
+        self.set_parameters_atomically(node_parameters.values())
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -114,10 +114,15 @@ class Node:
             self._parameters[param.name] = param
 
         node_parameters = _rclpy.rclpy_get_node_parameters(Parameter, self.handle)
-        # use the set_parameters API so parameter events are publish.
-        if node_parameters:
+        # Combine parameters from params files with those from the node constructor and
+        # use the set_parameters API so parameter events are published.
+        if node_parameters and initial_parameters:
+            params_by_name = {p.name: p for p in node_parameters}
+            params_by_name.update({p.name: p for p in initial_parameters})
+            self.set_parameters(params_by_name.values())
+        elif node_parameters:
             self.set_parameters(node_parameters)
-        if initial_parameters is not None:
+        elif initial_parameters:
             self.set_parameters(initial_parameters)
 
         if start_parameter_services:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -61,7 +61,7 @@ class Node:
 
     def __init__(
         self, node_name, *, cli_args=None, namespace=None, use_global_arguments=True,
-        start_parameter_services=True
+        start_parameter_services=True, initial_parameters=[]
     ):
         self._handle = None
         self._parameters = {}
@@ -103,6 +103,15 @@ class Node:
 
         self._parameter_event_publisher = self.create_publisher(
             ParameterEvent, 'parameter_events', qos_profile=qos_profile_parameter_events)
+
+        for param in _rclpy.rclpy_get_node_parameters(Parameter, self.handle):
+            self._parameters[param.name] = param
+        for param in initial_parameters:
+            if not isinstance(param, Parameter):
+                raise TypeError(
+                    'initial_parameters must be a list of {}'.format(repr(Parameter))
+                )
+            self._parameters[param.name] = param
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3436,7 +3436,10 @@ static PyObject * _parameter_from_rcl_variant(
   const char * name, rcl_variant_t * variant, PyObject * parameter_cls,
   PyObject * parameter_type_cls)
 {
-  int type_enum_value;
+
+  /* Default to 0 (not set) to suppress warnings. A python error will raise if
+   * type and value don't agree */
+  int type_enum_value = 0;
   PyObject * value;
   PyObject * member_value;
   if (variant->bool_value) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3385,7 +3385,8 @@ rclpy_clock_set_ros_time_override(PyObject * Py_UNUSED(self), PyObject * args)
  *         false when there was an error during parsing and a Python exception was raised.
  *
  */
-static bool _parse_param_files(
+static bool
+_parse_param_files(
   const rcl_arguments_t * args, rcl_allocator_t allocator,
   rcl_params_t * params)
 {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3436,7 +3436,6 @@ static PyObject * _parameter_from_rcl_variant(
   const char * name, rcl_variant_t * variant, PyObject * parameter_cls,
   PyObject * parameter_type_cls)
 {
-
   /* Default to 0 (not set) to suppress warnings. A python error will raise if
    * type and value don't agree */
   int type_enum_value = 0;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3442,12 +3442,21 @@ static PyObject * _parameter_from_rcl_variant(
   } else if (variant->integer_value) {
     type_enum_value = 2;
     value = PyLong_FromLong(*(variant->integer_value));
+    if (NULL == value) {
+      return NULL;
+    }
   } else if (variant->double_value) {
     type_enum_value = 3;
     value = PyFloat_FromDouble(*(variant->double_value));
+    if (NULL == value) {
+      return NULL;
+    }
   } else if (variant->string_value) {
     type_enum_value = 4;
     value = PyUnicode_FromString(variant->string_value);
+    if (NULL == value) {
+      return NULL;
+    }
   } else if (variant->byte_array_value) {
     type_enum_value = 5;
     value = PyList_New(variant->byte_array_value->size);
@@ -3458,6 +3467,7 @@ static PyObject * _parameter_from_rcl_variant(
 
       member_value = PyBytes_FromFormat("%u", variant->byte_array_value->values[i]);
       if (NULL == member_value) {
+        Py_DECREF(value);
         return NULL;
       }
       PyList_SET_ITEM(value, i, member_value);
@@ -3480,7 +3490,12 @@ static PyObject * _parameter_from_rcl_variant(
       return NULL;
     }
     for (size_t i = 0; i < variant->integer_array_value->size; i++) {
-      PyList_SET_ITEM(value, i, PyLong_FromLong(variant->integer_array_value->values[i]));
+      member_value = PyLong_FromLong(variant->integer_array_value->values[i]);
+      if (NULL == member_value) {
+        Py_DECREF(value);
+        return NULL;
+      }
+      PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->double_array_value) {
     type_enum_value = 8;
@@ -3489,7 +3504,12 @@ static PyObject * _parameter_from_rcl_variant(
       return NULL;
     }
     for (size_t i = 0; i < variant->double_array_value->size; i++) {
-      PyList_SET_ITEM(value, i, PyFloat_FromDouble(variant->double_array_value->values[i]));
+      member_value = PyFloat_FromDouble(variant->double_array_value->values[i]);
+      if (NULL == member_value) {
+        Py_DECREF(value);
+        return NULL;
+      }
+      PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->string_array_value) {
     type_enum_value = 9;
@@ -3498,7 +3518,12 @@ static PyObject * _parameter_from_rcl_variant(
       return NULL;
     }
     for (size_t i = 0; i < variant->string_array_value->size; i++) {
-      PyList_SET_ITEM(value, i, PyUnicode_FromString(variant->string_array_value->data[i]));
+      member_value = PyUnicode_FromString(variant->string_array_value->data[i]);
+      if (NULL == member_value) {
+        Py_DECREF(value);
+        return NULL;
+      }
+      PyList_SET_ITEM(value, i, member_value);
     }
   }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -22,6 +22,7 @@
 #include <rcl/time.h>
 #include <rcl/validate_topic_name.h>
 #include <rcl_yaml_param_parser/parser.h>
+#include <rcl_interfaces/msg/parameter_type__struct.h>
 #include <rcutils/strdup.h>
 #include <rcutils/types.h>
 #include <rmw/error_handling.h>
@@ -3388,35 +3389,35 @@ static PyObject * _parameter_from_rcl_variant(
   PyObject * name, rcl_variant_t * variant, PyObject * parameter_cls,
   PyObject * parameter_type_cls)
 {
-  /* Default to 0 (not set) to suppress warnings. A Python error will raise if
+  /* Default to NOT_SET to suppress warnings. A Python error will raise if
    * type and value don't agree */
-  int type_enum_value = 0;
+  int type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_NOT_SET;
   PyObject * value;
   PyObject * member_value;
   if (variant->bool_value) {
-    type_enum_value = 1;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_BOOL;
     value = *(variant->bool_value) ? Py_True : Py_False;
     Py_INCREF(value);
   } else if (variant->integer_value) {
-    type_enum_value = 2;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_INTEGER;
     value = PyLong_FromLongLong(*(variant->integer_value));
     if (NULL == value) {
       return NULL;
     }
   } else if (variant->double_value) {
-    type_enum_value = 3;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_DOUBLE;
     value = PyFloat_FromDouble(*(variant->double_value));
     if (NULL == value) {
       return NULL;
     }
   } else if (variant->string_value) {
-    type_enum_value = 4;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_STRING;
     value = PyUnicode_FromString(variant->string_value);
     if (NULL == value) {
       return NULL;
     }
   } else if (variant->byte_array_value) {
-    type_enum_value = 5;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_BYTE_ARRAY;
     value = PyList_New(variant->byte_array_value->size);
     if (NULL == value) {
       return NULL;
@@ -3430,7 +3431,7 @@ static PyObject * _parameter_from_rcl_variant(
       PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->bool_array_value) {
-    type_enum_value = 6;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_BOOL_ARRAY;
     value = PyList_New(variant->bool_array_value->size);
     if (NULL == value) {
       return NULL;
@@ -3441,7 +3442,7 @@ static PyObject * _parameter_from_rcl_variant(
       PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->integer_array_value) {
-    type_enum_value = 7;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_INTEGER_ARRAY;
     value = PyList_New(variant->integer_array_value->size);
     if (NULL == value) {
       return NULL;
@@ -3455,7 +3456,7 @@ static PyObject * _parameter_from_rcl_variant(
       PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->double_array_value) {
-    type_enum_value = 8;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_DOUBLE_ARRAY;
     value = PyList_New(variant->double_array_value->size);
     if (NULL == value) {
       return NULL;
@@ -3469,7 +3470,7 @@ static PyObject * _parameter_from_rcl_variant(
       PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->string_array_value) {
-    type_enum_value = 9;
+    type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_STRING_ARRAY;
     value = PyList_New(variant->string_array_value->size);
     if (NULL == value) {
       return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3486,17 +3486,22 @@ static PyObject * _parameter_from_rcl_variant(
 
   PyObject * args = Py_BuildValue("(i)", type_enum_value);
   if (NULL == args) {
+    Py_DECREF(value);
     return NULL;
   }
   PyObject * type = PyObject_CallObject(parameter_type_cls, args);
   Py_DECREF(args);
   args = Py_BuildValue("OOO", name, type, value);
   if (NULL == args) {
+    Py_DECREF(type);
+    Py_DECREF(value);
     return NULL;
   }
+  Py_DECREF(value);
+  Py_DECREF(type);
+
   PyObject * param = PyObject_CallObject(parameter_cls, args);
   Py_DECREF(args);
-  Py_DECREF(type);
   return param;
 }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3443,7 +3443,7 @@ static PyObject * _parameter_from_rcl_variant(
   PyObject * member_value;
   if (variant->bool_value) {
     type_enum_value = 1;
-    value = variant->bool_value ? Py_True : Py_False;
+    value = *(variant->bool_value) ? Py_True : Py_False;
     Py_INCREF(value);
   } else if (variant->integer_value) {
     type_enum_value = 2;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3392,6 +3392,7 @@ static bool _parse_param_files(
   char ** param_files;
   int param_files_count = rcl_arguments_get_param_files_count(args);
   rcl_ret_t ret;
+  bool successful = true;
   if (param_files_count > 0) {
     ret = rcl_arguments_get_param_files(args, allocator, &param_files);
     if (RCL_RET_OK != ret) {
@@ -3400,15 +3401,16 @@ static bool _parse_param_files(
       return false;
     }
     for (int i = 0; i < param_files_count; i++) {
-      if (!rcl_parse_yaml_file(param_files[i], params)) {
+      if (successfull && !rcl_parse_yaml_file(param_files[i], params)) {
         /* failure to parse will automatically fini the params struct */
         PyErr_Format(PyExc_RuntimeError, "Failed to parse yaml params file: %s", param_files[i]);
-        return false;
+        successful = false;
       }
       allocator.deallocate(param_files[i], allocator.state);
     }
+    allocator.deallocate(param_files, allocator.state);
   }
-  return true;
+  return successful;
 }
 
 /// Create an rclpy.parameter.Parameter from an rcl_variant_t

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3447,7 +3447,7 @@ static PyObject * _parameter_from_rcl_variant(
     Py_INCREF(value);
   } else if (variant->integer_value) {
     type_enum_value = 2;
-    value = PyLong_FromLong(*(variant->integer_value));
+    value = PyLong_FromLongLong(*(variant->integer_value));
     if (NULL == value) {
       return NULL;
     }
@@ -3495,7 +3495,7 @@ static PyObject * _parameter_from_rcl_variant(
       return NULL;
     }
     for (size_t i = 0; i < variant->integer_array_value->size; i++) {
-      member_value = PyLong_FromLong(variant->integer_array_value->values[i]);
+      member_value = PyLong_FromLongLong(variant->integer_array_value->values[i]);
       if (NULL == member_value) {
         Py_DECREF(value);
         return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3399,6 +3399,10 @@ _parse_param_files(
     if (RCL_RET_OK != ret) {
       PyErr_Format(PyExc_RuntimeError, "Failed to get initial parameters: %s",
         rcl_get_error_string_safe());
+      /* We fini here because later calls in this function may fini the struct
+       * on error so the calling code has no idea whether fini has already been
+       * called. */
+      rcl_yaml_node_struct_fini(params);
       return false;
     }
     for (int i = 0; i < param_files_count; i++) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3540,13 +3540,12 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(node_capsule, "rcl_node_t");
-  const rcl_node_options_t * node_options = rcl_node_get_options(node);
-  const rcl_allocator_t allocator = node_options->allocator;
   if (!node) {
-    PyErr_Format(PyExc_RuntimeError, "Failed to retrieve rcl node from capsule");
     return NULL;
   }
 
+  const rcl_node_options_t * node_options = rcl_node_get_options(node);
+  const rcl_allocator_t allocator = node_options->allocator;
   rcl_params_t * params = rcl_yaml_node_struct_init(allocator);
   if (NULL == params) {
     PyErr_Format(PyExc_RuntimeError, "Failed to allocate initial parameters");

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3645,10 +3645,9 @@ _parse_param_files(
  * Raises RuntimeError if the parameters file fails to parse
  *
  * \param[in] parameter_cls The rclpy.parameter.Parameter class object.
- * \param[in] node_handle Capsule pointing to the node handle
+ * \param[in] node_capsule Capsule pointing to the node handle
  * \return NULL on failure
- *         A list of rclpy.parameter.Parameter on success (may be empty).
- *
+ *         A dict mapping parameter names to rclpy.parameter.Parameter on success (may be empty).
  */
 static PyObject *
 rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
@@ -3726,7 +3725,7 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
     /* No parameters for current node.*/
     Py_DECREF(params_by_node_name);
     Py_DECREF(py_node_name_with_namespace);
-    return PyList_New(0);
+    return PyDict_New();
   }
   PyObject * node_params = PyDict_GetItem(params_by_node_name, py_node_name_with_namespace);
   if (NULL == node_params) {
@@ -3734,17 +3733,12 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
     Py_DECREF(py_node_name_with_namespace);
     return NULL;
   }
-  PyObject * node_param_list = PyDict_Values(node_params);
-  if (NULL == node_param_list) {
-    Py_DECREF(parameter_type_cls);
-    Py_DECREF(params_by_node_name);
-    Py_DECREF(py_node_name_with_namespace);
-    return NULL;
-  }
+  // PyDict_GetItem is a borrowed reference. INCREF so we can return a new one.
+  Py_INCREF(node_params);
 
   Py_DECREF(parameter_type_cls);
   Py_DECREF(params_by_node_name);
-  return node_param_list;
+  return node_params;
 }
 
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3433,9 +3433,11 @@ static PyObject * _parameter_from_rcl_variant(
 {
   int type_enum_value;
   PyObject * value;
+  PyObject * member_value;
   if (variant->bool_value) {
     type_enum_value = 1;
     value = variant->bool_value ? Py_True : Py_False;
+    Py_INCREF(value);
   } else if (variant->integer_value) {
     type_enum_value = 2;
     value = PyLong_FromLong(*(variant->integer_value));
@@ -3455,7 +3457,9 @@ static PyObject * _parameter_from_rcl_variant(
     type_enum_value = 6;
     value = PyList_New(variant->bool_array_value->size);
     for (size_t i = 0; i < variant->bool_array_value->size; i++) {
-      PyList_SetItem(value, i, variant->bool_array_value->values[i] ? Py_True : Py_False);
+      member_value = variant->bool_array_value->values[i] ? Py_True : Py_False;
+      Py_INCREF(member_value)
+      PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->integer_array_value) {
     type_enum_value = 7;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3401,7 +3401,7 @@ static bool _parse_param_files(
       return false;
     }
     for (int i = 0; i < param_files_count; i++) {
-      if (successfull && !rcl_parse_yaml_file(param_files[i], params)) {
+      if (successful && !rcl_parse_yaml_file(param_files[i], params)) {
         /* failure to parse will automatically fini the params struct */
         PyErr_Format(PyExc_RuntimeError, "Failed to parse yaml params file: %s", param_files[i]);
         successful = false;
@@ -3469,7 +3469,7 @@ static PyObject * _parameter_from_rcl_variant(
     }
     for (size_t i = 0; i < variant->bool_array_value->size; i++) {
       member_value = variant->bool_array_value->values[i] ? Py_True : Py_False;
-      Py_INCREF(member_value)
+      Py_INCREF(member_value);
       PyList_SET_ITEM(value, i, member_value);
     }
   } else if (variant->integer_array_value) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3659,7 +3659,7 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(node_capsule, "rcl_node_t");
-  if (!node) {
+  if (NULL == node) {
     return NULL;
   }
 
@@ -3675,7 +3675,7 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
   }
   PyObject * parameter_type_cls = PyObject_GetAttrString(parameter_cls, "Type");
   if (NULL == parameter_type_cls) {
-    /* PyObject_GetAttrString raises AttributeError on failure. */
+    // PyObject_GetAttrString raises AttributeError on failure.
     Py_DECREF(params_by_node_name);
     return NULL;
   }
@@ -3720,9 +3720,8 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
   }
   allocator.deallocate(node_name_with_namespace, allocator.state);
 
-
   if (!PyDict_Contains(params_by_node_name, py_node_name_with_namespace)) {
-    /* No parameters for current node.*/
+    // No parameters for current node.
     Py_DECREF(params_by_node_name);
     Py_DECREF(py_node_name_with_namespace);
     return PyDict_New();

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3521,8 +3521,8 @@ _populate_node_parameters_from_rcl_params(
   for (size_t i = 0; i < params->num_nodes; i++) {
     PyObject * py_node_name;
     if (params->node_names[i][0] != '/') {
-      py_node_name = PyUnicode_FromString(rcutils_format_string(allocator,
-        "/%s", params->node_names[i]));
+      py_node_name = PyUnicode_FromString(
+        rcutils_format_string(allocator, "/%s", params->node_names[i]));
     } else {
       py_node_name = PyUnicode_FromString(params->node_names[i]);
     }
@@ -3621,8 +3621,10 @@ _parse_param_files(
           successful = false;
         } else {
           if (!_populate_node_parameters_from_rcl_params(
-            params, allocator, parameter_cls, parameter_type_cls, params_by_node_name)) {
-            PyErr_Format(PyExc_RuntimeError, "Unable to populate params dict from file: %s", param_files[i]);
+              params, allocator, parameter_cls, parameter_type_cls, params_by_node_name))
+          {
+            PyErr_Format(PyExc_RuntimeError,
+              "Failed to fill params dict from file: %s", param_files[i]);
             rcl_yaml_node_struct_fini(params);
             return false;
           }
@@ -3685,7 +3687,8 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
 
   if (node_options->use_global_arguments) {
     if (!_parse_param_files(rcl_get_global_arguments(), allocator, parameter_cls,
-        parameter_type_cls, params_by_node_name)) {
+      parameter_type_cls, params_by_node_name))
+    {
       Py_DECREF(parameter_type_cls);
       Py_DECREF(params_by_node_name);
       return NULL;
@@ -3693,7 +3696,8 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   if (!_parse_param_files(&(node_options->arguments), allocator, parameter_cls,
-      parameter_type_cls, params_by_node_name)) {
+    parameter_type_cls, params_by_node_name))
+  {
     Py_DECREF(parameter_type_cls);
     Py_DECREF(params_by_node_name);
     return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3372,7 +3372,7 @@ rclpy_clock_set_ros_time_override(PyObject * Py_UNUSED(self), PyObject * args)
 
 /// Create an rclpy.parameter.Parameter from an rcl_variant_t
 /**
- * On failure a Python exception is raised and false is returned if:
+ * On failure a Python exception is raised and NULL is returned if:
  *
  * Raises ValueError if the variant points to no data.
  *

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3633,8 +3633,6 @@ _parse_param_files(
         if (!_populate_node_parameters_from_rcl_params(
             params, allocator, parameter_cls, parameter_type_cls, params_by_node_name))
         {
-          PyErr_Format(PyExc_RuntimeError,
-            "Failed to fill params dict from file: %s", param_files[i]);
           rcl_yaml_node_struct_fini(params);
           successful = false;
         }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -261,7 +261,7 @@ _rclpy_pyargs_to_list(PyObject * pyargs, int * num_args, char *** arg_values)
 /// Parse a sequence of strings into rcl_arguments_t struct
 /* Raises TypeError of pyargs is not a sequence
  * Raises OverflowError if len(pyargs) > INT_MAX
- * \param[in] pyargs a python sequence of strings
+ * \param[in] pyargs a Python sequence of strings
  * \param[out] parsed_args a zero initialized pointer to rcl_arguments_t
  */
 rcl_ret_t
@@ -3382,13 +3382,13 @@ rclpy_clock_set_ros_time_override(PyObject * Py_UNUSED(self), PyObject * args)
  * \param[in] parameter_type_cls The PythonObject for the Parameter.Type class.
  *
  * Returns a pointer to an rclpy.parameter.Parameter with the name, type, and value from
- * the variant or NULL when raising a python exception.
+ * the variant or NULL when raising a Python exception.
  */
 static PyObject * _parameter_from_rcl_variant(
   PyObject * name, rcl_variant_t * variant, PyObject * parameter_cls,
   PyObject * parameter_type_cls)
 {
-  /* Default to 0 (not set) to suppress warnings. A python error will raise if
+  /* Default to 0 (not set) to suppress warnings. A Python error will raise if
    * type and value don't agree */
   int type_enum_value = 0;
   PyObject * value;
@@ -3997,7 +3997,7 @@ static PyMethodDef rclpy_methods[] = {
 
   {
     "rclpy_convert_from_py_qos_policy", rclpy_convert_from_py_qos_policy, METH_VARARGS,
-    "Convert a QoSPolicy python object into a rmw_qos_profile_t."
+    "Convert a QoSPolicy Python object into a rmw_qos_profile_t."
   },
 
   {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3468,7 +3468,6 @@ static PyObject * _parameter_from_rcl_variant(
       return NULL;
     }
     for (size_t i = 0; i < variant->byte_array_value->size; i++) {
-
       member_value = PyBytes_FromFormat("%u", variant->byte_array_value->values[i]);
       if (NULL == member_value) {
         Py_DECREF(value);


### PR DESCRIPTION
With this pull request initial parameters can be passed via yaml parameters file with the `__params:=` and as a list of parameters in the `initial_parameters` kwarg of the Node constructor.

Parameters in the constructor will override parameters from a parameters file.

If at least one reviewer could keep a close eye on my use of Py_DECREF and make sure that I have employed everywhere I should and nowhere I shouldn't have I'd be grateful..  I'm fairly confident in my usage but it's also my first time in Python's C API. 

To test this PR I've been using the params.yaml in this gist https://gist.github.com/nuclearsandwich/8753121711671bfa8d9cb5f718ce09bc and the talker node from demo_nodes_py as well as the parameter services behavior just merged from #214 


Connects to #202 