### PR TITLE
Rename action state transitions

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -45,10 +45,10 @@ class GoalEvent(Enum):
     """Goal events that cause state transitions."""
 
     EXECUTE = 1
-    REQUEST_CANCEL = 2
+    CANCEL_GOAL = 2
     SUCCEED = 3
     ABORT = 4
-    CANCEL = 5
+    CANCELED = 5
 
 
 class ServerGoalHandle:
@@ -155,8 +155,8 @@ class ServerGoalHandle:
     def abort(self):
         self._update_state(GoalEvent.ABORT)
 
-    def cancel(self):
-        self._update_state(GoalEvent.CANCEL)
+    def canceled(self):
+        self._update_state(GoalEvent.CANCELED)
 
     def destroy(self):
         with self._lock:
@@ -363,7 +363,7 @@ class ActionServer(Waitable):
 
             if CancelResponse.ACCEPT == response:
                 # Notify goal handle
-                goal_handle._update_state(GoalEvent.REQUEST_CANCEL)
+                goal_handle._update_state(GoalEvent.CANCEL_GOAL)
             else:
                 # Remove from response
                 cancel_response.goals_canceling.remove(goal_info)

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -45,10 +45,10 @@ class GoalEvent(Enum):
     """Goal events that cause state transitions."""
 
     EXECUTE = 1
-    CANCEL = 2
-    SET_SUCCEEDED = 3
-    SET_ABORTED = 4
-    SET_CANCELED = 5
+    REQUEST_CANCEL = 2
+    SUCCEED = 3
+    ABORT = 4
+    CANCEL = 5
 
 
 class ServerGoalHandle:
@@ -149,14 +149,14 @@ class ServerGoalHandle:
             _rclpy_action.rclpy_action_publish_feedback(
                 self._action_server._handle, feedback_message)
 
-    def set_succeeded(self):
-        self._update_state(GoalEvent.SET_SUCCEEDED)
+    def succeed(self):
+        self._update_state(GoalEvent.SUCCEED)
 
-    def set_aborted(self):
-        self._update_state(GoalEvent.SET_ABORTED)
+    def abort(self):
+        self._update_state(GoalEvent.ABORT)
 
-    def set_canceled(self):
-        self._update_state(GoalEvent.SET_CANCELED)
+    def cancel(self):
+        self._update_state(GoalEvent.CANCEL)
 
     def destroy(self):
         with self._lock:
@@ -330,7 +330,7 @@ class ActionServer(Waitable):
         if goal_handle.is_active:
             self._node.get_logger().warning(
                 'Goal state not set, assuming aborted. Goal ID: {0}'.format(goal_uuid))
-            goal_handle.set_aborted()
+            goal_handle.abort()
 
         self._node.get_logger().debug(
             'Goal with ID {0} finished with state {1}'.format(goal_uuid, goal_handle.status))
@@ -363,7 +363,7 @@ class ActionServer(Waitable):
 
             if CancelResponse.ACCEPT == response:
                 # Notify goal handle
-                goal_handle._update_state(GoalEvent.CANCEL)
+                goal_handle._update_state(GoalEvent.REQUEST_CANCEL)
             else:
                 # Remove from response
                 cancel_response.goals_canceling.remove(goal_info)

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1349,12 +1349,12 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyexecute;
 
