### PR TITLE
QoS - Expose Lifespan, Deadline, and Liveliness policy settings

### DIFF
--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -76,3 +76,6 @@ class Duration:
         if not isinstance(msg, builtin_interfaces.msg.Duration):
             raise TypeError('Must pass a builtin_interfaces.msg.Duration object')
         return cls(seconds=msg.sec, nanoseconds=msg.nanosec)
+
+    def get_c_duration(self):
+        return self._duration_handle

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -159,7 +159,7 @@ class QoSProfile:
 
     @liveliness.setter
     def liveliness(self, value):
-        assert isinstance(value, QoSLivelinessPolicy) or isinstance(value, int)
+        assert isinstance(value, (QoSLivelinessPolicy, int))
         self._liveliness = QoSLivelinessPolicy(value)
 
     @property

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -205,6 +205,13 @@ class QoSProfile:
             self.avoid_ros_namespace_conventions,
         )
 
+    def __eq__(self, other):
+        if not isinstance(other, QoSProfile):
+            return False
+        return all(
+            self.__getattribute__(slot) == other.__getattribute__(slot)
+            for slot in self.__slots__)
+
 
 class QoSHistoryPolicy(IntEnum):
     """

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -14,6 +14,7 @@
 
 from enum import IntEnum
 
+from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
@@ -26,6 +27,10 @@ class QoSProfile:
         '_depth',
         '_reliability',
         '_durability',
+        '_lifespan',
+        '_deadline',
+        '_liveliness',
+        '_liveliness_lease_duration',
         '_avoid_ros_namespace_conventions',
     ]
 
@@ -42,6 +47,12 @@ class QoSProfile:
         self.durability = kwargs.get(
             'durability',
             QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT)
+        self.lifespan = kwargs.get('lifespan', Duration())
+        self.deadline = kwargs.get('deadline', Duration())
+        self.liveliness = kwargs.get(
+            'liveliness',
+            QoSLivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT)
+        self.liveliness_lease_duration = kwargs.get('liveliness_lease_duration', Duration())
         self.avoid_ros_namespace_conventions = kwargs.get(
             'avoid_ros_namespace_conventions',
             False)
@@ -107,6 +118,66 @@ class QoSProfile:
         self._depth = value
 
     @property
+    def lifespan(self):
+        """
+        Get field 'lifespan'.
+
+        :returns: lifespan attribute
+        :rtype: Duration
+        """
+        return self._lifespan
+
+    @lifespan.setter
+    def lifespan(self, value):
+        assert isinstance(value, Duration)
+        self._lifespan = value
+
+    @property
+    def deadline(self):
+        """
+        Get field 'deadline'.
+
+        :returns: deadline attribute.
+        :rtype: Duration
+        """
+        return self._deadline
+
+    @deadline.setter
+    def deadline(self, value):
+        assert isinstance(value, Duration)
+        self._deadline = value
+
+    @property
+    def liveliness(self):
+        """
+        Get field 'liveliness'.
+
+        :returns: liveliness attribute
+        :rtype: QoSLivelinessPolicy
+        """
+        return self._liveliness
+
+    @liveliness.setter
+    def liveliness(self, value):
+        assert isinstance(value, QoSLivelinessPolicy) or isinstance(value, int)
+        self._liveliness = QoSLivelinessPolicy(value)
+
+    @property
+    def liveliness_lease_duration(self):
+        """
+        Get field 'liveliness_lease_duration'.
+
+        :returns: liveliness_lease_duration attribute.
+        :rtype: Duration
+        """
+        return self._liveliness_lease_duration
+
+    @liveliness_lease_duration.setter
+    def liveliness_lease_duration(self, value):
+        assert isinstance(value, Duration)
+        self._liveliness_lease_duration = value
+
+    @property
     def avoid_ros_namespace_conventions(self):
         """
         Get field 'avoid_ros_namespace_conventions'.
@@ -127,6 +198,10 @@ class QoSProfile:
             self.depth,
             self.reliability,
             self.durability,
+            self.lifespan.get_c_duration(),
+            self.deadline.get_c_duration(),
+            self.liveliness,
+            self.liveliness_lease_duration.get_c_duration(),
             self.avoid_ros_namespace_conventions,
         )
 
@@ -165,6 +240,19 @@ class QoSDurabilityPolicy(IntEnum):
     RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT = 0
     RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL = 1
     RMW_QOS_POLICY_DURABILITY_VOLATILE = 2
