### PR TITLE
rclpy raw subscriptions

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -238,7 +238,7 @@ class Executor:
         await await_or_execute(tmr.callback)
 
     def _take_subscription(self, sub):
-        msg = _rclpy.rclpy_take(sub.subscription_handle, sub.msg_type)
+        msg = _rclpy.rclpy_take(sub.subscription_handle, sub.msg_type, sub.raw)
         return msg
 
     async def _execute_subscription(self, sub, msg):

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -230,7 +230,7 @@ class Node:
 
     def create_subscription(
             self, msg_type, topic, callback, *, qos_profile=qos_profile_default,
-            callback_group=None):
+            callback_group=None, raw=False):
         if callback_group is None:
             callback_group = self._default_callback_group
         # this line imports the typesupport for the message module if not already done
@@ -246,7 +246,7 @@ class Node:
 
         subscription = Subscription(
             subscription_handle, subscription_pointer, msg_type,
-            topic, callback, callback_group, qos_profile, self.handle)
+            topic, callback, callback_group, qos_profile, self.handle, raw)
         self.subscriptions.append(subscription)
         callback_group.add_entity(subscription)
         return subscription

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -17,7 +17,7 @@ class Subscription:
 
     def __init__(
             self, subscription_handle, subscription_pointer,
-            msg_type, topic, callback, callback_group, qos_profile, node_handle):
+            msg_type, topic, callback, callback_group, qos_profile, node_handle, raw):
         self.node_handle = node_handle
         self.subscription_handle = subscription_handle
         self.subscription_pointer = subscription_pointer
@@ -28,3 +28,4 @@ class Subscription:
         # True when the callback is ready to fire but has not been "taken" by an executor
         self._executor_event = False
         self.qos_profile = qos_profile
+        self.raw = raw

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2642,6 +2642,8 @@ rclpy_take_raw(rcl_subscription_t * subscription)
   rmw_ret_t r_fini = rmw_serialized_message_fini(&msg);
   if (r_fini != RMW_RET_OK) {
     PyErr_Format(PyExc_RuntimeError, "Failed to deallocate message buffer: %d", r_fini);
+    Py_DECREF(python_bytes);
+    return NULL;
   }
   return python_bytes;
 }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2251,23 +2251,23 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
   if (0 == strcmp(entity_type, "subscription")) {
     rcl_subscription_t * subscription =
       (rcl_subscription_t *)PyCapsule_GetPointer(pyentity, "rcl_subscription_t");
-    ret = rcl_wait_set_add_subscription(wait_set, subscription);
+    ret = rcl_wait_set_add_subscription(wait_set, subscription, NULL);
   } else if (0 == strcmp(entity_type, "client")) {
     rcl_client_t * client =
       (rcl_client_t *)PyCapsule_GetPointer(pyentity, "rcl_client_t");
-    ret = rcl_wait_set_add_client(wait_set, client);
+    ret = rcl_wait_set_add_client(wait_set, client, NULL);
   } else if (0 == strcmp(entity_type, "service")) {
     rcl_service_t * service =
       (rcl_service_t *)PyCapsule_GetPointer(pyentity, "rcl_service_t");
-    ret = rcl_wait_set_add_service(wait_set, service);
+    ret = rcl_wait_set_add_service(wait_set, service, NULL);
   } else if (0 == strcmp(entity_type, "timer")) {
     rcl_timer_t * timer =
       (rcl_timer_t *)PyCapsule_GetPointer(pyentity, "rcl_timer_t");
-    ret = rcl_wait_set_add_timer(wait_set, timer);
+    ret = rcl_wait_set_add_timer(wait_set, timer, NULL);
   } else if (0 == strcmp(entity_type, "guard_condition")) {
     rcl_guard_condition_t * guard_condition =
       (rcl_guard_condition_t *)PyCapsule_GetPointer(pyentity, "rcl_guard_condition_t");
-    ret = rcl_wait_set_add_guard_condition(wait_set, guard_condition);
+    ret = rcl_wait_set_add_guard_condition(wait_set, guard_condition, NULL);
   } else {
     ret = RCL_RET_ERROR;  // to avoid a linter warning
     PyErr_Format(PyExc_RuntimeError,

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -23,11 +23,8 @@
 #include <rcl/validate_topic_name.h>
 #include <rcl_yaml_param_parser/parser.h>
 #include <rcl_interfaces/msg/parameter_type__struct.h>
-<<<<<<< 52dc2dba062dd5828e093e8ca174e3147a37ad37
 #include <rcutils/format_string.h>
-=======
 #include <rcutils/allocator.h>
->>>>>>> Fixed allocation to use rmw allocatior rather than fixed size buffer
 #include <rcutils/strdup.h>
 #include <rcutils/types.h>
 #include <rmw/error_handling.h>

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -23,8 +23,8 @@
 #include <rcl/validate_topic_name.h>
 #include <rcl_yaml_param_parser/parser.h>
 #include <rcl_interfaces/msg/parameter_type__struct.h>
-#include <rcutils/format_string.h>
 #include <rcutils/allocator.h>
+#include <rcutils/format_string.h>
 #include <rcutils/strdup.h>
 #include <rcutils/types.h>
 #include <rmw/error_handling.h>

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2638,7 +2638,7 @@ rclpy_take_raw(rcl_subscription_t * subscription)
     }
     return NULL;
   }
