### PR TITLE
Set QoS profile to default values (pre-QoS, standalone)

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3656,6 +3656,9 @@ rclpy_convert_from_py_qos_policy(PyObject * Py_UNUSED(self), PyObject * args)
     PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for QoS profile");
     return NULL;
   }
+  // Set to default so that we don't use uninitialized data if new fields are added
+  *qos_profile = rmw_qos_profile_default;
+  // Overwrite defaults with passed values
   qos_profile->history = pyqos_history;
   qos_profile->depth = pyqos_depth;
   qos_profile->reliability = pyqos_reliability;


### PR DESCRIPTION
Set allocated `rmw_qos_profile_t` to the default, to future-proof against uninitialized data if new fields are added. E.g. if a field is added to `rmw_qos_profile_t` and that field is not immediately exposed in `rclpy`, the value of that field will be garbage data, and be passed all the way to the RMW implementation.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>