### PR TITLE
Don't use MethodType when monkey patching

### DIFF
--- a/rclpy/test/mock_compat.py
+++ b/rclpy/test/mock_compat.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import types
 from unittest.mock import Mock
 
 
@@ -32,5 +31,5 @@ if not hasattr(Mock, 'assert_called_once'):
             return self.call_count > 0
 
     # Monkey patch methods onto Mock type
-    Mock.assert_called_once = types.MethodType(assert_called_once, None, Mock)
-    Mock.assert_called = types.MethodType(assert_called, None, Mock)
+    Mock.assert_called_once = assert_called_once
+    Mock.assert_called = assert_called


### PR DESCRIPTION
ros2/rclpy#237 added monkey patching to `unitest.mock.Mock` for compatibility with python 3.5. It looks like I got confused and ended up merging without running xenial CI again, and the approach had test failures: https://ci.ros2.org/view/nightly/job/nightly_xenial_linux_release/101/testReport/junit/(root)/rclpy/test_test_clock/

There seems to be a difference in the number of arguments `MethodType` takes in python 3.5 and 3.6. It turns out `MethodType` isn't necessary when adding new methods to a class rather than an instance, so this PR removes it. 

Xenial
[![Build Status](https://ci.ros2.org/job/ci_linux/5202/badge/icon)](https://ci.ros2.org/job/ci_linux/5202/)

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5203)](http://ci.ros2.org/job/ci_linux/5203/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1967)](http://ci.ros2.org/job/ci_linux-aarch64/1967/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4321)](http://ci.ros2.org/job/ci_osx/4321/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5181)](http://ci.ros2.org/job/ci_windows/5181/)
