### PR TITLE
refactor to allow for non-global init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 
 # PyBuilder
 target/
+.pytest_cache

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -14,17 +14,17 @@
 
 import sys
 
+from rclpy.utilities import get_default_context
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
-from rclpy.utilities import ok
 from rclpy.utilities import shutdown as _shutdown
 from rclpy.utilities import try_shutdown  # noqa
 
 
-def init(*, args=None):
+def init(*, args=None, context=None):
+    context = get_default_context if context is None else context
     # imported locally to avoid loading extensions on module import
     from rclpy.impl.implementation_singleton import rclpy_implementation
-    return rclpy_implementation.rclpy_init(
-        args if args is not None else sys.argv)
+    return rclpy_implementation.rclpy_init(args if args is not None else sys.argv, context)
 
 
 # The global spin functions need an executor to do the work
@@ -97,7 +97,7 @@ def spin_once(node, *, timeout_sec=None):
         executor.remove_node(node)
 
 
-def spin(node):
+def spin(node, executor=None):
     """
     Execute work blocking until the library is shutdown.
 
@@ -105,29 +105,32 @@ def spin(node):
     This method blocks.
 
     :param node: A node to add to the executor to check for work.
+    :param executor: The executor to use, of the global executor if None is passed.
     :return: Always returns None regardless whether work executes or timeout expires.
     :rtype: None
     """
-    executor = get_global_executor()
+    executor = get_global_executor() if executor is None else executor
     try:
         executor.add_node(node)
-        while ok():
+        while executor.context.ok():
             executor.spin_once()
     finally:
         executor.remove_node(node)
 
 
-def spin_until_future_complete(node, future):
+def spin_until_future_complete(node, future, executor=None):
     """
     Execute work until the future is complete.
 
     Callbacks and other work will be executed in a SingleThreadedExecutor until future.done()
     returns True or rclpy is shutdown.
 
+    :param node: A node to add to the executor to check for work.
     :param future: The future object to wait on.
+    :param executor: The executor to use, of the global executor if None is passed.
     :type future: rclpy.task.Future
     """
-    executor = get_global_executor()
+    executor = get_global_executor() if executor is None else executor
     try:
         executor.add_node(node)
         executor.spin_until_future_complete(future)

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -16,6 +16,7 @@ import sys
 
 from rclpy.utilities import get_default_context
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa
+from rclpy.utilities import ok  # noqa: forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
 from rclpy.utilities import try_shutdown  # noqa
 
@@ -41,22 +42,23 @@ def get_global_executor():
     return __executor
 
 
-def shutdown():
+def shutdown(*, context=None):
     global __executor
     if __executor is not None:
         __executor.shutdown()
         __executor = None
-    _shutdown()
+    _shutdown(context=context)
 
 
 def create_node(
-    node_name, *, cli_args=None, namespace=None, use_global_arguments=True,
+    node_name, *, context=None, cli_args=None, namespace=None, use_global_arguments=True,
     start_parameter_services=True, initial_parameters=None
 ):
     """
     Create an instance of :class:`rclpy.node.Node`.
 
-    :param node_name: A unique name to give to this node
+    :param node_name: A unique name to give to this node.
+    :param context: The context to be associated with, or None for the default global context.
     :param cli_args: A list of strings of command line args to be used only by this node.
     :param namespace: The namespace to which relative topic and service names will be prefixed.
     :param use_global_arguments: False if the node should ignore process-wide command line args.
@@ -68,7 +70,7 @@ def create_node(
     # imported locally to avoid loading extensions on module import
     from rclpy.node import Node
     return Node(
-        node_name, cli_args=cli_args, namespace=namespace,
+        node_name, context=context, cli_args=cli_args, namespace=namespace,
         use_global_arguments=use_global_arguments,
         start_parameter_services=start_parameter_services,
         initial_parameters=initial_parameters)

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -17,14 +17,14 @@ import time
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.task import Future
-import rclpy.utilities
 
 
 class Client:
     def __init__(
-            self, node_handle, client_handle, client_pointer,
+            self, node_handle, context, client_handle, client_pointer,
             srv_type, srv_name, qos_profile, callback_group):
         self.node_handle = node_handle
+        self.context = context
         self.client_handle = client_handle
         self.client_pointer = client_pointer
         self.srv_type = srv_type
@@ -102,7 +102,7 @@ class Client:
         sleep_time = 0.25
         if timeout_sec is None:
             timeout_sec = float('inf')
-        while rclpy.utilities.ok() and not self.service_is_ready() and timeout_sec > 0.0:
+        while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
             time.sleep(sleep_time)
             timeout_sec -= sleep_time
 

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -19,6 +19,8 @@ class Context:
     """
     Encapsulates the lifecycle of init and shutdown.
 
