### PR TITLE
Every executor gets its own SIGINT guard condition

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -137,6 +137,17 @@ ament_target_dependencies(rclpy_logging
   "rcutils"
 )
 
+# Signal handling library
+add_library(
+  rclpy_signal_handler
+  SHARED src/rclpy/_rclpy_signal_handler.c
+)
+configure_python_c_extension_library(rclpy_signal_handler)
+ament_target_dependencies(rclpy_signal_handler
+  "rcl"
+  "rcutils"
+)
+
 if(NOT WIN32)
   ament_environment_hooks(
     "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}"

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -45,10 +45,10 @@ class GoalEvent(Enum):
     """Goal events that cause state transitions."""
 
     EXECUTE = 1
-    CANCEL = 2
-    SET_SUCCEEDED = 3
-    SET_ABORTED = 4
-    SET_CANCELED = 5
+    CANCEL_GOAL = 2
+    SUCCEED = 3
+    ABORT = 4
+    CANCELED = 5
 
 
 class ServerGoalHandle:
@@ -149,14 +149,14 @@ class ServerGoalHandle:
             _rclpy_action.rclpy_action_publish_feedback(
                 self._action_server._handle, feedback_message)
 
-    def set_succeeded(self):
-        self._update_state(GoalEvent.SET_SUCCEEDED)
+    def succeed(self):
+        self._update_state(GoalEvent.SUCCEED)
 
-    def set_aborted(self):
-        self._update_state(GoalEvent.SET_ABORTED)
+    def abort(self):
+        self._update_state(GoalEvent.ABORT)
 
-    def set_canceled(self):
-        self._update_state(GoalEvent.SET_CANCELED)
+    def canceled(self):
+        self._update_state(GoalEvent.CANCELED)
 
     def destroy(self):
         with self._lock:
@@ -330,7 +330,7 @@ class ActionServer(Waitable):
         if goal_handle.is_active:
             self._node.get_logger().warning(
                 'Goal state not set, assuming aborted. Goal ID: {0}'.format(goal_uuid))
-            goal_handle.set_aborted()
+            goal_handle.abort()
 
         self._node.get_logger().debug(
             'Goal with ID {0} finished with state {1}'.format(goal_uuid, goal_handle.status))
@@ -363,7 +363,7 @@ class ActionServer(Waitable):
 
             if CancelResponse.ACCEPT == response:
                 # Notify goal handle
-                goal_handle._update_state(GoalEvent.CANCEL)
+                goal_handle._update_state(GoalEvent.CANCEL_GOAL)
             else:
                 # Remove from response
                 cancel_response.goals_canceling.remove(goal_info)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -209,11 +209,12 @@ class Executor:
             if self._guard_condition:
                 _rclpy.rclpy_destroy_entity(self._guard_condition)
                 self._guard_condition = None
+            if self._sigint_gc:
+                self._sigint_gc.destroy()
+                self._sigint_gc = None
         self._cb_iter = None
         self._last_args = None
         self._last_kwargs = None
-        self._sigint_gc.destroy()
-        self._sigint_gc = None
         return True
 
     def __del__(self):

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -31,3 +31,4 @@ from rclpy.impl import _import
 rclpy_implementation = _import('._rclpy')
 rclpy_action_implementation = _import('._rclpy_action')
 rclpy_logging_implementation = _import('._rclpy_logging')
+rclpy_signal_handler_implementation = _import('._rclpy_signal_handler')

--- a/rclpy/rclpy/signals.py
+++ b/rclpy/rclpy/signals.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import rclpy_signal_handler_implementation as _signals
+from rclpy.utilities import get_default_context
+
+
+class SignalHandlerGuardCondition:
+
+    def __init__(self, context=None):
+        if context is None:
+            context = get_default_context()
+        self.guard_handle, self.guard_pointer = _rclpy.rclpy_create_guard_condition(context.handle)
+        _signals.rclpy_register_sigint_guard_condition(self.guard_handle)
+
+    def __del__(self):
+        self.destroy()
+
+    def destroy(self):
+        if self.guard_handle is None:
+            return
+        _signals.rclpy_unregister_sigint_guard_condition(self.guard_handle)
+        _rclpy.rclpy_destroy_entity(self.guard_handle)
+        self.guard_handle = None
+        self.guard_pointer = None

--- a/rclpy/rclpy/signals.py
+++ b/rclpy/rclpy/signals.py
@@ -22,7 +22,7 @@ class SignalHandlerGuardCondition:
     def __init__(self, context=None):
         if context is None:
             context = get_default_context()
-        self.guard_handle, self.guard_pointer = _rclpy.rclpy_create_guard_condition(context.handle)
+        self.guard_handle, _ = _rclpy.rclpy_create_guard_condition(context.handle)
         _signals.rclpy_register_sigint_guard_condition(self.guard_handle)
 
     def __del__(self):
@@ -34,4 +34,3 @@ class SignalHandlerGuardCondition:
         _signals.rclpy_unregister_sigint_guard_condition(self.guard_handle)
         _rclpy.rclpy_destroy_entity(self.guard_handle)
         self.guard_handle = None
-        self.guard_pointer = None

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2721,8 +2721,12 @@ rclpy_destroy_wait_set(PyObject * Py_UNUSED(self), PyObject * args)
     if (struct_ptr[idx]) { \
       PyObject * obj = PyLong_FromUnsignedLongLong((uint64_t) & struct_ptr[idx]->impl); \
       if (obj) { \
-        PyList_Append(entity_ready_list, obj); \
+        int rc = PyList_Append(entity_ready_list, obj); \
         Py_DECREF(obj); \
+        if (rc != 0) { \
+          Py_DECREF(entity_ready_list); \
+          return NULL; \
+        } \
       } else { \
         Py_DECREF(entity_ready_list); \
         return NULL; \

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1349,33 +1349,33 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyexecute;
 
-  PyObject * pycancel = PyObject_GetAttrString(pygoal_event_class, "CANCEL");
-  if (!pycancel) {
+  PyObject * pycancel_goal = PyObject_GetAttrString(pygoal_event_class, "CANCEL_GOAL");
+  if (!pycancel_goal) {
     MULTI_DECREF(to_decref, num_to_decref)
     return -1;
   }
-  to_decref[num_to_decref++] = pycancel;
+  to_decref[num_to_decref++] = pycancel_goal;
 
-  PyObject * pyset_succeeded = PyObject_GetAttrString(pygoal_event_class, "SET_SUCCEEDED");
-  if (!pyset_succeeded) {
+  PyObject * pysucceed = PyObject_GetAttrString(pygoal_event_class, "SUCCEED");
+  if (!pysucceed) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pyset_succeeded;
+  to_decref[num_to_decref++] = pysucceed;
 
-  PyObject * pyset_aborted = PyObject_GetAttrString(pygoal_event_class, "SET_ABORTED");
-  if (!pyset_aborted) {
+  PyObject * pyabort = PyObject_GetAttrString(pygoal_event_class, "ABORT");
+  if (!pyabort) {
     MULTI_DECREF(to_decref, num_to_decref)
     return -1;
   }
-  to_decref[num_to_decref++] = pyset_aborted;
+  to_decref[num_to_decref++] = pyabort;
 
-  PyObject * pyset_canceled = PyObject_GetAttrString(pygoal_event_class, "SET_CANCELED");
-  if (!pyset_canceled) {
+  PyObject * pycanceled = PyObject_GetAttrString(pygoal_event_class, "CANCELED");
+  if (!pycanceled) {
     MULTI_DECREF(to_decref, num_to_decref)
     return -1;
   }
-  to_decref[num_to_decref++] = pyset_canceled;
+  to_decref[num_to_decref++] = pycanceled;
 
   PyObject * pyexecute_val = PyObject_GetAttrString(pyexecute, "value");
   if (!pyexecute_val) {
@@ -1384,55 +1384,55 @@ convert_from_py_goal_event(const int64_t pyevent)
   }
   to_decref[num_to_decref++] = pyexecute_val;
 
-  PyObject * pycancel_val = PyObject_GetAttrString(pycancel, "value");
-  if (!pycancel_val) {
+  PyObject * pycancel_goal_val = PyObject_GetAttrString(pycancel_goal, "value");
+  if (!pycancel_goal_val) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pycancel_val;
+  to_decref[num_to_decref++] = pycancel_goal_val;
 
-  PyObject * pyset_succeeded_val = PyObject_GetAttrString(pyset_succeeded, "value");
-  if (!pyset_succeeded_val) {
+  PyObject * pysucceed_val = PyObject_GetAttrString(pysucceed, "value");
+  if (!pysucceed_val) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pyset_succeeded_val;
+  to_decref[num_to_decref++] = pysucceed_val;
 
-  PyObject * pyset_aborted_val = PyObject_GetAttrString(pyset_aborted, "value");
-  if (!pyset_aborted_val) {
+  PyObject * pyabort_val = PyObject_GetAttrString(pyabort, "value");
+  if (!pyabort_val) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pyset_aborted_val;
+  to_decref[num_to_decref++] = pyabort_val;
 
-  PyObject * pyset_canceled_val = PyObject_GetAttrString(pyset_canceled, "value");
-  if (!pyset_canceled_val) {
+  PyObject * pycanceled_val = PyObject_GetAttrString(pycanceled, "value");
+  if (!pycanceled_val) {
     MULTI_DECREF(to_decref, num_to_decref);
     return -1;
   }
-  to_decref[num_to_decref++] = pyset_canceled_val;
+  to_decref[num_to_decref++] = pycanceled_val;
 
   const int64_t execute = PyLong_AsLong(pyexecute_val);
-  const int64_t cancel = PyLong_AsLong(pycancel_val);
-  const int64_t set_succeeded = PyLong_AsLong(pyset_succeeded_val);
-  const int64_t set_aborted = PyLong_AsLong(pyset_aborted_val);
-  const int64_t set_canceled = PyLong_AsLong(pyset_canceled_val);
+  const int64_t cancel_goal = PyLong_AsLong(pycancel_goal_val);
+  const int64_t succeed = PyLong_AsLong(pysucceed_val);
+  const int64_t abort = PyLong_AsLong(pyabort_val);
+  const int64_t canceled = PyLong_AsLong(pycanceled_val);
   MULTI_DECREF(to_decref, num_to_decref)
 
   if (execute == pyevent) {
     return GOAL_EVENT_EXECUTE;
   }
-  if (cancel == pyevent) {
-    return GOAL_EVENT_CANCEL;
+  if (cancel_goal == pyevent) {
+    return GOAL_EVENT_CANCEL_GOAL;
   }
-  if (set_succeeded == pyevent) {
-    return GOAL_EVENT_SET_SUCCEEDED;
+  if (succeed == pyevent) {
+    return GOAL_EVENT_SUCCEED;
   }
-  if (set_aborted == pyevent) {
-    return GOAL_EVENT_SET_ABORTED;
+  if (abort == pyevent) {
+    return GOAL_EVENT_ABORT;
   }
-  if (set_canceled == pyevent) {
-    return GOAL_EVENT_SET_CANCELED;
+  if (canceled == pyevent) {
+    return GOAL_EVENT_CANCELED;
   }
 
   PyErr_Format(

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -101,11 +101,11 @@ static void catch_function(int signo)
   rcl_guard_condition_t ** guard_conditions;
   rcutils_atomic_load(&g_guard_conditions, guard_conditions);
   if (NULL == guard_conditions || NULL == guard_conditions[0]) {
+    call_original_signal_handler(signo);
     // There may have been another signal handler chaining to this one when we last tried to
     // restore the old signal handler.
     // Try to restore the old handler again.
     restore_original_signal_handler();
-    call_original_signal_handler(signo);
     return;
   }
 

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -1,0 +1,288 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Python.h>
+
+#include <rcl/error_handling.h>
+#include <rcl/rcl.h>
+#include <rcutils/allocator.h>
+
+#include <signal.h>
+
+#ifdef _WIN32
+  #define SIGNAL_HANDLER_T _crt_signal_t
+#else
+  #define SIGNAL_HANDLER_T sig_t
+#endif  // _WIN32
+
+/// Global reference to original signal handler for chaining purposes
+SIGNAL_HANDLER_T g_original_signal_handler = NULL;
+
+/// Global reference to guard conditions
+/// End with sentinel value instead of count to avoid mismatch if signal
+/// interrupts while adding or removing from the list
+rcl_guard_condition_t ** g_guard_conditions = NULL;
+
+// Forward declaration
+static void catch_function(int signo);
+
+/// Restore the original signal handler when ours was registered
+static void
+restore_original_signal_handler()
+{
+  const SIGNAL_HANDLER_T current_handler = signal(SIGINT, g_original_signal_handler);
+  if (current_handler != catch_function) {
+    // Oops, someone else must have registered a signal handler that chains to us
+    // put it back so it continues to work
+    signal(SIGINT, current_handler);
+    return;
+  }
+  // Got ourself out of the chain
+  g_original_signal_handler = NULL;
+}
+
+/// Register our signal handler and store the current
+static void
+register_signal_handler()
+{
+  if (NULL != g_original_signal_handler) {
+    // We must already be registered
+    return;
+  }
+  g_original_signal_handler = signal(SIGINT, catch_function);
+}
+
+/// Call the original signal handler if there was one
+static void
+call_original_signal_handler(int signo)
+{
+  if (NULL != g_original_signal_handler) {
+    g_original_signal_handler(signo);
+  }
+}
+
+/// Catch signals
+/**
+ * This triggers guard conditions when a signal is received.
+ * These wake executors currently blocked in `rcl_wait`.
+ */
+static void catch_function(int signo)
+{
+  if (NULL == g_guard_conditions || NULL == g_guard_conditions[0]) {
+    // There may have been another signal handler chaining to this one when we last tried to
+    // restore the old signal handler.
+    // Try to restore the old handler again.
+    restore_original_signal_handler();
+    call_original_signal_handler(signo);
+    return;
+  }
+
+  // Trigger python signal handlers
+  rcl_guard_condition_t ** pgc = g_guard_conditions;
+  while (NULL != *pgc) {
+    rcl_ret_t ret = rcl_trigger_guard_condition(*pgc);
+    if (ret != RCL_RET_OK) {
+      // TODO(sloretz) find signal safe way to tell the world an error occurred
+      rcl_reset_error();
+    }
+    ++pgc;
+  }
+
+  // Chain signal handlers
+  call_original_signal_handler(signo);
+}
+
+/// Register a guard condition to be triggered when SIGINT is received.
+/**
+ * On failure, an exception is raised and NULL is returned if:
+ *
+ * Raises ValueError if the argument is not a guard condition handle
+ * Raises ValueError if the argument was already registered
+ *
+ * \param[in] pygc a guard condition pycapsule
+ * \return None
+ */
+static PyObject *
+rclpy_register_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  // Expect a pycapsule with a guard condition
+  PyObject * pygc;
+  if (!PyArg_ParseTuple(args, "O", &pygc)) {
+    return NULL;
+  }
+
+  rcl_guard_condition_t * gc = (rcl_guard_condition_t *)PyCapsule_GetPointer(
+    pygc, "rcl_guard_condition_t");
+  if (!gc) {
+    return NULL;
+  }
+
+  // Figure out how big the list currently is
+  size_t count_gcs = 0;
+  if (NULL != g_guard_conditions) {
+    while (NULL != g_guard_conditions[count_gcs]) {
+      if (gc == g_guard_conditions[count_gcs]) {
+        PyErr_Format(PyExc_ValueError, "Guard condition was already registered");
+        return NULL;
+      }
+      ++count_gcs;
+    }
+  }
+
+  // Current size of guard condition list: count_gcs + 1 (sentinel value)
+  // Allocate space for one more guard condition: count_cs + 1 (new gc) + 1 (sentinel value)
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_guard_condition_t ** new_gcs =
+    allocator.allocate(sizeof(rcl_guard_condition_t *) * (count_gcs + 2), allocator.state);
+
+  // populate the new guard condition list, ending with a sentinel of NULL
+  for (size_t i = 0; i < count_gcs; ++i) {
+    new_gcs[i] = g_guard_conditions[i];
+  }
+  new_gcs[count_gcs] = gc;
+  new_gcs[count_gcs + 1] = NULL;
+
+  // Swap the lists and free the old
+  rcl_guard_condition_t ** old_gcs = g_guard_conditions;
+  // Assumes this assignment is atomic
+  g_guard_conditions = new_gcs;
+  if (NULL != old_gcs) {
+    allocator.deallocate(old_gcs, allocator.state);
+  }
+
+  // make sure our signal handler is registered
+  register_signal_handler();
+
+  Py_RETURN_NONE;
+}
+
+/// Unregister a guard condition so it is not triggered when SIGINT is received.
+/**
+ * On failure, an exception is raised and NULL is returned if:
+ *
+ * Raises ValueError if the argument is not a guard condition handle
+ * Raises ValueError if the argument was not registered
+ *
+ * \param[in] pygc a guard condition pycapsule
+ * \return None
+ */
+static PyObject *
+rclpy_unregister_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  // Expect a pycapsule with a guard condition
+  PyObject * pygc;
+  if (!PyArg_ParseTuple(args, "O", &pygc)) {
+    return NULL;
+  }
+
+  rcl_guard_condition_t * gc = (rcl_guard_condition_t *)PyCapsule_GetPointer(
+    pygc, "rcl_guard_condition_t");
+  if (!gc) {
+    return NULL;
+  }
+
+  // Figure out how big the list currently is
+  size_t count_gcs = 0;
+  bool found_gc = false;
+
+  if (NULL != g_guard_conditions) {
+    while (NULL != g_guard_conditions[count_gcs]) {
+      if (gc == g_guard_conditions[count_gcs]) {
+        found_gc = true;
+      }
+      ++count_gcs;
+    }
+  }
+
+  if (count_gcs == 0 || !found_gc) {
+    PyErr_Format(PyExc_ValueError, "Guard condition was not registered");
+    return NULL;
+  }
+
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+
+  if (count_gcs == 1) {
+    // Just delete the list if there are no guard conditions left
+    rcl_guard_condition_t ** old_gcs = g_guard_conditions;
+    g_guard_conditions = NULL;
+    allocator.deallocate(old_gcs, allocator.state);
+    restore_original_signal_handler();
+  } else {
+    // Create space for one less guard condition
+    // current list size: count_gcs + 1 (sentinel)
+    // new list size: count_gcs - 1 (removing a guard condition) + 1 (sentinel)
+    rcl_allocator_t allocator = rcl_get_default_allocator();
+    rcl_guard_condition_t ** new_gcs =
+      allocator.allocate(sizeof(rcl_guard_condition_t *) * (count_gcs), allocator.state);
+
+    // Put remaining guard conditions in the list, ending with a sentinel of NULL
+    size_t offset = 0;
+    for (size_t i = 0; i < count_gcs; ++i) {
+      // assumes guard condition was only added to list once
+      if (g_guard_conditions[i + offset] == gc) {
+        offset = 1;
+      }
+      new_gcs[i] = g_guard_conditions[i + offset];
+    }
+    // one less guard condition
+    --count_gcs;
+    // Put sentinel at end
+    new_gcs[count_gcs] = NULL;
+
+    // Replace guard condition list
+    rcl_guard_condition_t ** old_gcs = g_guard_conditions;
+    // Assumes this assignment is atomic
+    g_guard_conditions = new_gcs;
+    allocator.deallocate(old_gcs, allocator.state);
+  }
+
+  Py_RETURN_NONE;
+}
+
+/// Define the public methods of this module
+static PyMethodDef rclpy_signal_handler_methods[] = {
+  {
+    "rclpy_register_sigint_guard_condition", rclpy_register_sigint_guard_condition,
+    METH_VARARGS,
+    "Register a guard condition to be called on SIGINT."
+  },
+  {
+    "rclpy_unregister_sigint_guard_condition", rclpy_unregister_sigint_guard_condition,
+    METH_VARARGS,
+    "Stop triggering a guard condition when SIGINT occurs."
+  },
+  {NULL, NULL, 0, NULL}  /* sentinel */
+};
+
+PyDoc_STRVAR(rclpy_signal_handler__doc__,
+  "RCLPY module for handling signals.");
+
+/// Define the Python module
+static struct PyModuleDef _rclpy_signal_handler_module = {
+  PyModuleDef_HEAD_INIT,
+  "_rclpy_signal_handler",
+  rclpy_signal_handler__doc__,
+  -1,  /* -1 means that the module keeps state in global variables */
+  rclpy_signal_handler_methods,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
+/// Init function of this module
+PyMODINIT_FUNC PyInit__rclpy_signal_handler(void)
+{
+  return PyModule_Create(&_rclpy_signal_handler_module);
+}

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -260,11 +260,11 @@ rclpy_unregister_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * a
     for (size_t i = 0; i < found_index; ++i) {
       new_gcs[i] = guard_conditions[i];
     }
+    // one less guard condition
+    --count_gcs;
     for (size_t i = found_index; i < count_gcs; ++i) {
       new_gcs[i] = guard_conditions[i + 1];
     }
-    // one less guard condition
-    --count_gcs;
     // Put sentinel at end
     new_gcs[count_gcs] = NULL;
 

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -191,11 +191,14 @@ rclpy_unregister_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * a
   // Figure out how big the list currently is
   size_t count_gcs = 0;
   bool found_gc = false;
+  // assumes guard condition was only added to list once
+  size_t found_index = 0;
 
   if (NULL != g_guard_conditions) {
     while (NULL != g_guard_conditions[count_gcs]) {
       if (gc == g_guard_conditions[count_gcs]) {
         found_gc = true;
+        found_index = count_gcs;
       }
       ++count_gcs;
     }
@@ -223,13 +226,11 @@ rclpy_unregister_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * a
       allocator.allocate(sizeof(rcl_guard_condition_t *) * (count_gcs), allocator.state);
 
     // Put remaining guard conditions in the list, ending with a sentinel of NULL
-    size_t offset = 0;
-    for (size_t i = 0; i < count_gcs; ++i) {
-      // assumes guard condition was only added to list once
-      if (g_guard_conditions[i + offset] == gc) {
-        offset = 1;
-      }
-      new_gcs[i] = g_guard_conditions[i + offset];
+    for (size_t i = 0; i < found_index; ++i) {
+      new_gcs[i] = g_guard_conditions[i];
+    }
+    for (size_t i = found_index; i < count_gcs; ++i) {
+      new_gcs[i] = g_guard_conditions[i + 1];
     }
     // one less guard condition
     --count_gcs;

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -235,7 +235,7 @@ rclpy_unregister_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * a
     }
   }
 
-  if (count_gcs == 0 || !found_gc) {
+  if (!found_gc) {
     PyErr_Format(PyExc_ValueError, "Guard condition was not registered");
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -35,7 +35,7 @@ typedef _Atomic (rcl_guard_condition_t **) atomic_rcl_guard_condition_ptrptr_t;
 /// Global reference to guard conditions
 /// End with sentinel value instead of count to avoid mismatch if signal
 /// interrupts while adding or removing from the list
-atomic_rcl_guard_condition_ptrptr_t g_guard_conditions = NULL;
+atomic_rcl_guard_condition_ptrptr_t g_guard_conditions;
 
 /// Warn if getting g_guard_conditions could deadlock the signal handler
 /// \return 0 if no exception is raised, -1 if an exception was raised
@@ -43,7 +43,7 @@ static int
 check_signal_safety()
 {
   static bool did_warn = false;
-  if (!did_warn && !atomic_is_lock_free(g_guard_conditions)) {
+  if (!did_warn && !atomic_is_lock_free(&g_guard_conditions)) {
     did_warn = true;
     const char * deadlock_msg =
       "Global guard condition list access is not lock-free on this platform."

--- a/rclpy/src/rclpy/_rclpy_signal_handler.c
+++ b/rclpy/src/rclpy/_rclpy_signal_handler.c
@@ -105,8 +105,6 @@ static void catch_function(int signo)
 
 /// Register a guard condition to be triggered when SIGINT is received.
 /**
- * On failure, an exception is raised and NULL is returned if:
- *
  * Raises ValueError if the argument is not a guard condition handle
  * Raises ValueError if the argument was already registered
  *
@@ -169,8 +167,6 @@ rclpy_register_sigint_guard_condition(PyObject * Py_UNUSED(self), PyObject * arg
 
 /// Unregister a guard condition so it is not triggered when SIGINT is received.
 /**
- * On failure, an exception is raised and NULL is returned if:
- *
  * Raises ValueError if the argument is not a guard condition handle
  * Raises ValueError if the argument was not registered
  *

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -241,6 +241,7 @@ rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** des
 
   PyObject * pymetaclass = PyObject_GetAttrString(pymessage, "__class__");
   if (!pymetaclass) {
+    (**destroy_ros_message)(message);
     return NULL;
   }
 
@@ -248,6 +249,7 @@ rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** des
     pymetaclass, "_CONVERT_FROM_PY");
   Py_DECREF(pymetaclass);
   if (!convert) {
+    (**destroy_ros_message)(message);
     return NULL;
   }
 

--- a/rclpy/test/action/test_server.py
+++ b/rclpy/test/action/test_server.py
@@ -86,7 +86,7 @@ class TestActionServer(unittest.TestCase):
             rclpy.spin_once(self.node, executor=self.executor, timeout_sec=0.1)
 
     def execute_goal_callback(self, goal_handle):
-        goal_handle.set_succeeded()
+        goal_handle.succeed()
         return Fibonacci.Result()
 
     def test_constructor_defaults(self):
@@ -280,7 +280,7 @@ class TestActionServer(unittest.TestCase):
             # Wait, to give the opportunity to cancel
             time.sleep(3.0)
             self.assertTrue(goal_handle.is_cancel_requested)
-            goal_handle.set_canceled()
+            goal_handle.canceled()
             return Fibonacci.Result()
 
         def cancel_callback(request):
@@ -326,7 +326,7 @@ class TestActionServer(unittest.TestCase):
             # Wait, to give the opportunity to cancel
             time.sleep(3.0)
             self.assertFalse(goal_handle.is_cancel_requested)
-            goal_handle.set_canceled()
+            goal_handle.canceled()
             return Fibonacci.Result()
 
         def cancel_callback(request):
@@ -378,7 +378,7 @@ class TestActionServer(unittest.TestCase):
         def execute_callback(gh):
             # The goal should already be in state CANCELING
             self.assertTrue(gh.is_cancel_requested)
-            gh.set_canceled()
+            gh.canceled()
             return Fibonacci.Result()
 
         action_server = ActionServer(
@@ -424,13 +424,13 @@ class TestActionServer(unittest.TestCase):
         self.assertEqual(server_goal_handle.status, GoalStatus.STATUS_CANCELED)
         action_server.destroy()
 
-    def test_execute_set_succeeded(self):
+    def test_execute_succeed(self):
 
         def execute_callback(goal_handle):
             self.assertEqual(goal_handle.status, GoalStatus.STATUS_EXECUTING)
             result = Fibonacci.Result()
             result.sequence.extend([1, 1, 2, 3, 5])
-            goal_handle.set_succeeded()
+            goal_handle.succeed()
             return result
 
         action_server = ActionServer(
@@ -455,13 +455,13 @@ class TestActionServer(unittest.TestCase):
         self.assertEqual(result_response.result.sequence.tolist(), [1, 1, 2, 3, 5])
         action_server.destroy()
 
-    def test_execute_set_aborted(self):
+    def test_execute_abort(self):
 
         def execute_callback(goal_handle):
             self.assertEqual(goal_handle.status, GoalStatus.STATUS_EXECUTING)
             result = Fibonacci.Result()
             result.sequence.extend([1, 1, 2, 3, 5])
-            goal_handle.set_aborted()
+            goal_handle.abort()
             return result
 
         action_server = ActionServer(
@@ -596,7 +596,7 @@ class TestActionServer(unittest.TestCase):
             feedback = Fibonacci.Feedback()
             feedback.sequence = [1, 1, 2, 3]
             goal_handle.publish_feedback(feedback)
-            goal_handle.set_succeeded()
+            goal_handle.succeed()
             return Fibonacci.Result()
 
         action_server = ActionServer(


### PR DESCRIPTION
Implements @wjwwood's comment https://github.com/ros2/rclpy/issues/192#issuecomment-398251659

This moves signal handling code to a separate module `_rclpy_signal_handler`. Every executor adds a guard condition to a global list. The signal handler triggers all guard conditions in that list.

Resolves ros2/rclpy#192, and because of that this PR also allows multiple executors to wait in parallel again. This also resolves ros2/rclpy#287 by having each executor reuse the same guard condition.

It does not change the updated behavior of ros2/rclpy#253 described here: https://github.com/ros2/rclpy/issues/253#issuecomment-475613097 . Maybe that should be an issue downstream of rclpy?