### PR TITLE
Add methods on Mock class for Python 3.5 compatibility

### DIFF
--- a/rclpy/test/mock_compat.py
+++ b/rclpy/test/mock_compat.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock as _standard_mock
+
+
+if hasattr(_standard_mock, 'assert_called_once'):
+    # Python 3.6+
+    Mock = _standard_mock
+else:
+    # Python 3.5
+
+    class Mock(_standard_mock):
+        """Add methods added in python 3.6 for python 3.5 compatibility."""
+
+        def assert_called_once(self, *args, **kwargs):
+            if len(args) or len(kwargs):
+                return self.assert_called_once_with(*args, **kwargs)
+            else:
+                return 1 == self.call_count
+
+        def assert_called(self, *args, **kwargs):
+            if len(args) or len(kwargs):
+                return self.assert_called_with(*args, **kwargs)
+            else:
+                return self.call_count > 0

--- a/rclpy/test/mock_compat.py
+++ b/rclpy/test/mock_compat.py
@@ -12,26 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock as _standard_mock
+import types
+from unittest.mock import Mock
 
 
-if hasattr(_standard_mock, 'assert_called_once'):
-    # Python 3.6+
-    Mock = _standard_mock
-else:
+if not hasattr(Mock, 'assert_called_once'):
     # Python 3.5
 
-    class Mock(_standard_mock):
-        """Add methods added in python 3.6 for python 3.5 compatibility."""
+    def assert_called_once(self, *args, **kwargs):
+        if len(args) or len(kwargs):
+            return self.assert_called_once_with(*args, **kwargs)
+        else:
+            return 1 == self.call_count
 
-        def assert_called_once(self, *args, **kwargs):
-            if len(args) or len(kwargs):
-                return self.assert_called_once_with(*args, **kwargs)
-            else:
-                return 1 == self.call_count
+    def assert_called(self, *args, **kwargs):
+        if len(args) or len(kwargs):
+            return self.assert_called_with(*args, **kwargs)
+        else:
+            return self.call_count > 0
 
-        def assert_called(self, *args, **kwargs):
-            if len(args) or len(kwargs):
-                return self.assert_called_with(*args, **kwargs)
-            else:
-                return self.call_count > 0
+    # Monkey patch methods onto Mock type
+    Mock.assert_called_once = types.MethodType(assert_called_once, None, Mock)
+    Mock.assert_called = types.MethodType(assert_called, None, Mock)

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -23,7 +23,7 @@ from rclpy.clock import ROSClock
 from rclpy.duration import Duration
 from rclpy.time import Time
 
-from .mock_compat import *  # noqa
+from .mock_compat import __name__ as _  # noqa: ignore=F401
 
 
 class TestClock(unittest.TestCase):

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -14,7 +14,6 @@
 
 import time
 import unittest
-from unittest.mock import Mock
 
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
@@ -22,6 +21,8 @@ from rclpy.clock import JumpThreshold
 from rclpy.clock import ROSClock
 from rclpy.duration import Duration
 from rclpy.time import Time
+
+from .mock_compat import Mock
 
 
 class TestClock(unittest.TestCase):

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -14,6 +14,7 @@
 
 import time
 import unittest
+from unittest.mock import Mock
 
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
@@ -22,7 +23,7 @@ from rclpy.clock import ROSClock
 from rclpy.duration import Duration
 from rclpy.time import Time
 
-from .mock_compat import Mock
+from .mock_compat import *  # noqa
 
 
 class TestClock(unittest.TestCase):

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -28,7 +28,7 @@ from rclpy.time import Time
 from rclpy.time_source import CLOCK_TOPIC
 from rclpy.time_source import TimeSource
 
-from .mock_compat import *  # noqa
+from .mock_compat import __name__ as _  # noqa: ignore=F401
 
 
 class TestTimeSource(unittest.TestCase):

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -14,7 +14,6 @@
 
 import time
 import unittest
-from unittest.mock import Mock
 
 import builtin_interfaces.msg
 import rclpy
@@ -27,6 +26,8 @@ from rclpy.duration import Duration
 from rclpy.time import Time
 from rclpy.time_source import CLOCK_TOPIC
 from rclpy.time_source import TimeSource
+
+from .mock_compat import Mock
 
 
 class TestTimeSource(unittest.TestCase):

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -14,6 +14,7 @@
 
 import time
 import unittest
+from unittest.mock import Mock
 
 import builtin_interfaces.msg
 import rclpy
@@ -27,7 +28,7 @@ from rclpy.time import Time
 from rclpy.time_source import CLOCK_TOPIC
 from rclpy.time_source import TimeSource
 
-from .mock_compat import Mock
+from .mock_compat import *  # noqa
 
 
 class TestTimeSource(unittest.TestCase):


### PR DESCRIPTION
This fixes some test failures on xenial caused by ros2/rclpy#222. The tests used methods on `unittest.mock.Mock` that were added in python 3.6. This PR ~~~adds a subclass with those methods defined~~~ monkey patches those methods onto the mock class if they are not present.

Xenial CI just rclpy
[![Build Status](https://ci.ros2.org/job/ci_linux/5177/badge/icon)](https://ci.ros2.org/job/ci_linux/5177/)

CI bionic just rclpy
[![Build Status](https://ci.ros2.org/job/ci_linux/5178/badge/icon)](https://ci.ros2.org/job/ci_linux/5178/)

Will run full CI post review

Connects to ros2/build_cop#147