+    Context objects should not be reused, and are finalized in their destructor.
+
     Wraps the `rcl_context_t` type.
     """
 

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -1,0 +1,52 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+
+
+class Context:
+    """
+    Encapsulates the lifecycle of init and shutdown.
+
+    Wraps the `rcl_context_t` type.
+    """
+
+    def __init__(self):
+        from rclpy.impl.implementation_singleton import rclpy_implementation
+        self._handle = rclpy_implementation.rclpy_create_context()
+        self._lock = threading.Lock()
+
+    @property
+    def handle(self):
+        return self._handle
+
+    def ok(self):
+        # imported locally to avoid loading extensions on module import
+        from rclpy.impl.implementation_singleton import rclpy_implementation
+        with self._lock:
+            return rclpy_implementation.rclpy_ok(self._handle)
+
+    def shutdown(self):
+        # imported locally to avoid loading extensions on module import
+        from rclpy.impl.implementation_singleton import rclpy_implementation
+        with self._lock:
+            return rclpy_implementation.rclpy_shutdown(self._handle)
+
+    def try_shutdown(self):
+        """Shutdown rclpy if not already shutdown."""
+        # imported locally to avoid loading extensions on module import
+        from rclpy.impl.implementation_singleton import rclpy_implementation
+        with self._lock:
+            if rclpy_implementation.rclpy_ok(self._handle):
+                return rclpy_implementation.rclpy_shutdown(self._handle)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -112,7 +112,7 @@ class Executor:
     :param context: The context to be associated with, or None for the default global context.
     """
 
-    def __init__(self, context):
+    def __init__(self, *, context=None):
         super().__init__()
         self._context = get_default_context() if context is None else context
         self._nodes = set()
@@ -549,6 +549,9 @@ class Executor:
 class SingleThreadedExecutor(Executor):
     """Runs callbacks in the thread which calls :func:`SingleThreadedExecutor.spin`."""
 
+    def __init__(self, *, context=None):
+        super().__init__(context=context)
+
     def spin_once(self, timeout_sec=None):
         try:
             handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
@@ -563,7 +566,7 @@ class SingleThreadedExecutor(Executor):
 class MultiThreadedExecutor(Executor):
     """Runs callbacks in a pool of threads."""
 
-    def __init__(self, num_threads=None):
+    def __init__(self, num_threads=None, *, context=None):
         """
         Initialize the executor.
 
@@ -572,7 +575,7 @@ class MultiThreadedExecutor(Executor):
                       of threads defaults to 1.
         :type num_threads: int
         """
-        super().__init__()
+        super().__init__(context=context)
         if num_threads is None:
             try:
                 num_threads = multiprocessing.cpu_count()

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -22,7 +22,7 @@ from threading import RLock
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.task import Task
 from rclpy.timer import WallTimer
-from rclpy.utilities import ok
+from rclpy.utilities import get_default_context
 from rclpy.utilities import timeout_sec_to_nsec
 from rclpy.waitable import NumberOfEntities
 
@@ -108,17 +108,20 @@ class Executor:
 
     A custom executor must define :func:`Executor.spin_once`. If the executor has any cleanup then
     it should also define :func:`Executor.shutdown`.
