### PR TITLE
Fix Node's reference to executor

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -112,11 +112,14 @@ class Node:
     def executor(self, new_executor):
         """Set or change the executor the node belongs to."""
         current_executor = self.executor
+        if current_executor == new_executor:
+            return
         if current_executor is not None:
             current_executor.remove_node(self)
         if new_executor is None:
             self.__executor_weakref = None
-        elif new_executor.add_node(self):
+        else:
+            new_executor.add_node(self)
             self.__executor_weakref = weakref.ref(new_executor)
 
     @property

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -298,7 +298,9 @@ class TestExecutor(unittest.TestCase):
         self.assertIsNotNone(self.node.handle)
         executor = SingleThreadedExecutor(context=self.context)
         assert executor.add_node(self.node)
+        assert id(executor) == id(self.node.executor)
         assert not executor.add_node(self.node)
+        assert id(executor) == id(self.node.executor)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, if a `Node` was added to an `Executor` using the executors `add_node` method, then the nodes `executor` property would return `None`.