### PR TITLE
Refresh nodes when executor is woken

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -389,11 +389,13 @@ class Executor:
         if timeout_nsec > 0:
             timeout_timer = WallTimer(None, None, timeout_nsec)
 
-        if nodes is None:
-            nodes = self.get_nodes()
-
         yielded_work = False
         while not yielded_work and not self._is_shutdown:
+            # Refresh "all" nodes in case executor was woken by a node being added or removed
+            nodes_to_use = nodes
+            if nodes is None:
+                nodes_to_use = self.get_nodes()
+
             # Yield tasks in-progress before waiting for new work
             tasks = None
             with self._tasks_lock:
@@ -401,7 +403,7 @@ class Executor:
             if tasks:
                 for task, entity, node in reversed(tasks):
                     if (not task.executing() and not task.done() and
-                            (node is None or node in nodes)):
+                            (node is None or node in nodes_to_use)):
                         yielded_work = True
                         yield task, entity, node
                 with self._tasks_lock:
@@ -415,7 +417,7 @@ class Executor:
             clients: List[Client] = []
             services: List[Service] = []
             waitables: List[Waitable] = []
-            for node in nodes:
+            for node in nodes_to_use:
                 subscriptions.extend(filter(self.can_execute, node.subscriptions))
                 timers.extend(filter(self.can_execute, node.timers))
                 clients.extend(filter(self.can_execute, node.clients))
@@ -488,7 +490,7 @@ class Executor:
                         gc._executor_triggered = True
 
                 # Check waitables before wait set is destroyed
-                for node in nodes:
+                for node in nodes_to_use:
                     for wt in node.waitables:
                         # Only check waitables that were added to the wait set
                         if wt in waitables and wt.is_ready(wait_set):
@@ -498,7 +500,7 @@ class Executor:
                             yield handler, wt, node
 
             # Process ready entities one node at a time
-            for node in nodes:
+            for node in nodes_to_use:
                 for tmr in node.timers:
                     if tmr.timer_pointer in timers_ready:
                         # Check that a timer is ready to workaround rcl issue with cancelled timers

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -302,6 +302,34 @@ class TestExecutor(unittest.TestCase):
         assert not executor.add_node(self.node)
         assert id(executor) == id(self.node.executor)
 
+    def test_executor_add_node_wakes_executor(self):
+        self.assertIsNotNone(self.node.handle)
+        got_callback = False
+
+        def timer_callback():
+            nonlocal got_callback
+            got_callback = True
+
+        timer_period = 0.1
+        tmr = self.node.create_timer(timer_period, timer_callback)
+
+        executor = SingleThreadedExecutor(context=self.context)
+        try:
+            # spin in background
+            t = threading.Thread(target=executor.spin_once, daemon=True)
+            t.start()
+            # sleep to make sure executor is blocked in rcl_wait
+            time.sleep(0.5)
+
+            self.assertTrue(executor.add_node(self.node))
+            # Make sure timer has time to trigger
+            time.sleep(timer_period)
+
+            self.assertTrue(got_callback)
+        finally:
+            executor.shutdown()
+            self.node.destroy_timer(tmr)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes bug where executor would rebuild wait_set without adding or
removing nodes. This happened when an executor was waiting and had not
executed any work yet at the time the node was added or removed.