### PR TITLE
Dictionaries raise KeyError

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -262,7 +262,7 @@ class Executor:
         if sequence is not None:
             try:
                 future = client._pending_requests[sequence]
-            except IndexError:
+            except KeyError:
                 # The request was cancelled
                 pass
             else:


### PR DESCRIPTION
Dictionaries raise `KeyError` instead of `IndexError`. I'm not sure how to write a test for this, so I didn't.

See https://github.com/ros2/rclpy/pull/170#discussion_r257388836