### PR TITLE
Fix warning when parameter value is uninitialized.

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3541,10 +3541,11 @@ static PyObject * _parameter_from_rcl_variant(
   PyObject * name, rcl_variant_t * variant, PyObject * parameter_cls,
   PyObject * parameter_type_cls)
 {
-  /* Default to NOT_SET to suppress warnings. A Python error will raise if
-   * type and value don't agree */
+
+  // Default to NOT_SET and a value of Py_None to suppress warnings.
+  // A Python error will raise if type and value don't agree.
   int type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_NOT_SET;
-  PyObject * value;
+  PyObject * value = Py_None;
   PyObject * member_value;
   if (variant->bool_value) {
     type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_BOOL;
@@ -3635,6 +3636,9 @@ static PyObject * _parameter_from_rcl_variant(
       }
       PyList_SET_ITEM(value, i, member_value);
     }
+  } else {
+    // INCREF Py_None if no other value was set.
+    Py_INCREF(value);
   }
 
   PyObject * args = Py_BuildValue("(i)", type_enum_value);

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3541,7 +3541,6 @@ static PyObject * _parameter_from_rcl_variant(
   PyObject * name, rcl_variant_t * variant, PyObject * parameter_cls,
   PyObject * parameter_type_cls)
 {
-
   // Default to NOT_SET and a value of Py_None to suppress warnings.
   // A Python error will raise if type and value don't agree.
   int type_enum_value = rcl_interfaces__msg__ParameterType__PARAMETER_NOT_SET;


### PR DESCRIPTION
Resolves the warning below which popped up in the nightlies ([example](https://ci.ros2.org/view/nightly/job/nightly_linux_release/918)) from #225 

```
In file included from /usr/include/python3.6m/pytime.h:6:0,
                 from /usr/include/python3.6m/Python.h:68,
                 from /home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/src/rclpy/_rclpy.c:15:
/home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/src/rclpy/_rclpy.c: In function ‘_parse_param_files’:
/usr/include/python3.6m/object.h:791:27: warning: ‘value’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         --(_py_decref_tmp)->ob_refcnt != 0)             \
                           ^~
/home/rosbuild/ci_scripts/ws/src/ros2/rclpy/rclpy/src/rclpy/_rclpy.c:3547:14: note: ‘value’ was declared here
   PyObject * value;
              ^~~~~
```