### PR TITLE
Add library path hook.

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -92,6 +92,12 @@ ament_target_dependencies(rclpy_logging
   "rcutils"
 )
 
+if(NOT WIN32)
+  ament_environment_hooks(
+    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}"
+  )
+endif()
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()


### PR DESCRIPTION
Set library path environment hook for this package. This package is one of a handful which installs libraries without setting an environment hook to add them to the platform library path.

Connects to ros2/ros_workspace#10