+
+    :param context: The context to be associated with, or None for the default global context.
     """
 
-    def __init__(self):
+    def __init__(self, context):
         super().__init__()
+        self._context = get_default_context() if context is None else context
         self._nodes = set()
         self._nodes_lock = RLock()
         # Tasks to be executed (oldest first) 3-tuple Task, Entity, Node
         self._tasks = []
         self._tasks_lock = Lock()
         # This is triggered when wait_for_ready_callbacks should rebuild the wait list
-        gc, gc_handle = _rclpy.rclpy_create_guard_condition()
+        gc, gc_handle = _rclpy.rclpy_create_guard_condition(self._context.handle)
         self._guard_condition = gc
         self._guard_condition_handle = gc_handle
         # True if shutdown has been called
@@ -128,6 +131,10 @@ class Executor:
         self._cb_iter = None
         self._last_args = None
         self._last_kwargs = None
+
+    @property
+    def context(self):
+        return self._context
 
     def create_task(self, callback, *args, **kwargs):
         """
@@ -212,12 +219,12 @@ class Executor:
 
     def spin(self):
         """Execute callbacks until shutdown."""
-        while ok():
+        while self._context.ok():
             self.spin_once()
 
     def spin_until_future_complete(self, future):
         """Execute until a given future is done."""
-        while ok() and not future.done():
+        while self._context.ok() and not future.done():
             self.spin_once()
 
     def spin_once(self, timeout_sec=None):
@@ -419,7 +426,8 @@ class Executor:
                         )
                 for waitable in waitables:
                     waitable.add_to_wait_set(wait_set)
-                (sigint_gc, sigint_gc_handle) = _rclpy.rclpy_get_sigint_guard_condition()
+                (sigint_gc, sigint_gc_handle) = \
+                    _rclpy.rclpy_get_sigint_guard_condition(self._context.handle)
                 try:
                     _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
                     _rclpy.rclpy_wait_set_add_entity(

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.utilities import get_default_context
 
 
 class GuardCondition:
 
-    def __init__(self, callback, callback_group):
-        self.guard_handle, self.guard_pointer = _rclpy.rclpy_create_guard_condition()
+    def __init__(self, callback, callback_group, context=None):
+        self._context = get_default_context() if context is None else context
+        self.guard_handle, self.guard_pointer = \
+            _rclpy.rclpy_create_guard_condition(self._context.handle)
         self.callback = callback
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -318,7 +318,7 @@ class Node:
         timer_period_nsec = int(float(timer_period_sec) * S_TO_NS)
         if callback_group is None:
             callback_group = self._default_callback_group
-        timer = WallTimer(callback, callback_group, timer_period_nsec)
+        timer = WallTimer(callback, callback_group, timer_period_nsec, context=self.context)
 
         self.timers.append(timer)
         callback_group.add_entity(timer)
@@ -327,7 +327,7 @@ class Node:
     def create_guard_condition(self, callback, callback_group=None):
         if callback_group is None:
             callback_group = self._default_callback_group
-        guard = GuardCondition(callback, callback_group)
+        guard = GuardCondition(callback, callback_group, context=self.context)
 
         self.guards.append(guard)
         callback_group.add_entity(guard)

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -47,8 +47,8 @@ class Future:
     def __del__(self):
         if self._exception is not None and not self._exception_fetched:
             print(
-                'The following exception was never retrieved: ' +
-                str(self._exception), file=sys.stderr)
+                'The following exception was never retrieved: ' + str(self._exception),
+                file=sys.stderr)
 
     def __await__(self):
         # Yield if the task is not finished

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -15,12 +15,14 @@
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.utilities import get_default_context
 
 
 # TODO(mikaelarguedas) create a Timer or ROSTimer once we can specify custom time sources
 class WallTimer:
 
-    def __init__(self, callback, callback_group, timer_period_ns):
+    def __init__(self, callback, callback_group, timer_period_ns, context=None):
+        self._context = get_default_context() if context is None else context
         # TODO(sloretz) Allow passing clocks in via timer constructor
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -21,12 +21,12 @@ from rclpy.utilities import get_default_context
 # TODO(mikaelarguedas) create a Timer or ROSTimer once we can specify custom time sources
 class WallTimer:
 
