### PR TITLE
QoS - Expose the assert_liveliness API for Publishers and Nodes

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -835,3 +835,12 @@ class Node:
         :return: the number of subscribers on the topic.
         """
         return self._count_publishers_or_subscribers(topic_name, _rclpy.rclpy_count_subscribers)
+
+    def assert_liveliness(self) -> None:
+        """
+        Manually assert that this Node is alive.
+
+        If the QoS Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE, the
+        application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
+        """
+        _rclpy.rclpy_assert_liveliness(self.node_handle)

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -67,3 +67,12 @@ class Publisher:
 
     def destroy(self):
         self.handle.destroy()
+
+    def assert_liveliness(self) -> None:
+        """
+        Manually assert that this Publisher is alive.
+
+        If the QoS Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC, the
+        application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
+        """
+        _rclpy.rclpy_assert_liveliness(self.publisher_handle)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3633,9 +3633,9 @@ rclpy_assert_liveliness(PyObject * Py_UNUSED(self), PyObject * args)
       rcl_reset_error();
       return NULL;
     }
-  } else if (PyCapsule_IsValid(pyentity, "rcl_publisher_t")) {
+  } else if (PyCapsule_IsValid(pyentity, "rclpy_publisher_t")) {
     rcl_publisher_t * publisher = (rcl_publisher_t *)PyCapsule_GetPointer(
-      pyentity, "rcl_publisher_t");
+      pyentity, "rclpy_publisher_t");
     if (RCL_RET_OK != rcl_publisher_assert_liveliness(publisher)) {
       PyErr_Format(PyExc_RuntimeError,
         "Failed to assert liveliness on the Publisher: %s", rcl_get_error_string().str);


### PR DESCRIPTION
Depends on ros2/rmw#171

Expose the rcl assert_liveliness APIs for Nodes and Publishers

Signed-off-by: Emerson Knapp <eknapp@amazon.com>