### PR TITLE
Add ActionServer

### DIFF
--- a/rclpy/rclpy/action/__init__.py
+++ b/rclpy/rclpy/action/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 from .client import ActionClient  # noqa
+from .server import ActionServer, CancelResponse, GoalResponse  # noqa

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -129,7 +129,6 @@ class ServerGoalHandle:
             if not _rclpy_action.rclpy_action_goal_handle_is_active(self._handle):
                 self._action_server.notify_goal_done()
 
-
     def publish_feedback(self, feedback_msg):
         with self._lock:
             # Ignore for already destructed goal handles

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -124,7 +124,12 @@ class ServerGoalHandle:
             if self._handle is None:
                 return
 
+            # Update state
             _rclpy_action.rclpy_action_update_goal_state(self._handle, event.value)
+
+            # Publish state change
+            _rclpy_action.rclpy_action_publish_status(self._action_server._handle)
+
             # If it's a terminal state, then also notify the action server
             if not _rclpy_action.rclpy_action_goal_handle_is_active(self._handle):
                 self._action_server.notify_goal_done()
@@ -134,6 +139,11 @@ class ServerGoalHandle:
             # Ignore for already destructed goal handles
             if self._handle is None:
                 return
+
+            # Ensure the feedback message contains metadata about this goal
+            feedback_msg.action_goal_id = self.goal_id
+
+            # Publish
             _rclpy_action.rclpy_action_publish_feedback(self._action_server._handle, feedback_msg)
 
     def set_succeeded(self):

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -1,0 +1,463 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+import threading
+import time
+
+from action_msgs.msg import GoalInfo, GoalStatus
+
+from rclpy.executors import await_or_execute
+from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
+from rclpy.type_support import check_for_type_support
+from rclpy.qos import qos_profile_action_status_default
+from rclpy.qos import qos_profile_default, qos_profile_services_default
+from rclpy.task import Future, Task
+from rclpy.waitable import NumberOfEntities, Waitable
+
+
+class GoalResponse(Enum):
+    """Possible goal responses."""
+
+    # Reject the goal.
+    REJECT = 1
+    # Accept the goal and start executing it right away.
+    ACCEPT_AND_EXECUTE = 2
+    # Accept the goal and defer execution until a later time.
+    ACCEPT_AND_DEFER = 3
+
+
+class CancelResponse(Enum):
+    """Possible cancel responses."""
+
+    REJECT = 1
+    ACCEPT = 2
+
+
+class GoalEvent(Enum):
+    """Goal events that cause state transitions."""
+
+    EXECUTE = 1
+    CANCEL = 2
+    SET_SUCCEEDED = 3
+    SET_ABORTED = 4
+    SET_CANCELED = 5
+
+
+class ServerGoalHandle:
+    """Goal handle for working with Action Servers."""
+
+    def __init__(self, action_server, goal_info, goal_request):
+        """
+        Accept a new goal with the given action server.
+
+        Instances of this class should only be constructed in the ActionServer class.
+        Instances for accepted goals will be passed to the user-defined goal execution functions.
+
+        If the goal fails to be accepted, then a RuntimeError is raised.
+
+        :param action_server: The ActionServer to accept the goal.
+        :param goal_info: GoalInfo message.
+        :param goal_request: The original goal request message from an ActionClient.
+        """
+        self._handle = _rclpy_action.rclpy_action_accept_new_goal(
+            action_server._handle, goal_info)
+        self._action_server = action_server
+        self._goal_info = goal_info
+        self._goal_request = goal_request
+        self._cancel_requested = False
+        self._result = None
+        self._lock = threading.Lock()
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __ne__(self, other):
+        return self.id != other.id
+
+    @property
+    def request(self):
+        return self._goal_request
+
+    @property
+    def id(self):
+        return self._goal_info.goal_id
+
+    @property
+    def is_cancel_requested(self):
+        with self._lock:
+            return self._cancel_requested
+
+    @property
+    def status(self):
+        with self._lock:
+            return _rclpy_action.rclpy_action_goal_handle_get_status(self._handle)
+
+    def _notify_cancel_requested(self):
+        with self._lock:
+            self._cancel_requested = True
+
+    def _update_state(self, event):
+        with self._lock:
+            if self._handle is None:
+                return
+
+            _rclpy_action.rclpy_action_update_goal_state(self._handle, event.value)
+            # If it's a terminal state, then also notify the action server
+            if not _rclpy_action.rclpy_action_goal_handle_is_active(self._handle):
+                _rclpy_action.rclpy_action_notify_goal_done(self._action_server._handle)
+
+    def is_active(self):
+        with self._lock:
+            if self._handle is None:
+                return False
+            return _rclpy_action.rclpy_action_goal_handle_is_active(self._handle)
+
+    def publish_feedback(self, feedback_msg):
+        with self._lock:
+            if self._handle is None:
+                return
+            _rclpy_action.rclpy_action_publish_feedback(self._action_sever._handle, feedback_msg)
+
+    def set_succeeded(self):
+        self._update_state(GoalEvent.SET_SUCCEEDED)
+
+    def set_aborted(self):
+        self._update_state(GoalEvent.SET_ABORTED)
+
+    def set_canceled(self):
+        self._update_state(GoalEvent.SET_CANCELED)
+
+    def destroy(self):
+        if self._handle is None:
+            return
+        _rclpy_action.rclpy_action_destroy_server_goal_handle(self._handle)
+        self._handle = None
+
+
+def default_goal_callback(goal_request):
+    """Accept all goals."""
+    return GoalResponse.ACCEPT_AND_EXECUTE
+
+
+def default_cancel_callback(cancel_request):
+    """No cancellations."""
+    return CancelResponse.REJECT
+
+
+class ActionServer(Waitable):
+    """ROS Action server."""
+
+    def __init__(
+        self,
+        node,
+        action_type,
+        action_name,
+        execute_callback,
+        *,
+        callback_group=None,
+        goal_callback=default_goal_callback,
+        cancel_callback=default_cancel_callback,
+        goal_service_qos_profile=qos_profile_services_default,
+        result_service_qos_profile=qos_profile_services_default,
+        cancel_service_qos_profile=qos_profile_services_default,
+        feedback_pub_qos_profile=qos_profile_default,
+        status_pub_qos_profile=qos_profile_action_status_default
+    ):
+        """
+        Constructor.
+
+        :param node: The ROS node to add the action server to.
+        :param action_type: Type of the action.
+        :param action_name: Name of the action.
+            Used as part of the underlying topic and service names.
+        :param execute_callback: Callback function for processing accepted goals.
+        :param callback_group: Callback group to add the action server to.
+            If None, then the node's default callback group is used.
+        :param goal_callback: Callback function for handling new goal requests.
+        :param cancel_callback: Callback function for handling cancel requests.
+        :param goal_service_qos_profile: QoS profile for the goal service.
+        :param result_service_qos_profile: QoS profile for the result service.
+        :param cancel_service_qos_profile: QoS profile for the cancel service.
+        :param feedback_pub_qos_profile: QoS profile for the feedback publisher.
+        :param status_pub_qos_profile: QoS profile for the status publisher.
+        """
+        if callback_group is None:
+            callback_group = node.default_callback_group
+
+        super().__init__(callback_group)
+
+        self.register_goal_callback(goal_callback)
+        self.register_cancel_callback(cancel_callback)
+        self.register_execute_callback(execute_callback)
+
+        # Import the typesupport for the action module if not already done
+        check_for_type_support(action_type)
+        self._node = node
+        self._action_type = action_type
+        self._handle = _rclpy_action.rclpy_action_create_server(
+            node.handle,
+            node.get_clock().handle,
+            action_type,
+            action_name,
+            goal_service_qos_profile.get_c_qos_profile(),
+            result_service_qos_profile.get_c_qos_profile(),
+            cancel_service_qos_profile.get_c_qos_profile(),
+            feedback_pub_qos_profile.get_c_qos_profile(),
+            status_pub_qos_profile.get_c_qos_profile(),
+        )
+
+        # key: UUID in bytes, value: GoalHandle
+        self._goal_handles = {}
+        self._pending_cancel_requests = {}
+        self._pending_result_requests = {}
+        # self._feedback_callbacks = {}
+
+        callback_group.add_entity(self)
+        self._node.add_waitable(self)
+
+    async def _execute_goal_request(self, request_header_and_message):
+        request_header, goal_request = request_header_and_message
+        goal_uuid = goal_request.action_goal_id
+
+        self._node.get_logger().debug('New goal request with ID: {0}'.format(goal_uuid.uuid))
+
+        # TODO: Check if goal ID is already being tracked by this action server
+
+        # Call user goal callback
+        response = await await_or_execute(self._goal_callback, goal_request)
+        accepted = ((GoalResponse.ACCEPT_AND_EXECUTE == response) or
+            (GoalResponse.ACCEPT_AND_DEFER == response))
+
+        if accepted:
+            # TODO: lock on new goal creation to avoid multiple goals with same ID being accepted
+            goal_info = GoalInfo()
+            goal_info.goal_id = goal_uuid
+            goal_info.stamp = self._node.get_clock().now().to_msg()
+            # Create a goal handle
+            try:
+                goal_handle = ServerGoalHandle(self, goal_info, goal_request)
+            except RuntimeError as e:
+                self._node.get_logger().error(
+                    'Failed to accept new goal with ID {0}: {1}'.format(goal_uuid.uuid, e))
+                accepted = False
+            else:
+              self._goal_handles[bytes(goal_uuid.uuid)] = goal_handle
+
+        # Send response
+        response_msg = self._action_type.GoalRequestService.Response()
+        response_msg.accepted = accepted
+        response_msg.stamp = self._node.get_clock().now().to_msg()
+        _rclpy_action.rclpy_action_send_goal_response(
+            self._handle,
+            request_header,
+            response_msg,
+        )
+
+        if not accepted:
+            self._node.get_logger().debug('New goal rejected: {0}'.format(goal_uuid.uuid))
+            return
+
+        self._node.get_logger().debug('New goal accepted: {0}'.format(goal_uuid.uuid))
+
+        goal_handle._update_state(GoalEvent.EXECUTE)
+        # Call user execute callback
+        execute_result = await await_or_execute(self._execute_callback, goal_handle)
+        # If user did not trigger a terminal state, assume success
+        if goal_handle.is_active():
+            self._node.get_logger().warn(
+                'Goal state not set, assuming success. Goal ID: {0}'.format(goal_uuid.uuid))
+            goal_handle.set_succeeded()
+        self._node.get_logger().debug(
+            'Goal with ID {0} finished with state {1}'.format(goal_uuid.uuid, goal_handle.status))
+        # Set result
+        goal_handle._result = execute_result
+
+    async def _execute_cancel_request(self, request_header_and_message):
+        request_header, cancel_request = request_header_and_message
+
+        self._node.get_logger().debug('Cancel request received: {0}'.format(cancel_request))
+
+        # Get list of goals that are requested to be canceled
+        cancel_response = _rclpy_action.rclpy_action_process_cancel_request(
+            self._handle, cancel_request, self._action_type.CancelGoalService.Response)
+
+        for goal_info in cancel_response.goals_canceling:
+            goal_uuid = bytes(goal_info.goal_id.uuid)
+            if goal_uuid not in self._goal_handles:
+                # Possibly the user doesn't care to track the goal handle
+                # Remove from response
+                cancel_response.goals_canceling.remove(goal_info)
+                continue
+            goal_handle = self._goal_handles[goal_uuid]
+            response = await await_or_execute(self._cancel_callback, goal_handle)
+
+            accepted = CancelResponse.ACCEPT == response
+            if accepted:
+                # Notify goal handle
+                goal_handle._notify_cancel_requested()
+            else:
+                # Remove from response
+                cancel_response.goals_canceling.remove(goal_info)
+
+        _rclpy_action.rclpy_action_send_cancel_response(
+            self._handle,
+            request_header,
+            cancel_response,
+        )
+
+    # Start Waitable API
+    def is_ready(self, wait_set):
+        """Return True if one or more entities are ready in the wait set."""
+        ready_entities = _rclpy_action.rclpy_action_wait_set_is_ready(self._handle, wait_set)
+        self._is_goal_request_ready = ready_entities[0]
+        self._is_cancel_request_ready = ready_entities[1]
+        self._is_result_request_ready = ready_entities[2]
+        self._is_goal_expired = ready_entities[3]
+        return any(ready_entities)
+
+    def take_data(self):
+        """Take stuff from lower level so the wait set doesn't immediately wake again."""
+        data = {}
+        if self._is_goal_request_ready:
+            take_result = _rclpy_action.rclpy_action_take_goal_request(
+                self._handle, self._action_type.GoalRequestService.Request)
+            data['goal'] = take_result
+
+        if self._is_cancel_request_ready:
+            take_result = _rclpy_action.rclpy_action_take_cancel_request(
+                self._handle, self._action_type.CancelGoalService.Request)
+            data['cancel'] = take_result
+
+        if self._is_result_request_ready:
+            take_result = _rclpy_action.rclpy_action_take_result_request(
+                self._handle, self._action_type.GoalResultService.Request)
+            data['result'] = take_result
+
+        if self._is_goal_expired:
+            expired_goals = _rclpy_action.rclpy_action_expire_goals(self._handle)
+            data['expired'] = expired_goals
+
+        if not any(data):
+            return None
+        return data
+
+    async def execute(self, taken_data):
+        """
+        Execute work after data has been taken from a ready wait set.
+
+        This will set results for Future objects for any received service responses and
+        call any user-defined callbacks (e.g. feedback).
+        """
+        if 'goal' in taken_data:
+            await self._execute_goal_request(taken_data['goal'])
+
+        if 'cancel' in taken_data:
+            await self._execute_cancel_request(taken_data['cancel'])
+
+        if 'result' in taken_data:
+            sequence_number, result_request = taken_data['result']
+            # If there is an accepted goal matching the goal ID, then schedule the
+            # response for sending as soon as it's ready
+            # future = Future()
+            # future.add_done_callback()
+            # self.add_future(future)
+            # TODO(jacobperron): Do something
+
+        if 'expired' in taken_data:
+            expired_goals = taken_data['expired']
+            # TODO(jacobperron): Do something
+
+    def get_num_entities(self):
+        """Return number of each type of entity used in the wait set."""
+        num_entities = _rclpy_action.rclpy_action_wait_set_get_num_entities(self._handle)
+        return NumberOfEntities(
+            num_entities[0],
+            num_entities[1],
+            num_entities[2],
+            num_entities[3],
+            num_entities[4])
+
+    def add_to_wait_set(self, wait_set):
+        """Add entities to wait set."""
+        _rclpy_action.rclpy_action_wait_set_add(self._handle, wait_set)
+    # End Waitable API
+
+    def register_goal_callback(self, goal_callback):
+        """
+        Register a callback for handling new goal requests.
+
+        The purpose of the goal callback is to decide if a new goal should be accepted or
+        rejected.
+        The callback should take the goal request message as a parameter and must return a
+        :class:`GoalResponse` value.
+
+        There can only be one goal callback per :class:`ActionServer`, therefore calling this
+        function will replace any previously registered callback.
+
+        :param goal_callback: Callback function, if `None`, then unregisters any previously
+            registered callback.
+        """
+        self._goal_callback = goal_callback
+
+    def register_cancel_callback(self, cancel_callback):
+        """
+        Register a callback for handling cancel requests.
+
+        The purpose of the cancel callback is to decide if a request to cancel an on-going
+        (or queued) goal should be accepted or rejected.
+        The callback should take one parameter containing the cancel request and must return a
+        :class:`CancelResponse` value.
+
+        There can only be one cancel callback per :class:`ActionServer`, therefore calling this
+        function will replace any previously registered callback.
+
+        :param cancel_callback: Callback function, if `None`, then unregisters any previously
+            registered callback.
+        """
+        self._cancel_callback = cancel_callback
+
+    def register_execute_callback(self, execute_callback):
+        """
+        Register a callback for executing action goals.
+
+        The purpose of the execute callback is to execute the action goal and return a result
+        when finished.
+
+        The callback should take one parameter containing goal request and must return a
+        result instance (i.e. `action_type.Result`).
+
+        There can only be one execute callback per :class:`ActionServer`, therefore calling this
+        function will replace any previously registered callback.
+
+        :param execute_callback: Callback function, if `None`, then unregisters any previously
+            registered callback.
+        """
+        self._execute_callback = execute_callback
+
+    def destroy(self):
+        """Destroy the underlying action server handle."""
+        if self._handle is None or self._node.handle is None:
+            return
+
+        for goal_handle in self._goal_handles.values():
+            goal_handle.destroy()
+
+        _rclpy_action.rclpy_action_destroy_entity(self._handle, self._node.handle)
+        self._node.remove_waitable(self)
+        self._handle = None
+
+    def __del__(self):
+        """Destroy the underlying action server handle."""
+        self.destroy()

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -277,7 +277,11 @@ class ActionServer(Waitable):
         if not goal_id_exists:
             # Call user goal callback
             response = await await_or_execute(self._goal_callback, goal_request)
