### PR TITLE
Publish parameter events

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -358,7 +358,6 @@ class Node:
         if self.handle is None:
             return ret
 
-        # TODO: is this needed/desired?
         # Drop extra reference to parameter event publisher.
         # It will be destroyed with other publishers below.
         self._parameter_event_publisher = None

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -175,15 +175,17 @@ class Node:
                 if Parameter.Type.NOT_SET == param.type_:
                     if Parameter.Type.NOT_SET != self.get_parameter(param.name).type_:
                         # Parameter deleted. (Parameter had value and new value is not set)
-                        parameter_event.deleted_parameters.append(param.get_rcl_parameter())
+                        parameter_event.deleted_parameters.append(
+                            param.to_rcl_interface_parameter())
                         del self._parameters[param.name]
                 else:
                     if Parameter.Type.NOT_SET == self.get_parameter(param.name).type_:
                         #  Parameter is new. (Parameter had no value and new value is set)
-                        parameter_event.new_parameters.append(param.get_rcl_parameter())
+                        parameter_event.new_parameters.append(param.to_rcl_interface_parameter())
                     else:
                         # Parameter changed. (Parameter had a value and new value is set)
-                        parameter_event.changed_parameters.append(param.get_rcl_parameter())
+                        parameter_event.changed_parameters.append(
+                            param.to_rcl_interface_parameter())
                     self._parameters[param.name] = param
             self._parameter_event_publisher.publish(parameter_event)
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -185,7 +185,7 @@ class Node:
                         # Parameter changed. (Parameter had a value and new value is set)
                         parameter_event.changed_parameters.append(param.get_rcl_parameter())
                     self._parameters[param.name] = param
-                self._parameter_event_publisher.publish(parameter_event)
+            self._parameter_event_publisher.publish(parameter_event)
 
         return result
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -173,12 +173,12 @@ class Node:
             parameter_event = ParameterEvent()
             for param in parameter_list:
                 if Parameter.Type.NOT_SET == param.type_:
-                    if Parameter.Type.NOT_SET != self.get_parameter(param.name):
+                    if Parameter.Type.NOT_SET != self.get_parameter(param.name).type_:
                         # Parameter deleted. (Parameter had value and new value is not set)
                         parameter_event.deleted_parameters.append(param.get_rcl_parameter())
                         del self._parameters[param.name]
                 else:
-                    if Parameter.Type.NOT_SET == self.get_parameter(param.name):
+                    if Parameter.Type.NOT_SET == self.get_parameter(param.name).type_:
                         #  Parameter is new. (Parameter had no value and new value is set)
                         parameter_event.new_parameters.append(param.get_rcl_parameter())
                     else:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -177,6 +177,9 @@ class Node:
                         # Parameter deleted. (Parameter had value and new value is not set)
                         parameter_event.deleted_parameters.append(
                             param.to_rcl_interface_parameter())
+                    # Delete any unset parameters regardless of their previous value.
+                    # We don't currently store NOT_SET parameters so this is an extra precaution.
+                    if param.name in self._parameters:
                         del self._parameters[param.name]
                 else:
                     if Parameter.Type.NOT_SET == self.get_parameter(param.name).type_:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -176,7 +176,7 @@ class Node:
                     if Parameter.Type.NOT_SET != self.get_parameter(param.name).type_:
                         # Parameter deleted. (Parameter had value and new value is not set)
                         parameter_event.deleted_parameters.append(
-                            param.to_rcl_interface_parameter())
+                            param.to_parameter_msg())
                     # Delete any unset parameters regardless of their previous value.
                     # We don't currently store NOT_SET parameters so this is an extra precaution.
                     if param.name in self._parameters:
@@ -184,11 +184,11 @@ class Node:
                 else:
                     if Parameter.Type.NOT_SET == self.get_parameter(param.name).type_:
                         #  Parameter is new. (Parameter had no value and new value is set)
-                        parameter_event.new_parameters.append(param.to_rcl_interface_parameter())
+                        parameter_event.new_parameters.append(param.to_parameter_msg())
                     else:
                         # Parameter changed. (Parameter had a value and new value is set)
                         parameter_event.changed_parameters.append(
-                            param.to_rcl_interface_parameter())
+                            param.to_parameter_msg())
                     self._parameters[param.name] = param
             self._parameter_event_publisher.publish(parameter_event)
 

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -14,6 +14,7 @@
 
 from enum import Enum
 
+from rcl_interfaces.msg import Parameter as RCLParameter
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType, ParameterValue
 
 PARAMETER_SEPARATOR_STRING = '.'
@@ -132,3 +133,6 @@ class Parameter:
         elif Parameter.Type.STRING_ARRAY == self.type_:
             parameter_value.string_array_value = self.value
         return parameter_value
+
+    def get_rcl_parameter(self):
+        return RCLParameter(name=self.name, value=self.get_parameter_value())

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -134,5 +134,5 @@ class Parameter:
             parameter_value.string_array_value = self.value
         return parameter_value
 
-    def get_rcl_parameter(self):
+    def to_rcl_interface_parameter(self):
         return RCLParameter(name=self.name, value=self.get_parameter_value())

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -14,7 +14,7 @@
 
 from enum import Enum
 