-  PyObject * python_bytes = PyBytes_FromStringAndSize(msg.buffer, msg.buffer_length);
+  PyObject * python_bytes = PyBytes_FromStringAndSize((char *)(msg.buffer), msg.buffer_length);
   rmw_ret_t r_fini = rmw_serialized_message_fini(&msg);
   if (r_fini != RMW_RET_OK) {
     PyErr_Format(PyExc_RuntimeError, "Failed to deallocate message buffer: %d", r_fini);

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2428,9 +2428,9 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
  * \param[in] rcl subscription pointer pointing to the subscription to process the message
  * \return Python byte array with the raw serialized message contents
  */
- static PyObject *
- rclpy_take_raw(rcl_subscription_t * subscription)
- {
+static PyObject *
+rclpy_take_raw(rcl_subscription_t * subscription)
+{
   // Create a serialized message object
   rcl_serialized_message_t msg = rmw_get_zero_initialized_serialized_message();
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
@@ -2457,7 +2457,7 @@ rclpy_wait(PyObject * Py_UNUSED(self), PyObject * args)
     }
     return NULL;
   }
-  PyObject* python_bytes = PyBytes_FromStringAndSize(msg.buffer, msg.buffer_length);
+  PyObject * python_bytes = PyBytes_FromStringAndSize(msg.buffer, msg.buffer_length);
   rmw_ret_t r_fini = rmw_serialized_message_fini(&msg);
   if (r_fini != RMW_RET_OK) {
     PyErr_Format(PyExc_RuntimeError, "Failed to deallocate message buffer: %d", r_fini);

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -193,7 +193,7 @@ class SubscriptionWaitable(Waitable):
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.subscription_is_ready:
             self.subscription_is_ready = False
-            return _rclpy.rclpy_take(self.subscription, EmptyMsg)
+            return _rclpy.rclpy_take(self.subscription, EmptyMsg, False)
         return None
 
     async def execute(self, taken_data):


### PR DESCRIPTION
Note: This implementation is incomplete and at the moment this PR exists primarily for getting feedback.
This is being done so that [ros2cli#132](https://github.com/ros2/ros2cli/issues/132) can implement "ros2 topic bw".

- [x] Initial prototype 
- [x] Correct memory allocation implementation
- [x] Add tests
- [x] Add example to demos/demo_nodes_py

The general idea is to allow creating a raw subscription like so:
```
class ListenerRaw(Node):

    def __init__(self):
        super().__init__('listener')
        self.sub = self.create_subscription(String, 'chatter', self.chatter_callback, raw=True)

    def chatter_callback(self, msg):
        self.get_logger().info('I heard: [%s]' % msg)
```
This will call rcl_take_serialized_message rather than rcl_take internally, and return a python byte array representing the serialised message.

> [INFO] [listener]: I heard: [b'\x00\x01\x00\x00\x05\x00\x00\x00Test\x00\x00\x00\x00']
(For the message "Test").