-            accepted = GoalResponse.ACCEPT == response
+            if not isinstance(response, GoalResponse):
+                self._node.get_logger().warn(
+                    'Goal request callback did not return a GoalResponse type. Rejecting goal.')
+            else:
+                accepted = GoalResponse.ACCEPT == response
 
         if accepted:
             # Create a goal handle

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -258,8 +258,6 @@ class ActionServer(Waitable):
 
         callback_group.add_entity(self)
         self._node.add_waitable(self)
-        # import rclpy
-        # self._node.get_logger().set_level(rclpy.logging.LoggingSeverity.DEBUG)
 
     async def _execute_goal_request(self, request_header_and_message):
         request_header, goal_request = request_header_and_message

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -132,6 +132,10 @@ class Clock:
     def clock_type(self):
         return self._clock_type
 
+    @property
+    def handle(self):
+        return self._clock_handle
+
     def __repr__(self):
         return 'Clock(clock_type={0})'.format(self.clock_type.name)
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -262,7 +262,7 @@ class Executor:
         if sequence is not None:
             try:
                 future = client._pending_requests[sequence]
-            except IndexError:
+            except KeyError:
                 # The request was cancelled
                 pass
             else:

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -76,6 +76,30 @@ rclpy_action_destroy_entity(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_NONE;
 }
 