+
+
+class QoSLivelinessPolicy(IntEnum):
+    """
+    Enum for QoS Liveliness settings.
+
+    This enum matches the one defined in rmw/types.h
+    """
+
+    RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT = 0
+    RMW_QOS_POLICY_LIVELINESS_AUTOMATIC = 1
+    RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE = 2
+    RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC = 3
 
 
 qos_profile_default = _rclpy.rclpy_get_rmw_qos_profile(

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3556,8 +3556,6 @@ _convert_py_duration_to_rmw_time(PyObject * pyobject, rmw_time_t * out_time)
 {
   rcl_duration_t * duration = (rcl_duration_t *)PyCapsule_GetPointer(pyobject, "rcl_duration_t");
   if (!duration) {
-    PyErr_Format(PyExc_TypeError,
-      "Passed object was not a valid rcl_duration_t.");
     return false;
   }
   *out_time = (rmw_time_t) {
@@ -3655,7 +3653,6 @@ rclpy_convert_to_py_qos_policy(PyObject * Py_UNUSED(self), PyObject * args)
   rmw_qos_profile_t * profile = (rmw_qos_profile_t *)PyCapsule_GetPointer(
     pyqos_profile, "rmw_qos_profile_t");
   if (!profile) {
-    PyErr_Format(PyExc_TypeError, "Capsule was not a valid rmw_qos_profile_t.");
     return NULL;
   }
   return rclpy_common_convert_to_py_qos_policy(profile);

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -119,7 +119,7 @@ rclpy_action_get_rmw_qos_profile(PyObject * Py_UNUSED(self), PyObject * args)
 
   PyObject * pyqos_profile = NULL;
   if (0 == strcmp(rmw_profile, "rcl_action_qos_profile_status_default")) {
-    pyqos_profile = rclpy_convert_to_py_qos_policy((void *)&rcl_action_qos_profile_status_default);
+    pyqos_profile = rclpy_common_convert_to_py_qos_policy(&rcl_action_qos_profile_status_default);
   } else {
     return PyErr_Format(PyExc_RuntimeError,
              "Requested unknown rmw_qos_profile: '%s'", rmw_profile);

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -48,14 +48,14 @@ RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_convert_to_py_names_and_types(rcl_names_and_types_t * topic_names_and_types);
 
-/// Convert a C rmw_qos_profile_t into a Python QoSProfile object
+/// Convert a C rmw_qos_profile_t into a Python QoSProfile object.
 /**
- * \param[in] void pointer to a rmw_qos_profile_t structure
+ * \param[in] profile Pointer to a rmw_qos_profile_t to convert
  * \return QoSProfile object
  */
 RCLPY_COMMON_PUBLIC
 PyObject *
-rclpy_convert_to_py_qos_policy(void * profile);
+rclpy_common_convert_to_py_qos_policy(const rmw_qos_profile_t * profile);
 
 RCLPY_COMMON_PUBLIC
 void *

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -119,7 +119,7 @@ rclpy_convert_to_py_names_and_types(rcl_names_and_types_t * names_and_types)
 
 static
 PyObject *
-_convert_rmw_time_to_py_duration(rmw_time_t * duration)
+_convert_rmw_time_to_py_duration(const rmw_time_t * duration)
 {
   uint64_t total_nanoseconds = RCUTILS_S_TO_NS(duration->sec) + duration->nsec;
   PyObject * pyduration_module = NULL;
@@ -140,7 +140,7 @@ _convert_rmw_time_to_py_duration(rmw_time_t * duration)
   if (!args) {
     goto cleanup;
   }
-  kwargs = Py_BuildValue("{s:i}", "nanoseconds", total_nanoseconds);
+  kwargs = Py_BuildValue("{s:l}", "nanoseconds", total_nanoseconds);
   if (!kwargs) {
     goto cleanup;
   }
@@ -158,7 +158,7 @@ cleanup:
 }
 
 PyObject *
-rclpy_convert_to_py_qos_policy(void * profile)
+rclpy_common_convert_to_py_qos_policy(const rmw_qos_profile_t * qos_profile)
 {
   PyObject * pyqos_module = PyImport_ImportModule("rclpy.qos");
   if (!pyqos_module) {
@@ -178,7 +178,6 @@ rclpy_convert_to_py_qos_policy(void * profile)
   }
 
   // start qos setting
-  rmw_qos_profile_t * qos_profile = (rmw_qos_profile_t *)profile;
   rclpy_qos_profile_t rclpy_qos;
   init_rclpy_qos_profile(&rclpy_qos);
 

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -122,23 +122,38 @@ PyObject *
 _convert_rmw_time_to_py_duration(rmw_time_t * duration)
 {
   uint64_t total_nanoseconds = RCUTILS_S_TO_NS(duration->sec) + duration->nsec;
+  PyObject * pyduration_module = NULL;
+  PyObject * pyduration_class = NULL;
+  PyObject * args = NULL;
+  PyObject * kwargs = NULL;
+  PyObject * pyduration_object = NULL;
 
-  PyObject * pyduration_module = PyImport_ImportModule("rclpy.duration");
+  pyduration_module = PyImport_ImportModule("rclpy.duration");
   if (!pyduration_module) {
-    return NULL;
+    goto cleanup;
   }
-  PyObject * pyduration_class = PyObject_GetAttrString(pyduration_module, "Duration");
-  Py_DECREF(pyduration_module);
+  pyduration_class = PyObject_GetAttrString(pyduration_module, "Duration");
   if (!pyduration_class) {
-    return NULL;
+    goto cleanup;
+  }
+  args = PyTuple_New(0);
+  if (!args) {
+    goto cleanup;
+  }
+  kwargs = Py_BuildValue("{s:i}", "nanoseconds", total_nanoseconds);
+  if (!kwargs) {
+    goto cleanup;
+  }
+  pyduration_object = PyObject_Call(pyduration_class, args, kwargs);
+  if (!pyduration_object) {
+    goto cleanup;
   }
 
-  PyObject * args = PyTuple_New(0);
-  PyObject * kwargs = Py_BuildValue("{s:i}", "nanoseconds", total_nanoseconds);
-  PyObject * pyduration_object = PyObject_Call(pyduration_class, args, kwargs);
-  Py_DECREF(pyduration_class);
-  Py_DECREF(kwargs);
-  Py_DECREF(args);
+cleanup:
+  Py_XDECREF(pyduration_module);
+  Py_XDECREF(pyduration_class);
+  Py_XDECREF(args);
+  Py_XDECREF(kwargs);
   return pyduration_object;
 }
 

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -140,7 +140,7 @@ _convert_rmw_time_to_py_duration(const rmw_time_t * duration)
   if (!args) {
     goto cleanup;
   }
-  kwargs = Py_BuildValue("{s:l}", "nanoseconds", total_nanoseconds);
+  kwargs = Py_BuildValue("{sK}", "nanoseconds", total_nanoseconds);
   if (!kwargs) {
     goto cleanup;
   }

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -1,0 +1,74 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.duration import Duration
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSHistoryPolicy
+from rclpy.qos import QoSLivelinessPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
+
+
+class TestQosProfile(unittest.TestCase):
+
+    def convert_and_assert_equality(self, qos_profile):
+        c_profile = qos_profile.get_c_qos_profile()
+        converted_profile = _rclpy.rclpy_convert_to_py_qos_policy(c_profile)
+        self.assertEqual(qos_profile, converted_profile)
+
+    def test_eq_operator(self):
+        profile_1 = QoSProfile()
+        profile_same = QoSProfile()
+        profile_different_number = QoSProfile(depth=1)
+        profile_different_duration = QoSProfile(deadline=Duration(seconds=2))
+        profile_equal_duration = QoSProfile(deadline=Duration(seconds=2))
+
+        self.assertEqual(profile_1, profile_same)
+        self.assertNotEqual(profile_1, profile_different_number)
+        self.assertNotEqual(profile_1, profile_different_duration)
+        self.assertEqual(profile_different_duration, profile_equal_duration)
+
+    def test_simple_round_trip(self):
+        source_profile = QoSProfile()
+        self.convert_and_assert_equality(source_profile)
+
+    def test_big_nanoseconds(self):
+        # Under 31 bits
+        no_problem = QoSProfile(lifespan=Duration(seconds=2))
+        self.convert_and_assert_equality(no_problem)
+
+        # Total nanoseconds in duration is too large to store in 32 bit signed int
+        int32_problem = QoSProfile(lifespan=Duration(seconds=4))
+        self.convert_and_assert_equality(int32_problem)
+
+        # Total nanoseconds in duration is too large to store in 32 bit unsigned int
+        uint32_problem = QoSProfile(lifespan=Duration(seconds=5))
+        self.convert_and_assert_equality(uint32_problem)
+
+    def test_alldata_round_trip(self):
+        source_profile = QoSProfile(
+            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+            depth=12,
+            reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
+            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE,
+            lifespan=Duration(seconds=4),
+            deadline=Duration(nanoseconds=1e6),
+            liveliness=QoSLivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE,
+            liveliness_lease_duration=Duration(nanoseconds=12),
+            avoid_ros_namespace_conventions=True
+        )
+        self.convert_and_assert_equality(source_profile)


### PR DESCRIPTION
Depends on ros2/rmw#173

Expose the new QoS policy settings for the Python client. Needs `rmw/types.h` from the above mentioned PR

Signed-off-by: Emerson Knapp <eknapp@amazon.com>