### PR TITLE
Abstract type conversions into functions

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -83,13 +83,18 @@ target_include_directories(rclpy_common
   src/rclpy_common/include
   ${PythonExtra_INCLUDE_DIRS}
 )
+ament_target_dependencies(rclpy_common
+  "rmw"
+)
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(rclpy_common PRIVATE "RCLPY_COMMON_BUILDING_DLL")
+
 install(TARGETS rclpy_common
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-)
-ament_target_dependencies(rclpy_common
-  "rmw"
 )
 
 add_library(

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -75,10 +75,19 @@ endfunction()
 add_library(rclpy_common
   SHARED src/rclpy_common/src/common.c
 )
-target_include_directories(rclpy_common
-  PUBLIC src/rclpy_common/include
+target_link_libraries(rclpy_common
+  ${PythonExtra_LIBRARIES}
 )
-configure_python_c_extension_library(rclpy_common)
+target_include_directories(rclpy_common
+  PUBLIC
+  src/rclpy_common/include
+  ${PythonExtra_INCLUDE_DIRS}
+)
+install(TARGETS rclpy_common
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 ament_target_dependencies(rclpy_common
   "rmw"
 )

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -72,10 +72,25 @@ function(configure_python_c_extension_library _library_name)
   )
 endfunction()
 
+add_library(rclpy_common
+  SHARED src/rclpy_common/src/common.c
+)
+target_include_directories(rclpy_common
+  PUBLIC src/rclpy_common/include
+)
+configure_python_c_extension_library(rclpy_common)
+ament_target_dependencies(rclpy_common
+  "rmw"
+)
+
 add_library(
   rclpy
   SHARED src/rclpy/_rclpy.c
 )
+target_link_libraries(rclpy
+  rclpy_common
+)
+
 configure_python_c_extension_library(rclpy)
 ament_target_dependencies(rclpy
   "rcl"
@@ -87,6 +102,10 @@ add_library(
   rclpy_action
   SHARED src/rclpy/_rclpy_action.c
 )
+target_link_libraries(rclpy_action
+  rclpy_common
+)
+
 configure_python_c_extension_library(rclpy_action)
 ament_target_dependencies(rclpy_action
   "rcl"

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -38,7 +38,7 @@
 
 #include <signal.h>
 
-#include "./impl/common.h"
+#include "rclpy_common/common.h"
 
 static rcl_guard_condition_t * g_sigint_gc_handle;
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1218,36 +1218,9 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pymsg_type = PyObject_GetAttrString(pymsg, "__class__");
-
-  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
-  Py_DECREF(pymsg_type);
-
-  create_ros_message_signature * create_ros_message = get_capsule_pointer(
-    pymetaclass, "_CREATE_ROS_MESSAGE");
-  assert(create_ros_message != NULL &&
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported");
-
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer(
-    pymetaclass, "_DESTROY_ROS_MESSAGE");
-  assert(destroy_ros_message != NULL &&
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
-
-  convert_from_py_signature * convert_from_py = get_capsule_pointer(
-    pymetaclass, "_CONVERT_FROM_PY");
-  assert(convert_from_py != NULL &&
-    "unable to retrieve convert_from_py function, type_support mustn't have been imported");
-
-  Py_DECREF(pymetaclass);
-
-  void * raw_ros_message = create_ros_message();
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * raw_ros_message = rclpy_convert_from_py(pymsg, &destroy_ros_message);
   if (!raw_ros_message) {
-    return PyErr_NoMemory();
-  }
-
-  if (!convert_from_py(pymsg, raw_ros_message)) {
-    // the function has set the Python error
-    destroy_ros_message(raw_ros_message);
     return NULL;
   }
 
@@ -1756,6 +1729,7 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pymetaclass = PyObject_GetAttrString(pysrv_type, "__class__");
 
   PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
+  Py_DECREF(pymetaclass);
 
   rosidl_service_type_support_t * ts =
     (rosidl_service_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
@@ -1820,37 +1794,9 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pyrequest_type = PyObject_GetAttrString(pyrequest, "__class__");
-  assert(pyrequest_type != NULL);
-
-  PyObject * pymetaclass = PyObject_GetAttrString(pyrequest_type, "__class__");
-  assert(pymetaclass != NULL);
-
-  create_ros_message_signature * create_ros_message = get_capsule_pointer(
-    pymetaclass, "_CREATE_ROS_MESSAGE");
-  assert(create_ros_message != NULL &&
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported");
-
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer(
-    pymetaclass, "_DESTROY_ROS_MESSAGE");
-  assert(destroy_ros_message != NULL &&
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
-
-  convert_from_py_signature * convert_from_py = get_capsule_pointer(
-    pymetaclass, "_CONVERT_FROM_PY");
-  assert(convert_from_py != NULL &&
-    "unable to retrieve convert_from_py function, type_support mustn't have been imported");
-
-  Py_DECREF(pymetaclass);
-
-  void * raw_ros_request = create_ros_message();
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * raw_ros_request = rclpy_convert_from_py(pyrequest, &destroy_ros_message);
   if (!raw_ros_request) {
-    return PyErr_NoMemory();
-  }
-
-  if (!convert_from_py(pyrequest, raw_ros_request)) {
-    // the function has set the Python error
-    destroy_ros_message(raw_ros_request);
     return NULL;
   }
 
@@ -1984,39 +1930,10 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
   if (!header) {
     return NULL;
   }
-  PyObject * pyresponse_type = PyObject_GetAttrString(pyresponse, "__class__");
-  assert(pyresponse_type != NULL);
 
-  PyObject * pymetaclass = PyObject_GetAttrString(pyresponse_type, "__class__");
-  assert(pymetaclass != NULL);
-
-  Py_DECREF(pyresponse_type);
-
-  create_ros_message_signature * create_ros_message = get_capsule_pointer(
-    pymetaclass, "_CREATE_ROS_MESSAGE");
-  assert(create_ros_message != NULL &&
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported");
-
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer(
-    pymetaclass, "_DESTROY_ROS_MESSAGE");
-  assert(destroy_ros_message != NULL &&
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
-
-  convert_from_py_signature * convert_from_py = get_capsule_pointer(
-    pymetaclass, "_CONVERT_FROM_PY");
-  assert(convert_from_py != NULL &&
-    "unable to retrieve convert_from_py function, type_support mustn't have been imported");
-
-  Py_DECREF(pymetaclass);
-
-  void * raw_ros_response = create_ros_message();
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * raw_ros_response = rclpy_convert_from_py(pyresponse, &destroy_ros_message);
   if (!raw_ros_response) {
-    return PyErr_NoMemory();
-  }
-
-  if (!convert_from_py(pyresponse, raw_ros_response)) {
-    // the function has set the Python error
-    destroy_ros_message(raw_ros_response);
     return NULL;
   }
 
@@ -2669,22 +2586,10 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
     return rclpy_take_raw(subscription);
   }
 
-  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
-
-  create_ros_message_signature * create_ros_message = get_capsule_pointer(
-    pymetaclass, "_CREATE_ROS_MESSAGE");
-  assert(create_ros_message != NULL &&
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported");
-
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer(
-    pymetaclass, "_DESTROY_ROS_MESSAGE");
-  assert(destroy_ros_message != NULL &&
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
-
-  void * taken_msg = create_ros_message();
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * taken_msg = rclpy_create_from_py(pymsg_type, &destroy_ros_message);
   if (!taken_msg) {
-    Py_DECREF(pymetaclass);
-    return PyErr_NoMemory();
+    return NULL;
   }
 
   rcl_ret_t ret = rcl_take(subscription, taken_msg, NULL);
@@ -2694,15 +2599,11 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
       "Failed to take from a subscription: %s", rcl_get_error_string().str);
     rcl_reset_error();
     destroy_ros_message(taken_msg);
-    Py_DECREF(pymetaclass);
     return NULL;
   }
 
   if (ret != RCL_RET_SUBSCRIPTION_TAKE_FAILED) {
-    convert_to_py_signature * convert_to_py = get_capsule_pointer(pymetaclass, "_CONVERT_TO_PY");
-    Py_DECREF(pymetaclass);
-
-    PyObject * pytaken_msg = convert_to_py(taken_msg);
+    PyObject * pytaken_msg = rclpy_convert_to_py(taken_msg, pymsg_type);
     destroy_ros_message(taken_msg);
     if (!pytaken_msg) {
       // the function has set the Python error
@@ -2714,7 +2615,6 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
 
   // if take failed, just do nothing
   destroy_ros_message(taken_msg);
-  Py_DECREF(pymetaclass);
   Py_RETURN_NONE;
 }
 
@@ -2744,23 +2644,10 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pymetaclass = PyObject_GetAttrString(pyrequest_type, "__class__");
-
-  create_ros_message_signature * create_ros_message = get_capsule_pointer(
-    pymetaclass, "_CREATE_ROS_MESSAGE");
-  assert(create_ros_message != NULL &&
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported");
-
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer(
-    pymetaclass, "_DESTROY_ROS_MESSAGE");
-  assert(destroy_ros_message != NULL &&
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
-
-  void * taken_request = create_ros_message();
-
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * taken_request = rclpy_create_from_py(pyrequest_type, &destroy_ros_message);
   if (!taken_request) {
-    Py_DECREF(pymetaclass);
-    return PyErr_NoMemory();
+    return NULL;
   }
 
   rmw_request_id_t * header = (rmw_request_id_t *)PyMem_Malloc(sizeof(rmw_request_id_t));
@@ -2772,19 +2659,13 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
     rcl_reset_error();
     destroy_ros_message(taken_request);
     PyMem_Free(header);
-    Py_DECREF(pymetaclass);
     return NULL;
   }
 
   if (ret != RCL_RET_SERVICE_TAKE_FAILED) {
-    convert_to_py_signature * convert_to_py = get_capsule_pointer(pymetaclass, "_CONVERT_TO_PY");
-    Py_DECREF(pymetaclass);
-
-    PyObject * pytaken_request = convert_to_py(taken_request);
+    PyObject * pytaken_request = rclpy_convert_to_py(taken_request, pyrequest_type);
     destroy_ros_message(taken_request);
     if (!pytaken_request) {
-      // the function has set the Python error
-      PyMem_Free(header);
       return NULL;
     }
 
@@ -2797,7 +2678,6 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
   // if take_request failed, just do nothing
   PyMem_Free(header);
   destroy_ros_message(taken_request);
-  Py_DECREF(pymetaclass);
   Py_RETURN_NONE;
 }
 
@@ -2824,24 +2704,12 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pymetaclass = PyObject_GetAttrString(pyresponse_type, "__class__");
-
-  create_ros_message_signature * create_ros_message = get_capsule_pointer(
-    pymetaclass, "_CREATE_ROS_MESSAGE");
-  assert(create_ros_message != NULL &&
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported");
-
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer(
-    pymetaclass, "_DESTROY_ROS_MESSAGE");
-  assert(destroy_ros_message != NULL &&
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported");
-
-  void * taken_response = create_ros_message();
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * taken_response = rclpy_create_from_py(pyresponse_type, &destroy_ros_message);
   if (!taken_response) {
-    // the function has set the Python error
-    Py_DECREF(pymetaclass);
     return NULL;
   }
+
   rmw_request_id_t * header = (rmw_request_id_t *)PyMem_Malloc(sizeof(rmw_request_id_t));
   rcl_ret_t ret = rcl_take_response(client, header, taken_response);
   int64_t sequence = header->sequence_number;
@@ -2854,10 +2722,7 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   if (ret != RCL_RET_CLIENT_TAKE_FAILED) {
-    convert_to_py_signature * convert_to_py = get_capsule_pointer(pymetaclass, "_CONVERT_TO_PY");
-    Py_DECREF(pymetaclass);
-
-    PyObject * pytaken_response = convert_to_py(taken_response);
+    PyObject * pytaken_response = rclpy_convert_to_py(taken_response, pyresponse_type);
     destroy_ros_message(taken_response);
     if (!pytaken_response) {
       // the function has set the Python error
@@ -2879,7 +2744,6 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
   PyTuple_SET_ITEM(pytuple, 0, Py_None);
   Py_INCREF(Py_None);
   PyTuple_SET_ITEM(pytuple, 1, Py_None);
-  Py_DECREF(pymetaclass);
   destroy_ros_message(taken_response);
   return pytuple;
 }

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -17,7 +17,7 @@
 #include <rcl/error_handling.h>
 #include <rcl_action/rcl_action.h>
 
-#include "./impl/common.h"
+#include "rclpy_common/common.h"
 
 /// Destroy an rcl_action entity.
 /**

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -18,6 +18,8 @@
 
 #include <rmw/types.h>
 
+#include "rclpy_common/visibility_control.h"
+
 typedef void * create_ros_message_signature (void);
 typedef void destroy_ros_message_signature (void *);
 typedef bool convert_from_py_signature (PyObject *, void *);
@@ -28,12 +30,15 @@ typedef PyObject * convert_to_py_signature (void *);
  * \param[in] void pointer to a rmw_qos_profile_t structure
  * \return QoSProfile object
  */
+RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_convert_to_py_qos_policy(void * profile);
 
+RCLPY_COMMON_PUBLIC
 void *
 get_capsule_pointer(PyObject * pymetaclass, const char * attr);
 
+RCLPY_COMMON_PUBLIC
 void *
 rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message);
 
@@ -46,6 +51,7 @@ rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** dest
  * \param[out] destroy_ros_message The destructor function for finalizing the returned message.
  * \return The C version of the input ROS message.
  */
+RCLPY_COMMON_PUBLIC
 void *
 rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message);
 
@@ -57,6 +63,7 @@ rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** des
  * \param[in] pyclass An instance of the Python type to convert to.
  * \return The Python version of the input ROS message.
  */
+RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_convert_to_py(void * message, PyObject * pyclass);
 

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -1,0 +1,63 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef RCLPY_COMMON__COMMON_H_
+#define RCLPY_COMMON__COMMON_H_
+
+#include <Python.h>
+
+#include <rmw/types.h>
+
+typedef void * create_ros_message_signature (void);
+typedef void destroy_ros_message_signature (void *);
+typedef bool convert_from_py_signature (PyObject *, void *);
+typedef PyObject * convert_to_py_signature (void *);
+
+/// Convert a C rmw_qos_profile_t into a Python QoSProfile object
+/**
+ * \param[in] void pointer to a rmw_qos_profile_t structure
+ * \return QoSProfile object
+ */
+PyObject *
+rclpy_convert_to_py_qos_policy(void * profile);
+
+void *
+get_capsule_pointer(PyObject * pymetaclass, const char * attr);
+
+void *
+rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message);
+
+/// Convert a ROS message from a Python type to a C type.
+/**
+ * Raises AttributeError if the Python message type is missing a required attribute.
+ * Raises MemoryError on a memory allocation failure.
+ *
+ * \param[in] pymessage The Python message to convert from.
+ * \param[out] destroy_ros_message The destructor function for finalizing the returned message.
+ * \return The C version of the input ROS message.
+ */
+void *
+rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message);
+
+/// Convert a ROS message from a C type to a Python type.
+/**
+ * Raises AttributeError if the Python type is missing a required attribute.
+ *
+ * \param[in] message The C message to convert to a Python type
+ * \param[in] pyclass An instance of the Python type to convert to.
+ * \return The Python version of the input ROS message.
+ */
+PyObject *
+rclpy_convert_to_py(void * message, PyObject * pyclass);
+
+#endif  // RCLPY_COMMON__COMMON_H_

--- a/rclpy/src/rclpy_common/include/rclpy_common/visibility_control.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/visibility_control.h
@@ -1,0 +1,48 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef RCLPY_COMMON__VISIBILITY_CONTROL_H_
+#define RCLPY_COMMON__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCLPY_COMMON_EXPORT __attribute__ ((dllexport))
+    #define RCLPY_COMMON_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCLPY_COMMON_EXPORT __declspec(dllexport)
+    #define RCLPY_COMMON_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCLPY_COMMON_BUILDING_DLL
+    #define RCLPY_COMMON_PUBLIC RCLPY_COMMON_EXPORT
+  #else
+    #define RCLPY_COMMON_PUBLIC RCLPY_COMMON_IMPORT
+  #endif
+  #define RCLPY_COMMON_PUBLIC_TYPE RCLPY_COMMON_PUBLIC
+  #define RCLPY_COMMON_LOCAL
+#else
+  #define RCLPY_COMMON_EXPORT __attribute__ ((visibility("default")))
+  #define RCLPY_COMMON_IMPORT
+  #if __GNUC__ >= 4
+    #define RCLPY_COMMON_PUBLIC __attribute__ ((visibility("default")))
+    #define RCLPY_COMMON_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCLPY_COMMON_PUBLIC
+    #define RCLPY_COMMON_LOCAL
+  #endif
+  #define RCLPY_COMMON_PUBLIC_TYPE
+#endif
+
+#endif  // RCLPY_COMMON__VISIBILITY_CONTROL_H_

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -11,24 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef RCLPY__IMPL__COMMON_H_
-#define RCLPY__IMPL__COMMON_H_
 
-#include <Python.h>
+#include "rclpy_common/common.h"
 
-#include <rmw/types.h>
-
-typedef void * create_ros_message_signature (void);
-typedef void destroy_ros_message_signature (void *);
-typedef bool convert_from_py_signature (PyObject *, void *);
-typedef PyObject * convert_to_py_signature (void *);
-
-/// Convert a C rmw_qos_profile_t into a Python QoSProfile object
-/**
- * \param[in] void pointer to a rmw_qos_profile_t structure
- * \return QoSProfile object
- */
-static PyObject *
+PyObject *
 rclpy_convert_to_py_qos_policy(void * profile)
 {
   PyObject * pyqos_module = PyImport_ImportModule("rclpy.qos");
@@ -113,7 +99,7 @@ rclpy_convert_to_py_qos_policy(void * profile)
   return pyqos_profile;
 }
 
-static void *
+void *
 get_capsule_pointer(PyObject * pymetaclass, const char * attr)
 {
   PyObject * pyattr = PyObject_GetAttrString(pymetaclass, attr);
@@ -125,7 +111,7 @@ get_capsule_pointer(PyObject * pymetaclass, const char * attr)
   return ptr;
 }
 
-static void *
+void *
 rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message)
 {
   PyObject * pymetaclass = PyObject_GetAttrString(pymessage, "__class__");
@@ -154,16 +140,7 @@ rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** dest
   return message;
 }
 
-/// Convert a ROS message from a Python type to a C type.
-/**
- * Raises AttributeError if the Python message type is missing a required attribute.
- * Raises MemoryError on a memory allocation failure.
- *
- * \param[in] pymessage The Python message to convert from.
- * \param[out] destroy_ros_message The destructor function for finalizing the returned message.
- * \return The C version of the input ROS message.
- */
-static void *
+void *
 rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message)
 {
   void * message = rclpy_create_from_py(pymessage, destroy_ros_message);
@@ -190,15 +167,7 @@ rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** des
   return message;
 }
 
-/// Convert a ROS message from a C type to a Python type.
-/**
- * Raises AttributeError if the Python type is missing a required attribute.
- *
- * \param[in] message The C message to convert to a Python type
- * \param[in] pyclass An instance of the Python type to convert to.
- * \return The Python version of the input ROS message.
- */
-static PyObject *
+PyObject *
 rclpy_convert_to_py(void * message, PyObject * pyclass)
 {
   PyObject * pymetaclass = PyObject_GetAttrString(pyclass, "__class__");
@@ -213,4 +182,3 @@ rclpy_convert_to_py(void * message, PyObject * pyclass)
   }
   return convert(message);
 }
-#endif  // RCLPY__IMPL__COMMON_H_


### PR DESCRIPTION
This helps with readability and maintainability.
Also eliminated use of assertions during conversions, defering to exceptions.

I plan to make use of these functions for the Action extension module (#257) in a follow-up PR.