-from rcl_interfaces.msg import Parameter as RCLParameter
+from rcl_interfaces.msg import Parameter as ParameterMsg
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType, ParameterValue
 
 PARAMETER_SEPARATOR_STRING = '.'
@@ -63,28 +63,28 @@ class Parameter:
             return False
 
     @classmethod
-    def from_rcl_interface_parameter(cls, rcl_param):
+    def from_parameter_msg(cls, param_msg):
         value = None
-        type_ = Parameter.Type(value=rcl_param.value.type)
+        type_ = Parameter.Type(value=param_msg.value.type)
         if Parameter.Type.BOOL == type_:
-            value = rcl_param.value.bool_value
+            value = param_msg.value.bool_value
         elif Parameter.Type.INTEGER == type_:
-            value = rcl_param.value.integer_value
+            value = param_msg.value.integer_value
         elif Parameter.Type.DOUBLE == type_:
-            value = rcl_param.value.double_value
+            value = param_msg.value.double_value
         elif Parameter.Type.STRING == type_:
-            value = rcl_param.value.string_value
+            value = param_msg.value.string_value
         elif Parameter.Type.BYTE_ARRAY == type_:
-            value = rcl_param.value.byte_array_value
+            value = param_msg.value.byte_array_value
         elif Parameter.Type.BOOL_ARRAY == type_:
-            value = rcl_param.value.bool_array_value
+            value = param_msg.value.bool_array_value
         elif Parameter.Type.INTEGER_ARRAY == type_:
-            value = rcl_param.value.integer_array_value
+            value = param_msg.value.integer_array_value
         elif Parameter.Type.DOUBLE_ARRAY == type_:
-            value = rcl_param.value.double_array_value
+            value = param_msg.value.double_array_value
         elif Parameter.Type.STRING_ARRAY == type_:
-            value = rcl_param.value.string_array_value
-        return cls(rcl_param.name, type_, value)
+            value = param_msg.value.string_array_value
+        return cls(param_msg.name, type_, value)
 
     def __init__(self, name, type_, value=None):
         if not isinstance(type_, Parameter.Type):
@@ -134,5 +134,5 @@ class Parameter:
             parameter_value.string_array_value = self.value
         return parameter_value
 
-    def to_rcl_interface_parameter(self):
-        return RCLParameter(name=self.name, value=self.get_parameter_value())
+    def to_parameter_msg(self):
+        return ParameterMsg(name=self.name, value=self.get_parameter_value())

--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -117,11 +117,11 @@ class ParameterService:
 
     def _set_parameters_callback(self, request, response):
         for p in request.parameters:
-            param = Parameter.from_rcl_interface_parameter(p)
+            param = Parameter.from_parameter_msg(p)
             response.results.append(self._node.set_parameters_atomically([param]))
         return response
 
     def _set_parameters_atomically_callback(self, request, response):
         response.result = self._node.set_parameters_atomically([
-            Parameter.from_rcl_interface_parameter(p) for p in request.parameters])
+            Parameter.from_parameter_msg(p) for p in request.parameters])
         return response

--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -122,6 +122,6 @@ class ParameterService:
         return response
 
     def _set_parameters_atomically_callback(self, request, response):
-        response.results = self._node.set_parameters_atomically([
+        response.result = self._node.set_parameters_atomically([
             Parameter.from_rcl_interface_parameter(p) for p in request.parameters])
         return response

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -174,8 +174,6 @@ qos_profile_sensor_data = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_sensor_data')
 qos_profile_services_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_services_default')
-# NOTE(mikaelarguedas) the following are defined but not used because
-# parameters are not implemented in Python yet
 qos_profile_parameters = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_parameters')
 qos_profile_parameter_events = _rclpy.rclpy_get_rmw_qos_profile(

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -107,10 +107,10 @@ def func_destroy_entities():
     timer  # noqa
     assert 1 == len(node.timers)
     pub1 = node.create_publisher(Primitives, 'pub1_topic')
-    assert 1 == len(node.publishers)
+    assert 2 == len(node.publishers)
     pub2 = node.create_publisher(Primitives, 'pub2_topic')
     pub2  # noqa
-    assert 2 == len(node.publishers)
+    assert 3 == len(node.publishers)
     sub1 = node.create_subscription(
         Primitives, 'sub1_topic', lambda msg: print('Received %r' % msg))
     assert 1 == len(node.subscriptions)
@@ -120,7 +120,7 @@ def func_destroy_entities():
     assert 2 == len(node.subscriptions)
 
     assert node.destroy_publisher(pub1) is True
-    assert 1 == len(node.publishers)
+    assert 2 == len(node.publishers)
 
     assert node.destroy_subscription(sub1) is True
     assert 1 == len(node.subscriptions)


### PR DESCRIPTION
This is a recreation of a change that was accidentally authored in a temporary container :sob:. 

Adds a parameter events publisher to rclpy nodes and publishes events when parameters are successfully set atomically.

I did some basic testing of the earlier version of this using `ros2 topic echo` and comparing the results with rclcpp nodes but I need to do a bit more before I feel good putting this in review.

Connects to #202 