+static PyObject *
+rclpy_action_destroy_server_goal_handle(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pygoal_handle;
+
+  if (!PyArg_ParseTuple(args, "O", &pygoal_handle)) {
+    return NULL;
+  }
+
+  rcl_action_goal_handle_t * goal_handle = (rcl_action_goal_handle_t *)PyCapsule_GetPointer(
+    pygoal_handle, "rcl_action_goal_handle_t");
+  if (!goal_handle) {
+    return NULL;
+  }
+
+  rcl_ret_t ret = rcl_action_goal_handle_fini(goal_handle);
+  if (RCL_RET_OK != ret) {
+    PyErr_Format(
+      PyExc_RuntimeError, "Error destroying action goal handle: %s", rcl_get_error_string().str);
+    rcl_reset_error();
+  }
+  Py_RETURN_NONE;
+}
+
 /// Fetch a predefined qos_profile from rcl_action and convert it to a Python QoSProfile object.
 /**
  * Raises RuntimeError if the QoS profile is unknown.
@@ -503,6 +527,138 @@ rclpy_action_create_client(PyObject * Py_UNUSED(self), PyObject * args)
   return PyCapsule_New(action_client, "rcl_action_client_t", NULL);
 }
 
+/// Create an action server.
+/**
+ * This function will create an action server for the given action name.
+ * This server will use the typesupport defined in the action module
+ * provided as pyaction_type to send messages over the wire.
+ *
+ * On a successful call a capsule referencing the created rcl_action_server_t structure
+ * is returned.
+ *
+ * Raises AttributeError if action type is invalid
+ * Raises ValueError if action name is invalid
+ * Raises RuntimeError if the action server could not be created.
+ *
+ * \remark Call rclpy_action_destroy_entity() to destroy an action server.
+ * \param[in] pynode Capsule pointing to the node to add the action server to.
+ * \param[in] pyaction_type Action module associated with the action server.
+ * \param[in] pyaction_name Python object containing the action name.
+ * \param[in] pygoal_service_qos Capsule pointing to a rmw_qos_profile_t object
+ *   for the goal service.
+ * \param[in] pyresult_service_qos Capsule pointing to a rmw_qos_profile_t object
+ *   for the result service.
+ * \param[in] pycancel_service_qos Capsule pointing to a rmw_qos_profile_t object
+ *   for the cancel service.
+ * \param[in] pyfeedback_qos Capsule pointing to a rmw_qos_profile_t object
+ *   for the feedback subscriber.
+ * \param[in] pystatus_qos Capsule pointing to a rmw_qos_profile_t object for the
+ *   status subscriber.
+ * \return Capsule named 'rcl_action_server_t', or
+ * \return NULL on failure.
+ */
+static PyObject *
+rclpy_action_create_server(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pynode;
+  PyObject * pyclock;
+  PyObject * pyaction_type;
+  PyObject * pyaction_name;
+  PyObject * pygoal_service_qos;
+  PyObject * pyresult_service_qos;
+  PyObject * pycancel_service_qos;
+  PyObject * pyfeedback_topic_qos;
+  PyObject * pystatus_topic_qos;
+
+  int parse_tuple_result = PyArg_ParseTuple(
+    args,
+    "OOOOOOOOO",
+    &pynode,
+    &pyclock,
+    &pyaction_type,
+    &pyaction_name,
+    &pygoal_service_qos,
+    &pyresult_service_qos,
+    &pycancel_service_qos,
+    &pyfeedback_topic_qos,
+    &pystatus_topic_qos);
+
+  if (!parse_tuple_result) {
+    return NULL;
+  }
+
+  const char * action_name = PyUnicode_AsUTF8(pyaction_name);
+  if (!action_name) {
+    return NULL;
+  }
+
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, "rcl_node_t");
+  if (!node) {
+    return NULL;
+  }
+
+  rcl_clock_t * clock = (rcl_clock_t *) PyCapsule_GetPointer(pyclock, "rcl_clock_t");
+  if (!clock) {
+    return NULL;
+  }
+
+  PyObject * pymetaclass = PyObject_GetAttrString(pyaction_type, "__class__");
+  if (!pymetaclass) {
+    return NULL;
+  }
+
+  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
+  Py_DECREF(pymetaclass);
+  if (!pyts) {
+    return NULL;
+  }
+
+  rosidl_action_type_support_t * ts =
+    (rosidl_action_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
+  Py_DECREF(pyts);
+  if (!ts) {
+    return NULL;
+  }
+
+  rcl_action_server_options_t action_server_ops = rcl_action_server_get_default_options();
+
+  OPTIONS_COPY_QOS_PROFILE(action_server_ops, goal_service_qos);
+  OPTIONS_COPY_QOS_PROFILE(action_server_ops, result_service_qos);
+  OPTIONS_COPY_QOS_PROFILE(action_server_ops, cancel_service_qos);
+  OPTIONS_COPY_QOS_PROFILE(action_server_ops, feedback_topic_qos);
+  OPTIONS_COPY_QOS_PROFILE(action_server_ops, status_topic_qos);
+
+  rcl_action_server_t * action_server =
+    (rcl_action_server_t *)PyMem_Malloc(sizeof(rcl_action_server_t));
+  if (!action_server) {
+    return PyErr_NoMemory();
+  }
+  *action_server = rcl_action_get_zero_initialized_server();
+  rcl_ret_t ret = rcl_action_server_init(
+    action_server,
+    node,
+    clock,
+    ts,
+    action_name,
+    &action_server_ops);
+  if (ret != RCL_RET_OK) {
+    if (ret == RCL_RET_ACTION_NAME_INVALID) {
+      PyErr_Format(PyExc_ValueError,
+        "Failed to create action server due to invalid topic name '%s': %s",
+        action_name, rcl_get_error_string().str);
+    } else {
+      PyErr_Format(PyExc_RuntimeError,
+        "Failed to create action server: %s", rcl_get_error_string().str);
+    }
+    PyMem_Free(action_server);
+    rcl_reset_error();
+    return NULL;
+  }
+
+  return PyCapsule_New(action_server, "rcl_action_server_t", NULL);
+}
+
+
 /// Check if an action server is available for the given action client.
 /**
  * Raises RuntimeError on failure.
@@ -555,35 +711,9 @@ rclpy_action_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
   if (!action_client) { \
     return NULL; \
   } \
-  PyObject * pyrequest_type = PyObject_GetAttrString(pyrequest, "__class__"); \
-  if (!pyrequest_type) { \
-    return NULL; \
-  } \
-  PyObject * pymetaclass = PyObject_GetAttrString(pyrequest_type, "__class__"); \
-  Py_DECREF(pyrequest_type); \
-  if (!pymetaclass) { \
-    return NULL; \
-  } \
-  create_ros_message_signature * create_ros_message = get_capsule_pointer( \
-    pymetaclass, "_CREATE_ROS_MESSAGE"); \
-  assert(create_ros_message != NULL && \
-    "unable to retrieve create_ros_message function, type_support must not have been imported"); \
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer( \
-    pymetaclass, "_DESTROY_ROS_MESSAGE"); \
-  assert(destroy_ros_message != NULL && \
-    "unable to retrieve destroy_ros_message function, type_support must not have been imported"); \
-  convert_from_py_signature * convert_from_py = get_capsule_pointer( \
-    pymetaclass, "_CONVERT_FROM_PY"); \
-  assert(convert_from_py != NULL && \
-    "unable to retrieve convert_from_py function, type_support must not have been imported"); \
-  Py_DECREF(pymetaclass); \
-  void * raw_ros_request = create_ros_message(); \
+  destroy_ros_message_signature * destroy_ros_message = NULL; \
+  void * raw_ros_request = rclpy_convert_from_py(pyrequest, & destroy_ros_message); \
   if (!raw_ros_request) { \
-    return PyErr_NoMemory(); \
-  } \
-  if (!convert_from_py(pyrequest, raw_ros_request)) { \
-    /* the function has set the Python error */ \
-    destroy_ros_message(raw_ros_request); \
     return NULL; \
   } \
   int64_t sequence_number; \
@@ -598,47 +728,66 @@ rclpy_action_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
   } \
   return PyLong_FromLongLong(sequence_number);
 
