### PR TITLE
Add param callback to time_source

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -130,7 +130,6 @@ class Node:
         self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(self.handle))
 
         # Clock that has support for ROS time.
-        # TODO(dhood): use sim time if parameter has been set on the node.
         self._clock = ROSClock()
         self._time_source = TimeSource(node=self)
         self._time_source.attach_clock(self._clock)

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import builtin_interfaces.msg
+from rcl_interfaces.msg import SetParametersResult
 from rclpy.clock import ClockType
 from rclpy.clock import ROSClock
+from rclpy.parameter import Parameter
 from rclpy.time import Time
 
 CLOCK_TOPIC = '/clock'
@@ -32,6 +34,21 @@ class TimeSource:
         if node is not None:
             self.attach_node(node)
 
+        use_sim_time_param = node.get_parameter('use_sim_time')
+        if use_sim_time_param.type_ != Parameter.Type.NOT_SET:
+            if use_sim_time_param.type_ == Parameter.Type.BOOL:
+                self._ros_time_is_active = use_sim_time_param.value
+            else:
+                node.get_logger().error(
+                    'Invalid type for parameter \'use_sim_time\' ' +
+                    str(use_sim_time_param.type_) + ' should be bool')
+        else:
+            node.get_logger().debug(
+                '\'use_sim_time\' parameter not set, \
+                    using wall time by default')
+
+        node.set_parameters_callback(self.on_parameter_event)
+
     @property
     def ros_time_is_active(self):
         return self._ros_time_is_active
@@ -45,6 +62,9 @@ class TimeSource:
             clock._set_ros_time_is_active(enabled)
         if enabled:
             self._subscribe_to_clock_topic()
+        else:
+            if self._clock_sub is not None and self._node is not None:
+                self._node.destroy_subscription(self._clock_sub)
 
     def _subscribe_to_clock_topic(self):
         if self._clock_sub is None and self._node is not None:
@@ -88,3 +108,14 @@ class TimeSource:
         self._last_time_set = time_from_msg
         for clock in self._associated_clocks:
             clock.set_ros_time_override(time_from_msg)
+
+    def on_parameter_event(self, parameter_list):
+        for parameter in parameter_list:
+            if parameter.name == 'use_sim_time':
+                if parameter.type_ == Parameter.Type.BOOL:
+                    self.ros_time_is_active = parameter.value
+                else:
+                    self._node.get_logger().error(
+                        'use_sim_time parameter set to something besides a bool')
+
+        return SetParametersResult(successful=True)

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -72,14 +72,16 @@ class TestTimeSource(unittest.TestCase):
         self.node.set_parameters(
             [Parameter('use_sim_time', Parameter.Type.BOOL, value)])
         executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
-
-        while rclpy.ok(context=self.context):
+        cycle_count = 0
+        while rclpy.ok(context=self.context) and cycle_count < 5:
             use_sim_time_param = self.node.get_parameter('use_sim_time')
-
-            if use_sim_time_param._type_ == Parameter.Type.BOOL:
+            cycle_count += 1
+            if use_sim_time_param.type_ == Parameter.Type.BOOL:
                 break
 
             rclpy.spin_once(self.node, timeout_sec=1, executor=executor)
+            time.sleep(1)
+        return use_sim_time_param.value == value
 
     def test_time_source_attach_clock(self):
         time_source = TimeSource(node=self.node)
@@ -129,7 +131,7 @@ class TestTimeSource(unittest.TestCase):
         # time to be set to active.
         self.assertFalse(time_source.ros_time_is_active)
         self.assertFalse(clock.ros_time_is_active)
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
         self.assertTrue(time_source.ros_time_is_active)
         self.assertTrue(clock.ros_time_is_active)
 
@@ -156,13 +158,13 @@ class TestTimeSource(unittest.TestCase):
         time_source.attach_node(node2)
         node2.destroy_node()
         assert time_source._node == node2
-        assert time_source._clock_sub is not None
+        assert time_source._clock_sub is None
 
     def test_forwards_jump(self):
         time_source = TimeSource(node=self.node)
         clock = ROSClock()
         time_source.attach_clock(clock)
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
 
         pre_cb = Mock()
         post_cb = Mock()
@@ -182,7 +184,7 @@ class TestTimeSource(unittest.TestCase):
         time_source = TimeSource(node=self.node)
         clock = ROSClock()
         time_source.attach_clock(clock)
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
 
         pre_cb = Mock()
         post_cb = Mock()
@@ -202,7 +204,7 @@ class TestTimeSource(unittest.TestCase):
         time_source = TimeSource(node=self.node)
         clock = ROSClock()
         time_source.attach_clock(clock)
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
 
         pre_cb = Mock()
         post_cb = Mock()
@@ -210,7 +212,7 @@ class TestTimeSource(unittest.TestCase):
         handler = clock.create_jump_callback(
             threshold, pre_callback=pre_cb, post_callback=post_cb)
 
-        self.set_use_sim_time_parameter(False)
+        assert self.set_use_sim_time_parameter(False)
         pre_cb.assert_called()
         post_cb.assert_called()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_DEACTIVATED
@@ -218,7 +220,7 @@ class TestTimeSource(unittest.TestCase):
         pre_cb.reset_mock()
         post_cb.reset_mock()
 
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
         pre_cb.assert_called()
         post_cb.assert_called()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_ACTIVATED
@@ -228,14 +230,14 @@ class TestTimeSource(unittest.TestCase):
         time_source = TimeSource(node=self.node)
         clock = ROSClock()
         time_source.attach_clock(clock)
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
 
         post_cb = Mock()
         threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
         handler = clock.create_jump_callback(
             threshold, pre_callback=None, post_callback=post_cb)
 
-        self.set_use_sim_time_parameter(False)
+        assert self.set_use_sim_time_parameter(False)
         post_cb.assert_called_once()
         assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_DEACTIVATED
         handler.unregister()
@@ -244,13 +246,17 @@ class TestTimeSource(unittest.TestCase):
         time_source = TimeSource(node=self.node)
         clock = ROSClock()
         time_source.attach_clock(clock)
-        self.set_use_sim_time_parameter(True)
+        assert self.set_use_sim_time_parameter(True)
 
         pre_cb = Mock()
         threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
         handler = clock.create_jump_callback(
             threshold, pre_callback=pre_cb, post_callback=None)
 
-        self.set_use_sim_time_parameter(False)
+        assert self.set_use_sim_time_parameter(False)
         pre_cb.assert_called_once()
         handler.unregister()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Targets to #240

Since it seems there have been no response on #240 for a long time, I made this PR. However, It seems that the callback function should be changed from [parameter callback](https://github.com/ros2/rclpy/pull/228) to something like rclcpp::SyncParametersClient or rclcpp::AsyncParametersClient.

Signed-off-by: vinnamkim <vinnam.kim@gmail.com>