### PR TITLE
Enable test using MultiThreadedExecutor

### DIFF
--- a/rclpy/test/action/test_client.py
+++ b/rclpy/test/action/test_client.py
@@ -18,7 +18,8 @@ import uuid
 
 import rclpy
 from rclpy.action import ActionClient
-from rclpy.executors import SingleThreadedExecutor
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor, SingleThreadedExecutor
 
 from test_msgs.action import Fibonacci
 
@@ -251,31 +252,29 @@ class TestActionClient(unittest.TestCase):
         finally:
             ac.destroy()
 
-    # TODO(jacobperron): Figure out why this test gets stuck on some CI instances
-    # Related issue: https://github.com/ros2/rclpy/issues/268
-    # def test_send_goal_multiple(self):
-    #     ac = ActionClient(
-    #         self.node,
-    #         Fibonacci,
-    #         'fibonacci',
-    #         callback_group=ReentrantCallbackGroup())
-    #     executor = MultiThreadedExecutor(context=self.context)
-    #     try:
-    #         self.assertTrue(ac.wait_for_server(timeout_sec=2.0))
-    #         future_0 = ac.send_goal_async(Fibonacci.Goal())
-    #         future_1 = ac.send_goal_async(Fibonacci.Goal())
-    #         future_2 = ac.send_goal_async(Fibonacci.Goal())
-    #         rclpy.spin_until_future_complete(self.node, future_0, executor)
-    #         rclpy.spin_until_future_complete(self.node, future_1, executor)
-    #         rclpy.spin_until_future_complete(self.node, future_2, executor)
-    #         self.assertTrue(future_0.done())
-    #         self.assertTrue(future_1.done())
-    #         self.assertTrue(future_2.done())
-    #         self.assertTrue(future_0.result().accepted)
-    #         self.assertTrue(future_1.result().accepted)
-    #         self.assertTrue(future_2.result().accepted)
-    #     finally:
-    #         ac.destroy()
+    def test_send_goal_multiple(self):
+        ac = ActionClient(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            callback_group=ReentrantCallbackGroup())
+        executor = MultiThreadedExecutor(context=self.context)
+        try:
+            self.assertTrue(ac.wait_for_server(timeout_sec=2.0))
+            future_0 = ac.send_goal_async(Fibonacci.Goal())
+            future_1 = ac.send_goal_async(Fibonacci.Goal())
+            future_2 = ac.send_goal_async(Fibonacci.Goal())
+            rclpy.spin_until_future_complete(self.node, future_0, executor)
+            rclpy.spin_until_future_complete(self.node, future_1, executor)
+            rclpy.spin_until_future_complete(self.node, future_2, executor)
+            self.assertTrue(future_0.done())
+            self.assertTrue(future_1.done())
+            self.assertTrue(future_2.done())
+            self.assertTrue(future_0.result().accepted)
+            self.assertTrue(future_1.result().accepted)
+            self.assertTrue(future_2.result().accepted)
+        finally:
+            ac.destroy()
 
     def test_send_goal_async_no_server(self):
         ac = ActionClient(self.node, Fibonacci, 'not_fibonacci')


### PR DESCRIPTION
Closes #268. 
I believe the issue was resolved by #272. This PR enables the previously failing test.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6312)](http://ci.ros2.org/job/ci_linux/6312/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2726)](http://ci.ros2.org/job/ci_linux-aarch64/2726/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5190)](https://ci.ros2.org/job/ci_osx/5190/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6158)](https://ci.ros2.org/job/ci_windows/6158/)

Errors are unrelated to this change (ros2/build_cop#166).