### PR TITLE
Add test for when sim time is active but unset

### DIFF
--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -102,6 +102,9 @@ class TestTimeSource(unittest.TestCase):
         # A subscriber should have been created
         assert time_source._clock_sub is not None
 
+        # Before any messages have been received on the /clock topic, now() should return 0
+        assert clock.now() == Time(seconds=0, clock_type=ClockType.ROS_TIME)
+
         # When using sim time, ROS time should look like the messages received on /clock
         self.publish_clock_messages()
         assert clock.now() > Time(seconds=0, clock_type=ClockType.ROS_TIME)


### PR DESCRIPTION
~Currently the time is uninitialised in rcl in that state~ Should be addressed by https://github.com/ros2/rcl/pull/283

I added this test in the past and it would fail. CI should pass now:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5086)](http://ci.ros2.org/job/ci_linux/5086/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1870)](http://ci.ros2.org/job/ci_linux-aarch64/1870/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4216)](http://ci.ros2.org/job/ci_osx/4216/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5067)](http://ci.ros2.org/job/ci_windows/5067/)