-#define TAKE_SERVICE_RESPONSE(Type) \
-  PyObject * pyaction_client; \
-  PyObject * pyresponse_type; \
-  if (!PyArg_ParseTuple(args, "OO", & pyaction_client, & pyresponse_type)) { \
+#define SEND_SERVICE_RESPONSE(Type) \
+  PyObject * pyaction_server; \
+  PyObject * pyheader; \
+  PyObject * pyresponse; \
+  if (!PyArg_ParseTuple(args, "OOO", & pyaction_server, & pyheader, & pyresponse)) { \
     return NULL; \
   } \
-  rcl_action_client_t * action_client = (rcl_action_client_t *)PyCapsule_GetPointer( \
-    pyaction_client, "rcl_action_client_t"); \
-  if (!action_client) { \
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer( \
+    pyaction_server, "rcl_action_server_t"); \
+  if (!action_server) { \
     return NULL; \
   } \
-  PyObject * pymetaclass = PyObject_GetAttrString(pyresponse_type, "__class__"); \
-  if (!pymetaclass) { \
+  rmw_request_id_t * header = (rmw_request_id_t *)PyCapsule_GetPointer( \
+    pyheader, "rmw_request_id_t"); \
+  if (!header) { \
     return NULL; \
   } \
-  create_ros_message_signature * create_ros_message = get_capsule_pointer( \
-    pymetaclass, "_CREATE_ROS_MESSAGE"); \
-  assert(create_ros_message != NULL && \
-    "unable to retrieve create_ros_message function, type_support mustn't have been imported"); \
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer( \
-    pymetaclass, "_DESTROY_ROS_MESSAGE"); \
-  assert(destroy_ros_message != NULL && \
-    "unable to retrieve destroy_ros_message function, type_support mustn't have been imported"); \
-  void * taken_response = create_ros_message(); \
-  if (!taken_response) { \
+  destroy_ros_message_signature * destroy_ros_message = NULL; \
+  void * raw_ros_response = rclpy_convert_from_py(pyresponse, & destroy_ros_message); \
+  if (!raw_ros_response) { \
+    return NULL; \
+  } \
+  rcl_ret_t ret = rcl_action_send_ ## Type ## _response(action_server, header, raw_ros_response); \
+  destroy_ros_message(raw_ros_response); \
+  if (ret != RCL_RET_OK) { \
+    PyErr_Format(PyExc_RuntimeError, \
+      "Failed to send " #Type " response: %s", rcl_get_error_string().str); \
+    rcl_reset_error(); \
+    return NULL; \
+  } \
+  Py_RETURN_NONE;
+
+#define TAKE_SERVICE_REQUEST(Type) \
+  PyObject * pyaction_server; \
+  PyObject * pymsg_type; \
+  if (!PyArg_ParseTuple(args, "OO", & pyaction_server, & pymsg_type)) { \
+    return NULL; \
+  } \
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer( \
+    pyaction_server, "rcl_action_server_t"); \
+  if (!action_server) { \
+    return NULL; \
+  } \
+  destroy_ros_message_signature * destroy_ros_message = NULL; \
+  void * taken_msg = rclpy_create_from_py(pymsg_type, & destroy_ros_message); \
+  if (!taken_msg) { \
     /* the function has set the Python error */ \
-    Py_DECREF(pymetaclass); \
     return NULL; \
   } \
   rmw_request_id_t * header = (rmw_request_id_t *)PyMem_Malloc(sizeof(rmw_request_id_t)); \
   if (!header) { \
-    Py_DECREF(pymetaclass); \
+    destroy_ros_message(taken_msg); \
     return PyErr_NoMemory(); \
   } \
-  rcl_ret_t ret = rcl_action_take_ ## Type ## _response(action_client, header, taken_response); \
-  int64_t sequence = header->sequence_number; \
-  PyMem_Free(header); \
+  rcl_ret_t ret = rcl_action_take_ ## Type ## _request(action_server, header, taken_msg); \
   /* Create the tuple to return */ \
   PyObject * pytuple = PyTuple_New(2); \
   if (!pytuple) { \
-    Py_DECREF(pymetaclass); \
+    destroy_ros_message(taken_msg); \
+    PyMem_Free(header); \
     return NULL; \
   } \
   if (ret != RCL_RET_OK) { \
@@ -646,32 +795,98 @@ rclpy_action_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
     PyTuple_SET_ITEM(pytuple, 0, Py_None); \
     Py_INCREF(Py_None); \
     PyTuple_SET_ITEM(pytuple, 1, Py_None); \
-    Py_DECREF(pymetaclass); \
-    destroy_ros_message(taken_response); \
+    destroy_ros_message(taken_msg); \
+    PyMem_Free(header); \
+    if (ret != RCL_RET_ACTION_CLIENT_TAKE_FAILED && ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) { \
+      PyErr_Format(PyExc_RuntimeError, \
+        "Failed to take " #Type ": %s", rcl_get_error_string().str); \
+      rcl_reset_error(); \
+      return NULL; \
+    } \
     return pytuple; \
   } \
-  convert_to_py_signature * convert_to_py = get_capsule_pointer(pymetaclass, "_CONVERT_TO_PY"); \
-  Py_DECREF(pymetaclass); \
-  PyObject * pytaken_response = convert_to_py(taken_response); \
-  destroy_ros_message(taken_response); \
-  if (!pytaken_response) { \
-    /* the function has set the Python error */ \
+  PyObject * pytaken_msg = rclpy_convert_to_py(taken_msg, pymsg_type); \
+  destroy_ros_message(taken_msg); \
+  if (!pytaken_msg) { \
+    Py_DECREF(pytuple); \
+    PyMem_Free(header); \
+    return NULL; \
+  } \
+  PyObject * pyheader = PyCapsule_New(header, "rmw_request_id_t", NULL); \
+  if (!pyheader) { \
+    Py_DECREF(pytaken_msg); \
+    Py_DECREF(pytuple); \
+    PyMem_Free(header); \
+    return NULL; \
+  } \
+  PyTuple_SET_ITEM(pytuple, 0, pyheader); \
+  PyTuple_SET_ITEM(pytuple, 1, pytaken_msg); \
+  return pytuple; \
+
+#define TAKE_SERVICE_RESPONSE(Type) \
+  PyObject * pyaction_client; \
+  PyObject * pymsg_type; \
+  if (!PyArg_ParseTuple(args, "OO", & pyaction_client, & pymsg_type)) { \
+    return NULL; \
+  } \
+  rcl_action_client_t * action_client = (rcl_action_client_t *)PyCapsule_GetPointer( \
+    pyaction_client, "rcl_action_client_t"); \
+  if (!action_client) { \
+    return NULL; \
+  } \
+  destroy_ros_message_signature * destroy_ros_message = NULL; \
+  void * taken_msg = rclpy_create_from_py(pymsg_type, & destroy_ros_message); \
+  if (!taken_msg) { \
+    return NULL; \
+  } \
+  rmw_request_id_t * header = (rmw_request_id_t *)PyMem_Malloc(sizeof(rmw_request_id_t)); \
+  if (!header) { \
+    destroy_ros_message(taken_msg); \
+    return PyErr_NoMemory(); \
+  } \
+  rcl_ret_t ret = rcl_action_take_ ## Type ## _response(action_client, header, taken_msg); \
+  int64_t sequence = header->sequence_number; \
+  PyMem_Free(header); \
+  /* Create the tuple to return */ \
+  PyObject * pytuple = PyTuple_New(2); \
+  if (!pytuple) { \
+    destroy_ros_message(taken_msg); \
+    return NULL; \
+  } \
+  if (ret != RCL_RET_OK) { \
+    Py_INCREF(Py_None); \
+    PyTuple_SET_ITEM(pytuple, 0, Py_None); \
+    Py_INCREF(Py_None); \
+    PyTuple_SET_ITEM(pytuple, 1, Py_None); \
+    destroy_ros_message(taken_msg); \
+    if (ret != RCL_RET_ACTION_CLIENT_TAKE_FAILED && ret != RCL_RET_ACTION_SERVER_TAKE_FAILED) { \
+      PyErr_Format(PyExc_RuntimeError, \
+        "Failed to take " #Type ": %s", rcl_get_error_string().str); \
+      rcl_reset_error(); \
+      return NULL; \
+    } \
+    return pytuple; \
+  } \
+  PyObject * pytaken_msg = rclpy_convert_to_py(taken_msg, pymsg_type); \
+  destroy_ros_message(taken_msg); \
+  if (!pytaken_msg) { \
     Py_DECREF(pytuple); \
     return NULL; \
   } \
   PyObject * pysequence = PyLong_FromLongLong(sequence); \
   if (!pysequence) { \
-    Py_DECREF(pytaken_response); \
+    Py_DECREF(pytaken_msg); \
     Py_DECREF(pytuple); \
     return NULL; \
   } \
   PyTuple_SET_ITEM(pytuple, 0, pysequence); \
-  PyTuple_SET_ITEM(pytuple, 1, pytaken_response); \
+  PyTuple_SET_ITEM(pytuple, 1, pytaken_msg); \
   return pytuple; \
+
 
 /// Send an action goal request.
 /**
- * Raises AttributeError if there is an issue parsing the pygoal_request type.
+ * Raises AttributeError if there is an issue parsing the pygoal_request.
  * Raises RuntimeError on failure.
  *
  * \param[in] pyaction_client The action client to use when sending the request.
@@ -685,15 +900,50 @@ rclpy_action_send_goal_request(PyObject * Py_UNUSED(self), PyObject * args)
   SEND_SERVICE_REQUEST(goal)
 }
 
+/// Take an action goal request.
+/**
+ * Raises AttributeError if there is an issue parsing the pygoal_request_type.
+ * Raises RuntimeError on failure.
+ *
+ * \param[in] pyaction_server The action server to use when taking the request.
+ * \param[in] pygoal_request_type An instance of the type of request message to take.
+ * \return 2-tuple (header, received request message) where the header is a Capsule of
+ *   type "rmw_request_id_t", or
+ * \return 2-tuple (None, None) if there as no message to take, or
+ * \return NULL if there is a failure.
+ */
+static PyObject *
+rclpy_action_take_goal_request(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  TAKE_SERVICE_REQUEST(goal)
+}
+
+/// Send an action goal response.
+/**
+ * Raises AttributeError if there is an issue parsing the pygoal_response.
+ * Raises RuntimeError on failure.
+ *
+ * \param[in] pyaction_server The action server to use when sending the response.
+ * \param[in] pyheader Capsule pointer to the message header of type "rmw_request_id_t".
+ * \param[in] pygoal_response The response message to send.
+ * \return None
+ * \return NULL if there is a failure.
+ */
+static PyObject *
+rclpy_action_send_goal_response(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  SEND_SERVICE_RESPONSE(goal)
+}
+
 /// Take an action goal response.
 /**
- * Raises AttributeError if there is an issue parsing the pygoal_response type.
+ * Raises AttributeError if there is an issue parsing the pygoal_response_type.
  * Raises RuntimeError if the underlying rcl library returns an error when taking the response.
  *
  * \param[in] pyaction_client The action client to use when sending the request.
  * \param[in] pygoal_response_type An instance of the response message type to take.
- * \return 2-tuple sequence number and received response, or
- * \return None if there is no response, or
+ * \return 2-tuple (sequence number, received response), or
+ * \return 2-tuple (None, None) if there is no response, or
  * \return NULL if there is a failure.
  */
 static PyObject *
@@ -704,7 +954,7 @@ rclpy_action_take_goal_response(PyObject * Py_UNUSED(self), PyObject * args)
 
 /// Send an action result request.
 /**
- * Raises AttributeError if there is an issue parsing the pyresult_request type.
+ * Raises AttributeError if there is an issue parsing the pyresult_request.
  * Raises RuntimeError if the underlying rcl library returns an error when sending the request.
  *
  * \param[in] pyaction_client The action client to use when sending the request.
@@ -718,15 +968,50 @@ rclpy_action_send_result_request(PyObject * Py_UNUSED(self), PyObject * args)
   SEND_SERVICE_REQUEST(result);
 }
 
+/// Take an action result request.
+/**
+ * Raises AttributeError if there is an issue parsing the pyresult_request_type.
+ * Raises RuntimeError on failure.
+ *
+ * \param[in] pyaction_server The action server to use when taking the request.
+ * \param[in] pyresult_request_type An instance of the type of request message to take.
+ * \return 2-tuple (header, received request message) where the header is a Capsule of
+ *   type "rmw_request_id_t", or
+ * \return 2-tuple (None, None) if there as no message to take, or
+ * \return NULL if there is a failure.
+ */
+static PyObject *
+rclpy_action_take_result_request(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  TAKE_SERVICE_REQUEST(result)
+}
+
+/// Send an action result response.
+/**
+ * Raises AttributeError if there is an issue parsing the pyresult_response.
+ * Raises RuntimeError on failure.
+ *
+ * \param[in] pyaction_server The action server to use when sending the response.
+ * \param[in] pyheader Capsule pointer to the message header of type "rmw_request_id_t".
+ * \param[in] pyresult_response The response message to send.
+ * \return None
+ * \return NULL if there is a failure.
+ */
+static PyObject *
+rclpy_action_send_result_response(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  SEND_SERVICE_RESPONSE(result)
+}
+
 /// Take an action result response.
 /**
- * Raises AttributeError if there is an issue parsing the pyresult_response type.
+ * Raises AttributeError if there is an issue parsing the pyresult_response_type.
  * Raises RuntimeError if the underlying rcl library returns an error when taking the response.
  *
  * \param[in] pyaction_client The action client to use when sending the request.
  * \param[in] pyresult_response_type An instance of the response message type to take.
- * \return 2-tuple sequence number and received response, or
- * \return None if there is no response, or
+ * \return 2-tuple (sequence number, received response), or
+ * \return 2-tuple (None, None) if there is no response, or
  * \return NULL if there is a failure.
  */
 static PyObject *
@@ -737,7 +1022,7 @@ rclpy_action_take_result_response(PyObject * Py_UNUSED(self), PyObject * args)
 
 /// Send an action cancel request.
 /**
- * Raises AttributeError if there is an issue parsing the pycancel_request type.
+ * Raises AttributeError if there is an issue parsing the pycancel_request.
  * Raises RuntimeError if the underlying rcl library returns an error when sending the request.
  *
  * \param[in] pyaction_client The action client to use when sending the request.
@@ -751,15 +1036,50 @@ rclpy_action_send_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
   SEND_SERVICE_REQUEST(cancel)
 }
 
+/// Take an action cancel request.
+/**
+ * Raises AttributeError if there is an issue parsing the pycancel_request_type.
+ * Raises RuntimeError on failure.
+ *
+ * \param[in] pyaction_server The action server to use when taking the request.
+ * \param[in] pycancel_request_type An instance of the type of request message to take.
+ * \return 2-tuple (header, received request message) where the header is a Capsule of
+ *   type "rmw_request_id_t", or
+ * \return 2-tuple (None, None) if there as no message to take, or
+ * \return NULL if there is a failure.
+ */
+static PyObject *
+rclpy_action_take_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  TAKE_SERVICE_REQUEST(cancel)
+}
+
+/// Send an action cancel response.
+/**
+ * Raises AttributeError if there is an issue parsing the pycancel_response.
+ * Raises RuntimeError on failure.
+ *
+ * \param[in] pyaction_server The action server to use when sending the response.
+ * \param[in] pyheader Capsule pointer to the message header of type "rmw_request_id_t".
+ * \param[in] pycancel_response The response message to send.
+ * \return sequence_number PyLong object representing the index of the sent response, or
+ * \return NULL if there is a failure.
+ */
+static PyObject *
+rclpy_action_send_cancel_response(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  SEND_SERVICE_RESPONSE(cancel)
+}
+
 /// Take an action cancel response.
 /**
- * Raises AttributeError if there is an issue parsing the pycancel_response type.
+ * Raises AttributeError if there is an issue parsing the pycancel_response_type.
  * Raises RuntimeError if the underlying rcl library returns an error when taking the response.
  *
  * \param[in] pyaction_client The action client to use when sending the request.
  * \param[in] pycancel_response_type An instance of the response message type to take.
- * \return 2-tuple sequence number and received response, or
- * \return None if there is no response, or
+ * \return 2-tuple (sequence number, received response), or
+ * \return 2-tuple (None, None) if there is no response, or
  * \return NULL if there is a failure.
  */
 static PyObject *
@@ -767,6 +1087,32 @@ rclpy_action_take_cancel_response(PyObject * Py_UNUSED(self), PyObject * args)
 {
   TAKE_SERVICE_RESPONSE(cancel)
 }
+
+#define PUBLISH_MESSAGE(Type) \
+  PyObject * pyaction_server; \
+  PyObject * pymsg; \
+  if (!PyArg_ParseTuple(args, "OO", & pyaction_server, & pymsg)) { \
+    return NULL; \
+  } \
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer( \
+    pyaction_server, "rcl_action_server_t"); \
+  if (!action_server) { \
+    return NULL; \
+  } \
+  destroy_ros_message_signature * destroy_ros_message = NULL; \
+  void * raw_ros_message = rclpy_convert_from_py(pymsg, & destroy_ros_message); \
+  if (!raw_ros_message) { \
+    return NULL; \
+  } \
+  rcl_ret_t ret = rcl_action_publish_ ## Type(action_server, raw_ros_message); \
+  destroy_ros_message(raw_ros_message); \
+  if (ret != RCL_RET_OK) { \
+    PyErr_Format(PyExc_RuntimeError, \
+      "Failed to publish " #Type " with an action server: %s", rcl_get_error_string().str); \
+    rcl_reset_error(); \
+    return NULL; \
+  } \
+  Py_RETURN_NONE;
 
 #define TAKE_MESSAGE(Type) \
   PyObject * pyaction_client; \
@@ -779,40 +1125,41 @@ rclpy_action_take_cancel_response(PyObject * Py_UNUSED(self), PyObject * args)
   if (!action_client) { \
     return NULL; \
   } \
-  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__"); \
-  if (!pymetaclass) { \
-    return NULL; \
-  } \
-  create_ros_message_signature * create_ros_message = get_capsule_pointer( \
-    pymetaclass, "_CREATE_ROS_MESSAGE"); \
-  assert(create_ros_message != NULL && \
-    "unable to retrieve create_ros_message function, type_support must not have been imported"); \
-  destroy_ros_message_signature * destroy_ros_message = get_capsule_pointer( \
-    pymetaclass, "_DESTROY_ROS_MESSAGE"); \
-  assert(destroy_ros_message != NULL && \
-    "unable to retrieve destroy_ros_message function, type_support must not have been imported"); \
-  convert_to_py_signature * convert_to_py = get_capsule_pointer(pymetaclass, "_CONVERT_TO_PY"); \
-  Py_DECREF(pymetaclass); \
-  void * taken_msg = create_ros_message(); \
+  destroy_ros_message_signature * destroy_ros_message = NULL; \
+  void * taken_msg = rclpy_create_from_py(pymsg_type, & destroy_ros_message); \
   if (!taken_msg) { \
-    return PyErr_NoMemory(); \
+    return NULL; \
   } \
   rcl_ret_t ret = rcl_action_take_ ## Type(action_client, taken_msg); \
   if (ret != RCL_RET_OK) { \
+    destroy_ros_message(taken_msg); \
     if (ret != RCL_RET_ACTION_CLIENT_TAKE_FAILED) { \
       /* if take failed, just do nothing */ \
-      destroy_ros_message(taken_msg); \
       Py_RETURN_NONE; \
     } \
     PyErr_Format(PyExc_RuntimeError, \
       "Failed to take " #Type " with an action client: %s", rcl_get_error_string().str); \
     rcl_reset_error(); \
-    destroy_ros_message(taken_msg); \
     return NULL; \
   } \
-  PyObject * pytaken_msg = convert_to_py(taken_msg); \
+  PyObject * pytaken_msg = rclpy_convert_to_py(taken_msg, pymsg_type); \
   destroy_ros_message(taken_msg); \
   return pytaken_msg;
+
+/// Publish a feedback message from a given action server.
+/**
+ * Raises AttributeError if there is an issue parsing the pyfeedback_msg.
+ * Raises RuntimeError on failure while publishing a feedback message.
+ *
+ * \param[in] pyaction_server Capsule pointing to the action server to publish the message.
+ * \param[in] pyfeedback_msg The feedback message to publish.
+ * \return None
+ */
+static PyObject *
+rclpy_action_publish_feedback(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PUBLISH_MESSAGE(feedback)
+}
 
 /// Take a feedback message from a given action client.
 /**
@@ -830,6 +1177,21 @@ static PyObject *
 rclpy_action_take_feedback(PyObject * Py_UNUSED(self), PyObject * args)
 {
   TAKE_MESSAGE(feedback)
+}
+
+/// Publish a status message from a given action server.
+/**
+ * Raises AttributeError if there is an issue parsing the pystatus_msg.
+ * Raises RuntimeError on failure while publishing a status message.
+ *
+ * \param[in] pyaction_server Capsule pointing to the action server to publish the message.
+ * \param[in] pystatus_msg The status message to publish.
+ * \return None
+ */
+static PyObject *
+rclpy_action_publish_status(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PUBLISH_MESSAGE(status)
 }
 
 /// Take a status message from a given action client.
@@ -850,11 +1212,347 @@ rclpy_action_take_status(PyObject * Py_UNUSED(self), PyObject * args)
   TAKE_MESSAGE(status)
 }
 
+static PyObject *
+rclpy_action_accept_new_goal(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pyaction_server;
+  PyObject * pygoal_info_msg;
+
+  if (!PyArg_ParseTuple(args, "OO", &pyaction_server, &pygoal_info_msg)) {
+    return NULL;
+  }
+
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer(
+    pyaction_server, "rcl_action_server_t");
+  if (!action_server) {
+    return NULL;
+  }
+
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  rcl_action_goal_info_t * goal_info_msg = (rcl_action_goal_info_t *)rclpy_convert_from_py(
+    pygoal_info_msg, &destroy_ros_message);
+  if (!goal_info_msg) {
+    return NULL;
+  }
+
+  rcl_action_goal_handle_t * goal_handle = rcl_action_accept_new_goal(
+    action_server, goal_info_msg);
+  destroy_ros_message(goal_info_msg);
+  if (!goal_handle) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to accept new goal: %s", rcl_get_error_string().str);
+    rcl_reset_error();
+    return NULL;
+  }
+
+  return PyCapsule_New(goal_handle, "rcl_action_goal_handle_t", NULL);
+}
+
+static PyObject *
+rclpy_action_notify_goal_done(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pyaction_server;
+
+  if (!PyArg_ParseTuple(args, "O", &pyaction_server)) {
+    return NULL;
+  }
+
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer(
+    pyaction_server, "rcl_action_server_t");
+  if (!action_server) {
+    return NULL;
+  }
+
+  rcl_ret_t ret = rcl_action_notify_goal_done(action_server);
+  if (RCL_RET_OK != ret) {
+    PyErr_Format(
+      PyExc_RuntimeError,
+      "Failed to notfiy action server of goal done: %s",
+      rcl_get_error_string().str);
+    rcl_reset_error();
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+#define MULTI_DECREF(Arr, Size) \
+  for (size_t i = 0; i < Size; ++i) { \
+    Py_DECREF(Arr[i]); \
+  }
+
+/// Convert from a Python GoalEvent code to an rcl goal event code.
+/**
+ *  Note, this this function makes the assumption that no event code has the value -1.
+ *  \param[in] pyevent The Python GoalEvent code.
+ *  \return The rcl equivalent of the Python GoalEvent code, or
+ *  \return -1 on failure.
+ */
+static int
+convert_from_py_goal_event(const int64_t pyevent)
+{
+  // Holds references to PyObjects that should have references decremented
+  PyObject * to_decref[11];
+  // The number of objects in the decref list
+  size_t num_to_decref = 0;
+
+  PyObject * pyaction_server_module = PyImport_ImportModule("rclpy.action_server");
+  if (!pyaction_server_module) {
+    return -1;
+  }
+
+  PyObject * pygoal_event_class = PyObject_GetAttrString(pyaction_server_module, "GoalEvent");
+  Py_DECREF(pyaction_server_module);
+  if (!pygoal_event_class) {
+    return -1;
+  }
+  to_decref[num_to_decref++] = pygoal_event_class;
+
+  PyObject * pyexecute = PyObject_GetAttrString(pygoal_event_class, "EXECUTE");
+  if (!pyexecute) {
+    MULTI_DECREF(to_decref, num_to_decref)
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyexecute;
+
+  PyObject * pycancel = PyObject_GetAttrString(pygoal_event_class, "CANCEL");
+  if (!pycancel) {
+    MULTI_DECREF(to_decref, num_to_decref)
+    return -1;
+  }
+  to_decref[num_to_decref++] = pycancel;
+
+  PyObject * pyset_succeeded = PyObject_GetAttrString(pygoal_event_class, "SET_SUCCEEDED");
+  if (!pyset_succeeded) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyset_succeeded;
+
+  PyObject * pyset_aborted = PyObject_GetAttrString(pygoal_event_class, "SET_ABORTED");
+  if (!pyset_aborted) {
+    MULTI_DECREF(to_decref, num_to_decref)
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyset_aborted;
+
+  PyObject * pyset_canceled = PyObject_GetAttrString(pygoal_event_class, "SET_CANCELED");
+  if (!pyset_canceled) {
+    MULTI_DECREF(to_decref, num_to_decref)
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyset_canceled;
+
+  PyObject * pyexecute_val = PyObject_GetAttrString(pyexecute, "value");
+  if (!pyexecute_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyexecute_val;
+
+  PyObject * pycancel_val = PyObject_GetAttrString(pycancel, "value");
+  if (!pycancel_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pycancel_val;
+
+  PyObject * pyset_succeeded_val = PyObject_GetAttrString(pyset_succeeded, "value");
+  if (!pyset_succeeded_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyset_succeeded_val;
+
+  PyObject * pyset_aborted_val = PyObject_GetAttrString(pyset_aborted, "value");
+  if (!pyset_aborted_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyset_aborted_val;
+
+  PyObject * pyset_canceled_val = PyObject_GetAttrString(pyset_canceled, "value");
+  if (!pyset_canceled_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyset_canceled_val;
+
+  const int64_t execute = PyLong_AsLong(pyexecute_val);
+  const int64_t cancel = PyLong_AsLong(pycancel_val);
+  const int64_t set_succeeded = PyLong_AsLong(pyset_succeeded_val);
+  const int64_t set_aborted = PyLong_AsLong(pyset_aborted_val);
+  const int64_t set_canceled = PyLong_AsLong(pyset_canceled_val);
+  MULTI_DECREF(to_decref, num_to_decref)
+
+  if (execute == pyevent) {
+    return GOAL_EVENT_EXECUTE;
+  }
+  if (cancel == pyevent) {
+    return GOAL_EVENT_CANCEL;
+  }
+  if (set_succeeded == pyevent) {
+    return GOAL_EVENT_SET_SUCCEEDED;
+  }
+  if (set_aborted == pyevent) {
+    return GOAL_EVENT_SET_ABORTED;
+  }
+  if (set_canceled == pyevent) {
+    return GOAL_EVENT_SET_CANCELED;
+  }
+
+  PyErr_Format(
+    PyExc_RuntimeError, "Error converting goal event type: unknown goal event '%d'", pyevent);
+  return -1;
+}
+
+static PyObject *
+rclpy_action_update_goal_state(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pygoal_handle;
+  int64_t pyevent;
+
+  if (!PyArg_ParseTuple(args, "Ol", &pygoal_handle, &pyevent)) {
+    return NULL;
+  }
+
+  rcl_action_goal_handle_t * goal_handle = (rcl_action_goal_handle_t *)PyCapsule_GetPointer(
+    pygoal_handle, "rcl_action_goal_handle_t");
+  if (!goal_handle) {
+    return NULL;
+  }
+
+  int event = convert_from_py_goal_event(pyevent);
+  if (event < 0) {
+    return NULL;
+  }
+
+  rcl_ret_t ret = rcl_action_update_goal_state(goal_handle, event);
+  if (RCL_RET_OK != ret) {
+    PyErr_Format(
+      PyExc_RuntimeError, "Failed to update goal state: %s", rcl_get_error_string().str);
+    rcl_reset_error();
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *
+rclpy_action_goal_handle_is_active(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pygoal_handle;
+
+  if (!PyArg_ParseTuple(args, "O", &pygoal_handle)) {
+    return NULL;
+  }
+
+  rcl_action_goal_handle_t * goal_handle = (rcl_action_goal_handle_t *)PyCapsule_GetPointer(
+    pygoal_handle, "rcl_action_goal_handle_t");
+  if (!goal_handle) {
+    return NULL;
+  }
+
+  bool is_active = rcl_action_goal_handle_is_active(goal_handle);
+  if (is_active) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+}
+
+static PyObject *
+rclpy_action_goal_handle_get_status(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pygoal_handle;
+
+  if (!PyArg_ParseTuple(args, "O", &pygoal_handle)) {
+    return NULL;
+  }
+
+  rcl_action_goal_handle_t * goal_handle = (rcl_action_goal_handle_t *)PyCapsule_GetPointer(
+    pygoal_handle, "rcl_action_goal_handle_t");
+  if (!goal_handle) {
+    return NULL;
+  }
+
+  rcl_action_goal_state_t status;
+  rcl_ret_t ret = rcl_action_goal_handle_get_status(goal_handle, &status);
+  if (RCL_RET_OK != ret) {
+    PyErr_Format(
+      PyExc_RuntimeError, "Failed to get goal status: %s", rcl_get_error_string().str);
+    rcl_reset_error();
+    return NULL;
+  }
+
+  return PyLong_FromLong(status);
+}
+
+static PyObject *
+rclpy_action_process_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pyaction_server;
+  PyObject * pycancel_request;
+  PyObject * pycancel_response_type;
+
+  if (!PyArg_ParseTuple(
+      args,
+      "OOO",
+      &pyaction_server,
+      &pycancel_request,
+      &pycancel_response_type))
+  {
+    return NULL;
+  }
+
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer(
+    pyaction_server, "rcl_action_server_t");
+  if (!action_server) {
+    return NULL;
+  }
+
+  destroy_ros_message_signature * destroy_cancel_request = NULL;
+  rcl_action_cancel_request_t * cancel_request =
+    (rcl_action_cancel_request_t *)rclpy_convert_from_py(pycancel_request, &destroy_cancel_request);
+  if (!cancel_request) {
+    return NULL;
+  }
+
+  rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
+  rcl_ret_t ret = rcl_action_process_cancel_request(
+    action_server, cancel_request, &cancel_response);
+  destroy_cancel_request(cancel_request);
+  if (RCL_RET_OK != ret) {
+    ret = rcl_action_cancel_response_fini(&cancel_response);
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to process cancel request: %s",
+      rcl_get_error_string().str);
+    rcl_reset_error();
+    return NULL;
+  }
+
+  PyObject * pycancel_response = rclpy_convert_to_py(&cancel_response.msg, pycancel_response_type);
+  ret = rcl_action_cancel_response_fini(&cancel_response);
+  if (!pycancel_response) {
+    return NULL;
+  }
+  if (RCL_RET_OK != ret) {
+    PyErr_Format(PyExc_RuntimeError,
+      "Failed to finalize cancel response: %s",
+      rcl_get_error_string().str);
+    rcl_reset_error();
+    return NULL;
+  }
+  return pycancel_response;
+}
+
 /// Define the public methods of this module
 static PyMethodDef rclpy_action_methods[] = {
   {
     "rclpy_action_destroy_entity", rclpy_action_destroy_entity, METH_VARARGS,
     "Destroy a rclpy_action entity."
+  },
+  {
+    "rclpy_action_destroy_server_goal_handle",
+    rclpy_action_destroy_server_goal_handle,
+    METH_VARARGS,
+    "Destroy a ServerGoalHandle."
   },
   {
     "rclpy_action_get_rmw_qos_profile", rclpy_action_get_rmw_qos_profile, METH_VARARGS,
@@ -877,12 +1575,24 @@ static PyMethodDef rclpy_action_methods[] = {
     "Create an action client."
   },
   {
+    "rclpy_action_create_server", rclpy_action_create_server, METH_VARARGS,
+    "Create an action server."
+  },
+  {
     "rclpy_action_server_is_available", rclpy_action_server_is_available, METH_VARARGS,
     "Check if an action server is available for a given client."
   },
   {
     "rclpy_action_send_goal_request", rclpy_action_send_goal_request, METH_VARARGS,
     "Send a goal request."
+  },
+  {
+    "rclpy_action_take_goal_request", rclpy_action_take_goal_request, METH_VARARGS,
+    "Take a goal request."
+  },
+  {
+    "rclpy_action_send_goal_response", rclpy_action_send_goal_response, METH_VARARGS,
+    "Send a goal response."
   },
   {
     "rclpy_action_take_goal_response", rclpy_action_take_goal_response, METH_VARARGS,
@@ -893,6 +1603,14 @@ static PyMethodDef rclpy_action_methods[] = {
     "Send a result request."
   },
   {
+    "rclpy_action_take_result_request", rclpy_action_take_result_request, METH_VARARGS,
+    "Take a result request."
+  },
+  {
+    "rclpy_action_send_result_response", rclpy_action_send_result_response, METH_VARARGS,
+    "Send a result response."
+  },
+  {
     "rclpy_action_take_result_response", rclpy_action_take_result_response, METH_VARARGS,
     "Take a result response."
   },
@@ -901,16 +1619,56 @@ static PyMethodDef rclpy_action_methods[] = {
     "Send a cancel request."
   },
   {
+    "rclpy_action_take_cancel_request", rclpy_action_take_cancel_request, METH_VARARGS,
+    "Take a cancel request."
+  },
+  {
+    "rclpy_action_send_cancel_response", rclpy_action_send_cancel_response, METH_VARARGS,
+    "Send a cancel response."
+  },
+  {
     "rclpy_action_take_cancel_response", rclpy_action_take_cancel_response, METH_VARARGS,
     "Take a cancel response."
+  },
+  {
+    "rclpy_action_publish_feedback", rclpy_action_publish_feedback, METH_VARARGS,
+    "Publish a feedback message."
   },
   {
     "rclpy_action_take_feedback", rclpy_action_take_feedback, METH_VARARGS,
     "Take a feedback message."
   },
   {
+    "rclpy_action_publish_status", rclpy_action_publish_status, METH_VARARGS,
+    "Publish a status message."
+  },
+  {
     "rclpy_action_take_status", rclpy_action_take_status, METH_VARARGS,
     "Take a status message."
+  },
+  {
+    "rclpy_action_accept_new_goal", rclpy_action_accept_new_goal, METH_VARARGS,
+    "Accept a new goal using an action server."
+  },
+  {
+    "rclpy_action_notify_goal_done", rclpy_action_notify_goal_done, METH_VARARGS,
+    "Notify and action server that a goal has reached a terminal state."
+  },
+  {
+    "rclpy_action_update_goal_state", rclpy_action_update_goal_state, METH_VARARGS,
+    "Update a goal state."
+  },
+  {
+    "rclpy_action_goal_handle_is_active", rclpy_action_goal_handle_is_active, METH_VARARGS,
+    "Check if goal is active."
+  },
+  {
+    "rclpy_action_goal_handle_get_status", rclpy_action_goal_handle_get_status, METH_VARARGS,
+    "Get the status of a goal."
+  },
+  {
+    "rclpy_action_process_cancel_request", rclpy_action_process_cancel_request, METH_VARARGS,
+    "Process a cancel request to determine what goals should be canceled."
   },
 
   {NULL, NULL, 0, NULL}  /* sentinel */

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1461,6 +1461,37 @@ rclpy_action_goal_handle_is_active(PyObject * Py_UNUSED(self), PyObject * args)
 }
 
 static PyObject *
+rclpy_action_server_goal_exists(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pyaction_server;
+  PyObject * pygoal_info;
+
+  if (!PyArg_ParseTuple(args, "OO", &pyaction_server, &pygoal_info)) {
+    return NULL;
+  }
+
+  rcl_action_server_t * action_server = (rcl_action_server_t *)PyCapsule_GetPointer(
+    pyaction_server, "rcl_action_server_t");
+  if (!action_server) {
+    return NULL;
+  }
+
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  rcl_action_goal_info_t * goal_info = rclpy_convert_from_py(pygoal_info, &destroy_ros_message);
+  if (!goal_info) {
+    return NULL;
+  }
+
+  bool exists = rcl_action_server_goal_exists(action_server, goal_info);
+  destroy_ros_message(goal_info);
+
+  if (exists) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+}
+
+static PyObject *
 rclpy_action_goal_handle_get_status(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pygoal_handle;
@@ -1735,7 +1766,11 @@ static PyMethodDef rclpy_action_methods[] = {
   },
   {
     "rclpy_action_goal_handle_is_active", rclpy_action_goal_handle_is_active, METH_VARARGS,
-    "Check if goal is active."
+    "Check if a goal is active."
+  },
+  {
+    "rclpy_action_server_goal_exists", rclpy_action_server_goal_exists, METH_VARARGS,
+    "Check if a goal being tracked by an action server."
   },
   {
     "rclpy_action_goal_handle_get_status", rclpy_action_goal_handle_get_status, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1297,7 +1297,7 @@ convert_from_py_goal_event(const int64_t pyevent)
   // The number of objects in the decref list
   size_t num_to_decref = 0;
 
-  PyObject * pyaction_server_module = PyImport_ImportModule("rclpy.action_server");
+  PyObject * pyaction_server_module = PyImport_ImportModule("rclpy.action.server");
   if (!pyaction_server_module) {
     return -1;
   }

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1446,7 +1446,7 @@ rclpy_action_update_goal_state(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pygoal_handle;
   int64_t pyevent;
 
-  if (!PyArg_ParseTuple(args, "Ol", &pygoal_handle, &pyevent)) {
+  if (!PyArg_ParseTuple(args, "OL", &pygoal_handle, &pyevent)) {
     return NULL;
   }
 
@@ -1615,7 +1615,7 @@ rclpy_action_expire_goals(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pyaction_server;
   int64_t max_num_goals;
 
-  if (!PyArg_ParseTuple(args, "Ol", &pyaction_server, &max_num_goals)) {
+  if (!PyArg_ParseTuple(args, "OL", &pyaction_server, &max_num_goals)) {
     return NULL;
   }
 

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -629,7 +629,7 @@ rclpy_action_create_server(PyObject * Py_UNUSED(self), PyObject * args)
   OPTIONS_COPY_QOS_PROFILE(action_server_ops, cancel_service_qos);
   OPTIONS_COPY_QOS_PROFILE(action_server_ops, feedback_topic_qos);
   OPTIONS_COPY_QOS_PROFILE(action_server_ops, status_topic_qos);
-  action_server_ops.result_timeout.nanoseconds = RCL_S_TO_NS(result_timeout);
+  action_server_ops.result_timeout.nanoseconds = (rcl_duration_value_t)RCL_S_TO_NS(result_timeout);
 
   rcl_action_server_t * action_server =
     (rcl_action_server_t *)PyMem_Malloc(sizeof(rcl_action_server_t));

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1663,6 +1663,7 @@ rclpy_action_expire_goals(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * result_tuple = PyTuple_New(num_expired);
   if (!result_tuple) {
     free(expired_goals);
+    Py_DECREF(pygoal_info_type);
     return NULL;
   }
   // PyTuple_SetItem() returns 0 on success

--- a/rclpy/test/action/test_client.py
+++ b/rclpy/test/action/test_client.py
@@ -81,10 +81,8 @@ class TestActionClient(unittest.TestCase):
 
     def timed_spin(self, duration):
         start_time = time.time()
-        current_time = start_time
-        while (current_time - start_time) < duration:
+        while (time.time() - start_time) < duration:
             rclpy.spin_once(self.node, executor=self.executor, timeout_sec=0.1)
-            current_time = time.time()
 
     def test_constructor_defaults(self):
         # Defaults

--- a/rclpy/test/action/test_server.py
+++ b/rclpy/test/action/test_server.py
@@ -1,0 +1,284 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+import uuid
+
+from action_msgs.srv import CancelGoal
+
+import rclpy
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor, SingleThreadedExecutor
+
+from test_msgs.action import Fibonacci
+
+from unique_identifier_msgs.msg import UUID
+
+
+class MockActionClient():
+
+    def __init__(self, node):
+        self.reset()
+        self.goal_srv = node.create_client(
+            Fibonacci.GoalRequestService, '/fibonacci/_action/send_goal')
+        self.cancel_srv = node.create_client(
+            Fibonacci.CancelGoalService, '/fibonacci/_action/cancel_goal')
+        self.result_srv = node.create_client(
+            Fibonacci.GoalResultService, '/fibonacci/_action/get_result')
+        self.feedback_sub = node.create_subscription(
+            Fibonacci.Feedback, '/fibonacci/_action/feedback', self.feedback_callback)
+        self.status_sub = node.create_subscription(
+            Fibonacci.GoalStatusMessage, '/fibonacci/_action/status', self.status_callback)
+
+    def reset(self):
+        self.feedback_msg = None
+        self.status_msg = None
+
+    def feedback_callback(self, feedback_msg):
+        self.feedback_msg = feedback_msg
+
+    def status_callback(self, status_msg):
+        self.status_msg = status_msg
+
+    def send_goal(self, goal_msg):
+        return self.goal_srv.call_async(goal_msg)
+
+    def cancel_goal(self, cancel_msg):
+        return self.cancel_srv.call_async(cancel_msg)
+
+    def get_result(self, get_result_msg):
+        return self.result_srv.call_async(get_result_msg)
+
+
+class TestActionServer(unittest.TestCase):
+
+    def setUp(self):
+        self.context = rclpy.context.Context()
+        rclpy.init(context=self.context)
+        self.executor = SingleThreadedExecutor(context=self.context)
+        self.node = rclpy.create_node('TestActionServer', context=self.context)
+        self.mock_action_client = MockActionClient(self.node)
+
+    def tearDown(self):
+        self.node.destroy_node()
+        self.executor.shutdown()
+        rclpy.shutdown(context=self.context)
+
+    def timed_spin(self, duration):
+        start_time = time.time()
+        current_time = start_time
+        while (current_time - start_time) < duration:
+            rclpy.spin_once(self.node, executor=self.executor, timeout_sec=0.1)
+            current_time = time.time()
+
+    def execute_goal_callback(self, goal_handle):
+        goal_handle.set_succeeded()
+        return Fibonacci.Result()
+
+    def test_constructor_defaults(self):
+        # Defaults
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=self.execute_goal_callback,
+        )
+        action_server.destroy()
+
+    def test_constructor_no_defaults(self):
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=self.execute_goal_callback,
+            callback_group=ReentrantCallbackGroup(),
+            goal_callback=lambda req: GoalResponse.REJECT,
+            cancel_callback=lambda req: CancelResponse.REJECT,
+            goal_service_qos_profile=rclpy.qos.qos_profile_default,
+            result_service_qos_profile=rclpy.qos.qos_profile_default,
+            cancel_service_qos_profile=rclpy.qos.qos_profile_default,
+            feedback_pub_qos_profile=rclpy.qos.qos_profile_default,
+            status_pub_qos_profile=rclpy.qos.qos_profile_default,
+        )
+        action_server.destroy()
+
+    def test_get_num_entities(self):
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=self.execute_goal_callback,
+        )
+        num_entities = action_server.get_num_entities()
+        self.assertEqual(num_entities.num_subscriptions, 0)
+        self.assertEqual(num_entities.num_guard_conditions, 0)
+        self.assertEqual(num_entities.num_timers, 1)
+        self.assertEqual(num_entities.num_clients, 0)
+        self.assertEqual(num_entities.num_services, 3)
+        action_server.destroy()
+
+    def test_single_goal_accept(self):
+        goal_uuid = UUID(uuid=list(uuid.uuid4().bytes))
+        goal_order = 10
+
+        def goal_callback(goal):
+            nonlocal goal_uuid
+            nonlocal goal_order
+            self.assertEqual(goal.action_goal_id, goal_uuid)
+            self.assertEqual(goal.order, goal_order)
+            return GoalResponse.ACCEPT_AND_EXECUTE
+
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=self.execute_goal_callback,
+            goal_callback=goal_callback,
+        )
+
+        goal_msg = Fibonacci.Goal()
+        goal_msg.action_goal_id = goal_uuid
+        goal_msg.order = goal_order
+        future = self.mock_action_client.send_goal(goal_msg)
+        rclpy.spin_until_future_complete(self.node, future, self.executor)
+        self.assertTrue(future.result().accepted)
+        action_server.destroy()
+
+    def test_single_goal_reject(self):
+        goal_uuid = UUID(uuid=list(uuid.uuid4().bytes))
+        goal_order = 10
+
+        def goal_callback(goal):
+            nonlocal goal_uuid
+            nonlocal goal_order
+            self.assertEqual(goal.action_goal_id, goal_uuid)
+            self.assertEqual(goal.order, goal_order)
+            return GoalResponse.REJECT
+
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=self.execute_goal_callback,
+            goal_callback=goal_callback,
+        )
+
+        goal_msg = Fibonacci.Goal()
+        goal_msg.action_goal_id = goal_uuid
+        goal_msg.order = goal_order
+        future = self.mock_action_client.send_goal(goal_msg)
+        rclpy.spin_until_future_complete(self.node, future, self.executor)
+        self.assertFalse(future.result().accepted)
+        action_server.destroy()
+
+    def test_cancel_goal_accept(self):
+
+        def execute_callback(goal_handle):
+            # Wait, to give the opportunity to cancel
+            time.sleep(3.0)
+            self.assertTrue(goal_handle.is_cancel_requested)
+            goal_handle.set_canceled()
+            return Fibonacci.Result()
+
+        def cancel_callback(request):
+            return CancelResponse.ACCEPT
+
+        executor = MultiThreadedExecutor(context=self.context)
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            callback_group=ReentrantCallbackGroup(),
+            execute_callback=execute_callback,
+            cancel_callback=cancel_callback,
+        )
+
+        goal_uuid = UUID(uuid=list(uuid.uuid4().bytes))
+        goal_order = 10
+        goal_msg = Fibonacci.Goal()
+        goal_msg.action_goal_id = goal_uuid
+        goal_msg.order = goal_order
+        goal_future = self.mock_action_client.send_goal(goal_msg)
+        rclpy.spin_until_future_complete(self.node, goal_future, executor)
+        goal_handle = goal_future.result()
+        self.assertTrue(goal_handle.accepted)
+
+        cancel_srv = CancelGoal.Request()
+        cancel_srv.goal_info.goal_id = goal_uuid
+        cancel_srv.goal_info.stamp.sec = 0
+        cancel_srv.goal_info.stamp.nanosec = 0
+        cancel_future = self.mock_action_client.cancel_goal(cancel_srv)
+        rclpy.spin_until_future_complete(self.node, cancel_future, executor)
+        cancel_result = cancel_future.result()
+        self.assertEqual(len(cancel_result.goals_canceling), 1)
+        self.assertEqual(cancel_result.goals_canceling[0].goal_id.uuid, goal_uuid.uuid)
+
+        action_server.destroy()
+        executor.shutdown()
+
+    def test_cancel_goal_reject(self):
+
+        def execute_callback(goal_handle):
+            # Wait, to give the opportunity to cancel
+            time.sleep(3.0)
+            self.assertTrue(goal_handle.is_cancel_requested)
+            goal_handle.set_canceled()
+            return Fibonacci.Result()
+
+        def cancel_callback(request):
+            return CancelResponse.REJECT
+
+        executor = MultiThreadedExecutor(context=self.context)
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            callback_group=ReentrantCallbackGroup(),
+            execute_callback=execute_callback,
+            cancel_callback=cancel_callback,
+        )
+
+        goal_uuid = UUID(uuid=list(uuid.uuid4().bytes))
+        goal_order = 10
+        goal_msg = Fibonacci.Goal()
+        goal_msg.action_goal_id = goal_uuid
+        goal_msg.order = goal_order
+        goal_future = self.mock_action_client.send_goal(goal_msg)
+        rclpy.spin_until_future_complete(self.node, goal_future, executor)
+        goal_handle = goal_future.result()
+        self.assertTrue(goal_handle.accepted)
+
+        cancel_srv = CancelGoal.Request()
+        cancel_srv.goal_info.goal_id = goal_uuid
+        cancel_srv.goal_info.stamp.sec = 0
+        cancel_srv.goal_info.stamp.nanosec = 0
+        cancel_future = self.mock_action_client.cancel_goal(cancel_srv)
+        rclpy.spin_until_future_complete(self.node, cancel_future, executor)
+        cancel_result = cancel_future.result()
+        self.assertEqual(len(cancel_result.goals_canceling), 0)
+
+        action_server.destroy()
+        executor.shutdown()
+
+    def test_send_result_success(self):
+        pass
+
+    def test_send_result_failure(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/action/test_server.py
+++ b/rclpy/test/action/test_server.py
@@ -82,10 +82,8 @@ class TestActionServer(unittest.TestCase):
 
     def timed_spin(self, duration):
         start_time = time.time()
-        current_time = start_time
-        while (current_time - start_time) < duration:
+        while (time.time() - start_time) < duration:
             rclpy.spin_once(self.node, executor=self.executor, timeout_sec=0.1)
-            current_time = time.time()
 
     def execute_goal_callback(self, goal_handle):
         goal_handle.set_succeeded()


### PR DESCRIPTION
Resolves #257 

Similar to `ActionClient`, `ActionServer` is implemented as a `Waitable` and the user interacts with goals via `ServerGoalHandle` objects. 

This is a work in progress. Still need to implement the "get result" logic, add documentation, and some more tests. I separated some changes to `_rclpy.c` into #269 to avoid adding more to this large change. Since this PR is based on that branch, #269 should be resolved first.