-  PyObject * pyrequest_cancel = PyObject_GetAttrString(pygoal_event_class, "REQUEST_CANCEL");
-  if (!pyrequest_cancel) {
+  PyObject * pycancel_goal = PyObject_GetAttrString(pygoal_event_class, "CANCEL_GOAL");
+  if (!pycancel_goal) {
     MULTI_DECREF(to_decref, num_to_decref)
     return -1;
   }
-  to_decref[num_to_decref++] = pyrequest_cancel;
+  to_decref[num_to_decref++] = pycancel_goal;
 
   PyObject * pysucceed = PyObject_GetAttrString(pygoal_event_class, "SUCCEED");
   if (!pysucceed) {
@@ -1370,12 +1370,12 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyabort;
 
-  PyObject * pycancel = PyObject_GetAttrString(pygoal_event_class, "CANCEL");
-  if (!pycancel) {
+  PyObject * pycanceled = PyObject_GetAttrString(pygoal_event_class, "CANCELED");
+  if (!pycanceled) {
     MULTI_DECREF(to_decref, num_to_decref)
     return -1;
   }
-  to_decref[num_to_decref++] = pycancel;
+  to_decref[num_to_decref++] = pycanceled;
 
   PyObject * pyexecute_val = PyObject_GetAttrString(pyexecute, "value");
   if (!pyexecute_val) {
@@ -1384,12 +1384,12 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyexecute_val;
 
-  PyObject * pyrequest_cancel_val = PyObject_GetAttrString(pyrequest_cancel, "value");
-  if (!pyrequest_cancel_val) {
+  PyObject * pycancel_goal_val = PyObject_GetAttrString(pycancel_goal, "value");
+  if (!pycancel_goal_val) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pyrequest_cancel_val;
+  to_decref[num_to_decref++] = pycancel_goal_val;
 
   PyObject * pysucceed_val = PyObject_GetAttrString(pysucceed, "value");
   if (!pysucceed_val) {
@@ -1405,25 +1405,25 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyabort_val;
 
-  PyObject * pycancel_val = PyObject_GetAttrString(pycancel, "value");
-  if (!pycancel_val) {
+  PyObject * pycanceled_val = PyObject_GetAttrString(pycanceled, "value");
+  if (!pycanceled_val) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pycancel_val;
+  to_decref[num_to_decref++] = pycanceled_val;
 
   const int64_t execute = PyLong_AsLong(pyexecute_val);
-  const int64_t request_cancel = PyLong_AsLong(pyrequest_cancel_val);
+  const int64_t cancel_goal = PyLong_AsLong(pycancel_goal_val);
   const int64_t succeed = PyLong_AsLong(pysucceed_val);
   const int64_t abort = PyLong_AsLong(pyabort_val);
-  const int64_t cancel = PyLong_AsLong(pycancel_val);
+  const int64_t canceled = PyLong_AsLong(pycanceled_val);
   MULTI_DECREF(to_decref, num_to_decref)
 
   if (execute == pyevent) {
     return GOAL_EVENT_EXECUTE;
   }
-  if (request_cancel == pyevent) {
-    return GOAL_EVENT_REQUEST_CANCEL;
+  if (cancel_goal == pyevent) {
+    return GOAL_EVENT_CANCEL_GOAL;
   }
   if (succeed == pyevent) {
     return GOAL_EVENT_SUCCEED;
@@ -1431,8 +1431,8 @@ convert_from_py_goal_event(const int64_t pyevent)
   if (abort == pyevent) {
     return GOAL_EVENT_ABORT;
   }
-  if (cancel == pyevent) {
-    return GOAL_EVENT_CANCEL;
+  if (canceled == pyevent) {
+    return GOAL_EVENT_CANCELED;
   }
 
   PyErr_Format(

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1349,33 +1349,33 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyexecute;
 
+  PyObject * pyrequest_cancel = PyObject_GetAttrString(pygoal_event_class, "REQUEST_CANCEL");
+  if (!pyrequest_cancel) {
+    MULTI_DECREF(to_decref, num_to_decref)
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyrequest_cancel;
+
+  PyObject * pysucceed = PyObject_GetAttrString(pygoal_event_class, "SUCCEED");
+  if (!pysucceed) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pysucceed;
+
+  PyObject * pyabort = PyObject_GetAttrString(pygoal_event_class, "ABORT");
+  if (!pyabort) {
+    MULTI_DECREF(to_decref, num_to_decref)
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyabort;
+
   PyObject * pycancel = PyObject_GetAttrString(pygoal_event_class, "CANCEL");
   if (!pycancel) {
     MULTI_DECREF(to_decref, num_to_decref)
     return -1;
   }
   to_decref[num_to_decref++] = pycancel;
-
-  PyObject * pyset_succeeded = PyObject_GetAttrString(pygoal_event_class, "SET_SUCCEEDED");
-  if (!pyset_succeeded) {
-    MULTI_DECREF(to_decref, num_to_decref);
-    return -1;
-  }
-  to_decref[num_to_decref++] = pyset_succeeded;
-
-  PyObject * pyset_aborted = PyObject_GetAttrString(pygoal_event_class, "SET_ABORTED");
-  if (!pyset_aborted) {
-    MULTI_DECREF(to_decref, num_to_decref)
-    return -1;
-  }
-  to_decref[num_to_decref++] = pyset_aborted;
-
-  PyObject * pyset_canceled = PyObject_GetAttrString(pygoal_event_class, "SET_CANCELED");
-  if (!pyset_canceled) {
-    MULTI_DECREF(to_decref, num_to_decref)
-    return -1;
-  }
-  to_decref[num_to_decref++] = pyset_canceled;
 
   PyObject * pyexecute_val = PyObject_GetAttrString(pyexecute, "value");
   if (!pyexecute_val) {
@@ -1384,6 +1384,27 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyexecute_val;
 
+  PyObject * pyrequest_cancel_val = PyObject_GetAttrString(pyrequest_cancel, "value");
+  if (!pyrequest_cancel_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyrequest_cancel_val;
+
+  PyObject * pysucceed_val = PyObject_GetAttrString(pysucceed, "value");
+  if (!pysucceed_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pysucceed_val;
+
+  PyObject * pyabort_val = PyObject_GetAttrString(pyabort, "value");
+  if (!pyabort_val) {
+    MULTI_DECREF(to_decref, num_to_decref);
+    return -1;
+  }
+  to_decref[num_to_decref++] = pyabort_val;
+
   PyObject * pycancel_val = PyObject_GetAttrString(pycancel, "value");
   if (!pycancel_val) {
     MULTI_DECREF(to_decref, num_to_decref);
@@ -1391,48 +1412,27 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pycancel_val;
 
-  PyObject * pyset_succeeded_val = PyObject_GetAttrString(pyset_succeeded, "value");
-  if (!pyset_succeeded_val) {
-    MULTI_DECREF(to_decref, num_to_decref);
-    return -1;
-  }
-  to_decref[num_to_decref++] = pyset_succeeded_val;
-
-  PyObject * pyset_aborted_val = PyObject_GetAttrString(pyset_aborted, "value");
-  if (!pyset_aborted_val) {
-    MULTI_DECREF(to_decref, num_to_decref);
-    return -1;
-  }
-  to_decref[num_to_decref++] = pyset_aborted_val;
-
-  PyObject * pyset_canceled_val = PyObject_GetAttrString(pyset_canceled, "value");
-  if (!pyset_canceled_val) {
-    MULTI_DECREF(to_decref, num_to_decref);
-    return -1;
-  }
-  to_decref[num_to_decref++] = pyset_canceled_val;
-
   const int64_t execute = PyLong_AsLong(pyexecute_val);
+  const int64_t request_cancel = PyLong_AsLong(pyrequest_cancel_val);
+  const int64_t succeed = PyLong_AsLong(pysucceed_val);
+  const int64_t abort = PyLong_AsLong(pyabort_val);
   const int64_t cancel = PyLong_AsLong(pycancel_val);
-  const int64_t set_succeeded = PyLong_AsLong(pyset_succeeded_val);
-  const int64_t set_aborted = PyLong_AsLong(pyset_aborted_val);
-  const int64_t set_canceled = PyLong_AsLong(pyset_canceled_val);
   MULTI_DECREF(to_decref, num_to_decref)
 
   if (execute == pyevent) {
     return GOAL_EVENT_EXECUTE;
   }
+  if (request_cancel == pyevent) {
+    return GOAL_EVENT_REQUEST_CANCEL;
+  }
+  if (succeed == pyevent) {
+    return GOAL_EVENT_SUCCEED;
+  }
+  if (abort == pyevent) {
+    return GOAL_EVENT_ABORT;
+  }
   if (cancel == pyevent) {
     return GOAL_EVENT_CANCEL;
-  }
-  if (set_succeeded == pyevent) {
-    return GOAL_EVENT_SET_SUCCEEDED;
-  }
-  if (set_aborted == pyevent) {
-    return GOAL_EVENT_SET_ABORTED;
-  }
-  if (set_canceled == pyevent) {
-    return GOAL_EVENT_SET_CANCELED;
   }
 
   PyErr_Format(

--- a/rclpy/test/action/test_server.py
+++ b/rclpy/test/action/test_server.py
@@ -86,7 +86,7 @@ class TestActionServer(unittest.TestCase):
             rclpy.spin_once(self.node, executor=self.executor, timeout_sec=0.1)
 
     def execute_goal_callback(self, goal_handle):
-        goal_handle.set_succeeded()
+        goal_handle.succeed()
         return Fibonacci.Result()
 
     def test_constructor_defaults(self):
@@ -280,7 +280,7 @@ class TestActionServer(unittest.TestCase):
             # Wait, to give the opportunity to cancel
             time.sleep(3.0)
             self.assertTrue(goal_handle.is_cancel_requested)
-            goal_handle.set_canceled()
+            goal_handle.cancel()
             return Fibonacci.Result()
 
         def cancel_callback(request):
@@ -326,7 +326,7 @@ class TestActionServer(unittest.TestCase):
             # Wait, to give the opportunity to cancel
             time.sleep(3.0)
             self.assertFalse(goal_handle.is_cancel_requested)
-            goal_handle.set_canceled()
+            goal_handle.cancel()
             return Fibonacci.Result()
 
         def cancel_callback(request):
@@ -378,7 +378,7 @@ class TestActionServer(unittest.TestCase):
         def execute_callback(gh):
             # The goal should already be in state CANCELING
             self.assertTrue(gh.is_cancel_requested)
-            gh.set_canceled()
+            gh.cancel()
             return Fibonacci.Result()
 
         action_server = ActionServer(
@@ -424,13 +424,13 @@ class TestActionServer(unittest.TestCase):
         self.assertEqual(server_goal_handle.status, GoalStatus.STATUS_CANCELED)
         action_server.destroy()
 
-    def test_execute_set_succeeded(self):
+    def test_execute_succeed(self):
 
         def execute_callback(goal_handle):
             self.assertEqual(goal_handle.status, GoalStatus.STATUS_EXECUTING)
             result = Fibonacci.Result()
             result.sequence.extend([1, 1, 2, 3, 5])
-            goal_handle.set_succeeded()
+            goal_handle.succeed()
             return result
 
         action_server = ActionServer(
@@ -455,13 +455,13 @@ class TestActionServer(unittest.TestCase):
         self.assertEqual(result_response.result.sequence.tolist(), [1, 1, 2, 3, 5])
         action_server.destroy()
 
-    def test_execute_set_aborted(self):
+    def test_execute_abort(self):
 
         def execute_callback(goal_handle):
             self.assertEqual(goal_handle.status, GoalStatus.STATUS_EXECUTING)
             result = Fibonacci.Result()
             result.sequence.extend([1, 1, 2, 3, 5])
-            goal_handle.set_aborted()
+            goal_handle.abort()
             return result
 
         action_server = ActionServer(
@@ -596,7 +596,7 @@ class TestActionServer(unittest.TestCase):
             feedback = Fibonacci.Feedback()
             feedback.sequence = [1, 1, 2, 3]
             goal_handle.publish_feedback(feedback)
-            goal_handle.set_succeeded()
+            goal_handle.succeed()
             return Fibonacci.Result()
 
         action_server = ActionServer(

--- a/rclpy/test/action/test_server.py
+++ b/rclpy/test/action/test_server.py
@@ -280,7 +280,7 @@ class TestActionServer(unittest.TestCase):
             # Wait, to give the opportunity to cancel
             time.sleep(3.0)
             self.assertTrue(goal_handle.is_cancel_requested)
-            goal_handle.cancel()
+            goal_handle.canceled()
             return Fibonacci.Result()
 
         def cancel_callback(request):
@@ -326,7 +326,7 @@ class TestActionServer(unittest.TestCase):
             # Wait, to give the opportunity to cancel
             time.sleep(3.0)
             self.assertFalse(goal_handle.is_cancel_requested)
-            goal_handle.cancel()
+            goal_handle.canceled()
             return Fibonacci.Result()
 
         def cancel_callback(request):
@@ -378,7 +378,7 @@ class TestActionServer(unittest.TestCase):
         def execute_callback(gh):
             # The goal should already be in state CANCELING
             self.assertTrue(gh.is_cancel_requested)
-            gh.cancel()
+            gh.canceled()
             return Fibonacci.Result()
 
         action_server = ActionServer(


### PR DESCRIPTION
Now using active verbs as described in the design doc:

http://design.ros2.org/articles/actions.html#goal-states

Connects to ros2/rcl#399.