### PR TITLE
update logger.warn (deprecated) to logger.warning

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -276,7 +276,7 @@ class ActionServer(Waitable):
             # Call user goal callback
             response = await await_or_execute(self._goal_callback, goal_request)
             if not isinstance(response, GoalResponse):
-                self._node.get_logger().warn(
+                self._node.get_logger().warning(
                     'Goal request callback did not return a GoalResponse type. Rejecting goal.')
             else:
                 accepted = GoalResponse.ACCEPT == response
@@ -324,7 +324,7 @@ class ActionServer(Waitable):
 
         # If user did not trigger a terminal state, assume aborted
         if goal_handle.is_active:
-            self._node.get_logger().warn(
+            self._node.get_logger().warning(
                 'Goal state not set, assuming aborted. Goal ID: {0}'.format(goal_uuid))
             goal_handle.set_aborted()
 

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -74,7 +74,7 @@ class TestLogging(unittest.TestCase):
 
         # Logging at or above threshold expected to be logged
         self.assertTrue(rclpy.logging._root_logger.info('message_info'))
-        self.assertTrue(rclpy.logging._root_logger.warn('message_warn'))
+        self.assertTrue(rclpy.logging._root_logger.warning('message_warn'))
         self.assertTrue(rclpy.logging._root_logger.error('message_error'))
         self.assertTrue(rclpy.logging._root_logger.fatal('message_fatal'))
 
@@ -225,7 +225,7 @@ class TestLogging(unittest.TestCase):
         self.assertFalse(my_logger.debug('message_debug'))
 
         # Logging at or above threshold expected to be logged
-        self.assertTrue(my_logger.warn('message_warn'))
+        self.assertTrue(my_logger.warning('message_warn'))
         self.assertTrue(my_logger.error('message_err'))
         self.assertTrue(my_logger.fatal('message_fatal'))
 


### PR DESCRIPTION
Use [non-deprecated method](https://docs.python.org/3.7/library/logging.html#logging.Logger.warning).

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6367)](https://ci.ros2.org/job/ci_linux/6367/)