-    def __init__(self, callback, callback_group, timer_period_ns, context=None):
+    def __init__(self, callback, callback_group, timer_period_ns, *, context=None):
         self._context = get_default_context() if context is None else context
         # TODO(sloretz) Allow passing clocks in via timer constructor
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(
-            self._clock._clock_handle, timer_period_ns)
+            self._clock._clock_handle, self._context.handle, timer_period_ns)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
         self.callback_group = callback_group

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -16,9 +16,20 @@ import sys
 import threading
 
 from rclpy.constants import S_TO_NS
+from rclpy.context import Context
+
+g_default_context = None
+g_context_lock = threading.Lock()
 
 
-g_shutdown_lock = threading.Lock()
+def get_default_context():
+    """Return the global default context singleton."""
+    global g_context_lock
+    with g_context_lock:
+        global g_default_context
+        if g_default_context is None:
+            g_default_context = Context()
+        return g_default_context
 
 
 def remove_ros_args(args=None):
@@ -28,27 +39,23 @@ def remove_ros_args(args=None):
         args if args is not None else sys.argv)
 
 
-def ok():
-    # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    with g_shutdown_lock:
-        return rclpy_implementation.rclpy_ok()
+def ok(context=None):
+    if context is None:
+        context = get_default_context()
+    return context.ok()
 
 
-def shutdown():
-    # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    with g_shutdown_lock:
-        return rclpy_implementation.rclpy_shutdown()
+def shutdown(context=None):
+    if context is None:
+        context = get_default_context()
+    return context.shutdown()
 
 
-def try_shutdown():
+def try_shutdown(context=None):
     """Shutdown rclpy if not already shutdown."""
-    # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    with g_shutdown_lock:
-        if rclpy_implementation.rclpy_ok():
-            return rclpy_implementation.rclpy_shutdown()
+    if context is None:
+        context = get_default_context()
+    return context.try_shutdown()
 
 
 def get_rmw_implementation_identifier():

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -22,13 +22,17 @@ g_default_context = None
 g_context_lock = threading.Lock()
 
 
-def get_default_context():
+def get_default_context(*, shutting_down=False):
     """Return the global default context singleton."""
     global g_context_lock
     with g_context_lock:
         global g_default_context
         if g_default_context is None:
             g_default_context = Context()
+        if shutting_down:
+            old_context = g_default_context
+            g_default_context = None
+            return old_context
         return g_default_context
 
 
@@ -39,19 +43,19 @@ def remove_ros_args(args=None):
         args if args is not None else sys.argv)
 
 
-def ok(context=None):
+def ok(*, context=None):
     if context is None:
         context = get_default_context()
     return context.ok()
 
 
-def shutdown(context=None):
+def shutdown(*, context=None):
     if context is None:
-        context = get_default_context()
+        context = get_default_context(shutting_down=True)
     return context.shutdown()
 
 
-def try_shutdown(context=None):
+def try_shutdown(*, context=None):
     """Shutdown rclpy if not already shutdown."""
     if context is None:
         context = get_default_context()

--- a/rclpy/test/test_callback_group.py
+++ b/rclpy/test/test_callback_group.py
@@ -25,13 +25,14 @@ class TestCallbackGroup(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        rclpy.init()
-        cls.node = rclpy.create_node('TestCallbackGroup', namespace='/rclpy')
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node('TestCallbackGroup', namespace='/rclpy', context=cls.context)
 
     @classmethod
     def tearDownClass(cls):
         cls.node.destroy_node()
-        rclpy.shutdown()
+        rclpy.shutdown(context=cls.context)
 
     def test_reentrant_group(self):
         self.assertIsNotNone(self.node.handle)

--- a/rclpy/test/test_create_node.py
+++ b/rclpy/test/test_create_node.py
@@ -24,51 +24,52 @@ class TestCreateNode(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        rclpy.init()
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
 
     @classmethod
     def tearDownClass(cls):
-        rclpy.shutdown()
+        rclpy.shutdown(context=cls.context)
 
     def test_create_node(self):
         node_name = 'create_node_test'
-        rclpy.create_node(node_name).destroy_node()
+        rclpy.create_node(node_name, context=self.context).destroy_node()
 
     def test_create_node_with_namespace(self):
         node_name = 'create_node_test'
         namespace = '/ns'
-        rclpy.create_node(node_name, namespace=namespace).destroy_node()
+        rclpy.create_node(node_name, namespace=namespace, context=self.context).destroy_node()
 
     def test_create_node_with_empty_namespace(self):
         node_name = 'create_node_test'
         namespace = ''
-        node = rclpy.create_node(node_name, namespace=namespace)
+        node = rclpy.create_node(node_name, namespace=namespace, context=self.context)
         self.assertEqual('/', node.get_namespace())
         node.destroy_node()
 
     def test_create_node_with_relative_namespace(self):
         node_name = 'create_node_test'
         namespace = 'ns'
-        node = rclpy.create_node(node_name, namespace=namespace)
+        node = rclpy.create_node(node_name, namespace=namespace, context=self.context)
         self.assertEqual('/ns', node.get_namespace())
         node.destroy_node()
 
     def test_create_node_invalid_name(self):
         node_name = 'create_node_test_invalid_name?'
         with self.assertRaisesRegex(InvalidNodeNameException, 'must not contain characters'):
-            rclpy.create_node(node_name)
+            rclpy.create_node(node_name, context=self.context)
 
     def test_create_node_invalid_relative_namespace(self):
         node_name = 'create_node_test_invalid_namespace'
         namespace = 'invalid_namespace?'
         with self.assertRaisesRegex(InvalidNamespaceException, 'must not contain characters'):
-            rclpy.create_node(node_name, namespace=namespace)
+            rclpy.create_node(node_name, namespace=namespace, context=self.context)
 
     def test_create_node_invalid_namespace(self):
         node_name = 'create_node_test_invalid_namespace'
         namespace = '/invalid_namespace?'
         with self.assertRaisesRegex(InvalidNamespaceException, 'must not contain characters'):
-            rclpy.create_node(node_name, namespace=namespace)
+            rclpy.create_node(node_name, namespace=namespace, context=self.context)
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -28,22 +28,24 @@ def run_catch_report_raise(func, *args, **kwargs):
 
 def func_destroy_node():
     import rclpy
-    rclpy.init()
-    node = rclpy.create_node('test_node1')
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_node1', context=context)
     ret = True
     try:
         node.destroy_node()
     except RuntimeError:
         ret = False
     finally:
-        rclpy.shutdown()
+        rclpy.shutdown(context=context)
     return ret
 
 
 def func_destroy_node_twice():
     import rclpy
-    rclpy.init()
-    node = rclpy.create_node('test_node2')
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_node2', context=context)
     assert node.destroy_node() is True
     assert node.destroy_node() is True
     return True
@@ -51,8 +53,9 @@ def func_destroy_node_twice():
 
 def func_destroy_corrupted_node():
     import rclpy
-    rclpy.init()
-    node = rclpy.create_node('test_node2')
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_node2', context=context)
     assert node.destroy_node() is True
     org_handle = node._handle
     node._handle = 'garbage'
@@ -64,15 +67,16 @@ def func_destroy_corrupted_node():
         node._handle = org_handle
         node.destroy_node()
     finally:
-        rclpy.shutdown()
+        rclpy.shutdown(context=context)
     return ret
 
 
 def func_destroy_timers():
     import rclpy
-    rclpy.init()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
 
-    node = rclpy.create_node('test_node3')
+    node = rclpy.create_node('test_node3', context=context)
 
     timer1 = node.create_timer(0.1, None)
     timer2 = node.create_timer(1, None)
@@ -92,16 +96,17 @@ def func_destroy_timers():
         assert node.handle is None
         ret = True
     finally:
-        rclpy.shutdown()
+        rclpy.shutdown(context=context)
     return ret
 
 
 def func_destroy_entities():
     import rclpy
     from test_msgs.msg import Primitives
-    rclpy.init()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
 
-    node = rclpy.create_node('test_node4')
+    node = rclpy.create_node('test_node4', context=context)
 
     timer = node.create_timer(0.1, None)
     timer  # noqa
@@ -136,14 +141,15 @@ def func_destroy_entities():
         assert node.handle is None
         ret = True
     finally:
-        rclpy.shutdown()
+        rclpy.shutdown(context=context)
     return ret
 
 
 def func_corrupt_node_handle():
     import rclpy
-    rclpy.init()
-    node = rclpy.create_node('test_node5')
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_node5', context=context)
     try:
         node.handle = 'garbage'
         ret = False
@@ -151,7 +157,7 @@ def func_corrupt_node_handle():
         node.destroy_node()
         ret = True
     finally:
-        rclpy.shutdown()
+        rclpy.shutdown(context=context)
     return ret
 
 

--- a/rclpy/test/test_guard_condition.py
+++ b/rclpy/test/test_guard_condition.py
@@ -22,16 +22,18 @@ class TestGuardCondition(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        rclpy.init()
-        cls.node = rclpy.create_node('TestGuardCondition', namespace='/rclpy/test')
-        cls.executor = SingleThreadedExecutor()
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node(
+            'TestGuardCondition', namespace='/rclpy/test', context=cls.context)
+        cls.executor = SingleThreadedExecutor(context=cls.context)
         cls.executor.add_node(cls.node)
 
     @classmethod
     def tearDownClass(cls):
         cls.executor.shutdown()
         cls.node.destroy_node()
-        rclpy.shutdown()
+        rclpy.shutdown(context=cls.context)
 
     def test_trigger(self):
         called = False

--- a/rclpy/test/test_init_shutdown.py
+++ b/rclpy/test/test_init_shutdown.py
@@ -28,20 +28,22 @@ def run_catch_report_raise(func, *args, **kwargs):
 
 def func_init():
     import rclpy
+    context = rclpy.context.Context()
     try:
-        rclpy.init()
+        rclpy.init(context=context)
     except RuntimeError:
         return False
 
-    rclpy.shutdown()
+    rclpy.shutdown(context=context)
     return True
 
 
 def func_init_shutdown():
     import rclpy
+    context = rclpy.context.Context()
     try:
-        rclpy.init()
-        rclpy.shutdown()
+        rclpy.init(context=context)
+        rclpy.shutdown(context=context)
         return True
     except RuntimeError:
         return False
@@ -49,11 +51,21 @@ def func_init_shutdown():
 
 def func_init_shutdown_sequence():
     import rclpy
-    rclpy.init()
-    rclpy.shutdown()
     try:
+        # local
+        context = rclpy.context.Context()
+        rclpy.init(context=context)
+        rclpy.shutdown(context=context)
+        context = rclpy.context.Context()  # context cannot be reused but should not interfere
+        rclpy.init(context=context)
+        rclpy.shutdown(context=context)
+
+        # global
         rclpy.init()
         rclpy.shutdown()
+        rclpy.init()
+        rclpy.shutdown()
+
         return True
     except RuntimeError:
         return False
@@ -61,22 +73,24 @@ def func_init_shutdown_sequence():
 
 def func_double_init():
     import rclpy
-    rclpy.init()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
     try:
-        rclpy.init()
+        rclpy.init(context=context)
     except RuntimeError:
-        rclpy.shutdown()
         return True
-    rclpy.shutdown()
+    finally:
+        rclpy.shutdown(context=context)
     return False
 
 
 def func_double_shutdown():
     import rclpy
-    rclpy.init()
-    rclpy.shutdown()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    rclpy.shutdown(context=context)
     try:
-        rclpy.shutdown()
+        rclpy.shutdown(context=context)
     except RuntimeError:
         return True
 
@@ -86,8 +100,9 @@ def func_double_shutdown():
 def func_create_node_without_init():
     import rclpy
     from rclpy.exceptions import NotInitializedException
+    context = rclpy.context.Context()
     try:
-        rclpy.create_node('foo')
+        rclpy.create_node('foo', context=context)
     except NotInitializedException:
         return True
     return False

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -32,13 +32,14 @@ class TestNode(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        rclpy.init()
-        cls.node = rclpy.create_node(TEST_NODE, namespace=TEST_NAMESPACE)
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node(TEST_NODE, namespace=TEST_NAMESPACE, context=cls.context)
 
     @classmethod
     def tearDownClass(cls):
         cls.node.destroy_node()
-        rclpy.shutdown()
+        rclpy.shutdown(context=cls.context)
 
     def test_accessors(self):
         self.assertIsNotNone(self.node.handle)
@@ -136,14 +137,14 @@ class TestNode(unittest.TestCase):
         node_logger.debug('test')
 
     def test_initially_no_executor(self):
-        node = rclpy.create_node('my_node')
+        node = rclpy.create_node('my_node', context=self.context)
         try:
             assert node.executor is None
         finally:
             node.destroy_node()
 
     def test_set_executor_adds_node_to_it(self):
-        node = rclpy.create_node('my_node')
+        node = rclpy.create_node('my_node', context=self.context)
         executor = Mock()
         executor.add_node.return_value = True
         try:
@@ -154,7 +155,7 @@ class TestNode(unittest.TestCase):
         executor.add_node.assert_called_once_with(node)
 
     def test_set_executor_removes_node_from_old_executor(self):
-        node = rclpy.create_node('my_node')
+        node = rclpy.create_node('my_node', context=self.context)
         old_executor = Mock()
         old_executor.add_node.return_value = True
         new_executor = Mock()
@@ -170,7 +171,7 @@ class TestNode(unittest.TestCase):
         new_executor.remove_node.assert_not_called()
 
     def test_set_executor_clear_executor(self):
-        node = rclpy.create_node('my_node')
+        node = rclpy.create_node('my_node', context=self.context)
         executor = Mock()
         executor.add_node.return_value = True
         try:
@@ -249,25 +250,30 @@ class TestNode(unittest.TestCase):
 class TestCreateNode(unittest.TestCase):
 
     def test_use_global_arguments(self):
-        rclpy.init(args=['process_name', '__node:=global_node_name'])
+        context = rclpy.context.Context()
+        rclpy.init(args=['process_name', '__node:=global_node_name'], context=context)
         try:
-            node1 = rclpy.create_node('my_node', namespace='/my_ns', use_global_arguments=True)
-            node2 = rclpy.create_node('my_node', namespace='/my_ns', use_global_arguments=False)
+            node1 = rclpy.create_node(
+                'my_node', namespace='/my_ns', use_global_arguments=True, context=context)
+            node2 = rclpy.create_node(
+                'my_node', namespace='/my_ns', use_global_arguments=False, context=context)
             self.assertEqual('global_node_name', node1.get_name())
             self.assertEqual('my_node', node2.get_name())
             node1.destroy_node()
             node2.destroy_node()
         finally:
-            rclpy.shutdown()
+            rclpy.shutdown(context=context)
 
     def test_node_arguments(self):
-        rclpy.init()
+        context = rclpy.context.Context()
+        rclpy.init(context=context)
         try:
-            node = rclpy.create_node('my_node', namespace='/my_ns', cli_args=['__ns:=/foo/bar'])
+            node = rclpy.create_node(
+                'my_node', namespace='/my_ns', cli_args=['__ns:=/foo/bar'], context=context)
             self.assertEqual('/foo/bar', node.get_namespace())
             node.destroy_node()
         finally:
-            rclpy.shutdown()
+            rclpy.shutdown(context=context)
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_parameters_callback.py
+++ b/rclpy/test/test_parameters_callback.py
@@ -23,14 +23,15 @@ class TestParametersCallback(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        rclpy.init()
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
 
     @classmethod
     def tearDownClass(cls):
-        rclpy.shutdown()
+        rclpy.shutdown(context=cls.context)
 
     def setUp(self):
-        self.node = rclpy.create_node('parameters_callback_node')
+        self.node = rclpy.create_node('parameters_callback_node', context=self.context)
 
     def tearDown(self):
         self.node.destroy_node()

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -38,9 +38,10 @@ def run_catch_report_raise(func, *args, **kwargs):
 def func_zero_callback(args):
     period = float(args[0])
 
-    rclpy.init()
-    node = rclpy.create_node('test_timer_no_callback')
-    executor = SingleThreadedExecutor()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_timer_no_callback', context=context)
+    executor = SingleThreadedExecutor(context=context)
     executor.add_node(node)
     # The first spin_once() takes slighly longer, just long enough for 1ms timer tests to fail
     executor.spin_once(timeout_sec=0)
@@ -51,7 +52,7 @@ def func_zero_callback(args):
 
     node.destroy_timer(timer)
     executor.shutdown()
-    rclpy.shutdown()
+    rclpy.shutdown(context=context)
     assert len(callbacks) == 0, \
         "shouldn't have received any callback, received %d" % len(callbacks)
 
@@ -61,9 +62,10 @@ def func_zero_callback(args):
 def func_number_callbacks(args):
     period = float(args[0])
 
-    rclpy.init()
-    node = rclpy.create_node('test_timer_no_callback')
-    executor = SingleThreadedExecutor()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_timer_no_callback', context=context)
+    executor = SingleThreadedExecutor(context=context)
     executor.add_node(node)
     # The first spin_once() takes slighly longer, just long enough for 1ms timer tests to fail
     executor.spin_once(timeout_sec=0)
@@ -72,12 +74,12 @@ def func_number_callbacks(args):
     timer = node.create_timer(period, lambda: callbacks.append(len(callbacks)))
     begin_time = time.time()
 
-    while rclpy.ok() and time.time() - begin_time < 4.5 * period:
+    while rclpy.ok(context=context) and time.time() - begin_time < 4.5 * period:
         executor.spin_once(timeout_sec=period / 10)
 
     node.destroy_timer(timer)
     executor.shutdown()
-    rclpy.shutdown()
+    rclpy.shutdown(context=context)
     assert len(callbacks) == 4, 'should have received 4 callbacks, received %s' % str(callbacks)
 
     return True
@@ -86,9 +88,10 @@ def func_number_callbacks(args):
 def func_cancel_reset_timer(args):
     period = float(args[0])
 
-    rclpy.init()
-    node = rclpy.create_node('test_timer_no_callback')
-    executor = SingleThreadedExecutor()
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_timer_no_callback', context=context)
+    executor = SingleThreadedExecutor(context=context)
     executor.add_node(node)
     # The first spin_once() takes slighly longer, just long enough for 1ms timer tests to fail
     executor.spin_once(timeout_sec=0)
@@ -99,7 +102,7 @@ def func_cancel_reset_timer(args):
 
     assert not timer.is_canceled()
 
-    while rclpy.ok() and time.time() - begin_time < 2.5 * period:
+    while rclpy.ok(context=context) and time.time() - begin_time < 2.5 * period:
         executor.spin_once(timeout_sec=period / 10)
 
     assert len(callbacks) == 2, 'should have received 2 callbacks, received %d' % len(callbacks)
@@ -109,7 +112,7 @@ def func_cancel_reset_timer(args):
     assert timer.is_canceled()
     callbacks = []
     begin_time = time.time()
-    while rclpy.ok() and time.time() - begin_time < 2.5 * period:
+    while rclpy.ok(context=context) and time.time() - begin_time < 2.5 * period:
         executor.spin_once(timeout_sec=period / 10)
 
     assert timer.is_canceled()
@@ -119,14 +122,14 @@ def func_cancel_reset_timer(args):
     timer.reset()
     assert not timer.is_canceled()
     begin_time = time.time()
-    while rclpy.ok() and time.time() - begin_time < 2.5 * period:
+    while rclpy.ok(context=context) and time.time() - begin_time < 2.5 * period:
         executor.spin_once(timeout_sec=period / 10)
 
     assert not timer.is_canceled()
     assert len(callbacks) == 2, 'should have received 2 callbacks, received %d' % len(callbacks)
     node.destroy_timer(timer)
     executor.shutdown()
-    rclpy.shutdown()
+    rclpy.shutdown(context=context)
 
     return True
 


### PR DESCRIPTION
Notable this pr, unlike the rclcpp one, does not provide access to the ingoing init options, partially because I think it's not as useful right now and partially because I'm completely out of time to work on this set of changes.

Connects to ros2/rmw#154