### PR TITLE
Thread safe node.destroy_*

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -247,10 +247,10 @@ class ActionServer(Waitable):
         check_for_type_support(action_type)
         self._node = node
         self._action_type = action_type
-        with node.handle as node_capsule:
+        with node.handle as node_capsule, node.get_clock().handle as clock_capsule:
             self._handle = _rclpy_action.rclpy_action_create_server(
                 node_capsule,
-                node.get_clock().handle,
+                clock_capsule,
                 action_type,
                 action_name,
                 goal_service_qos_profile.get_c_qos_profile(),

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -173,9 +173,3 @@ class Client:
 
     def destroy(self):
         self.handle.destroy()
-
-    def __eq__(self, other):
-        return self.handle == other.handle
-
-    def __hash__(self):
-        return self.handle.pointer

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -35,7 +35,6 @@ class Client:
         node_handle,
         context: Context,
         client_handle,
-        client_pointer: int,
         srv_type: SrvType,
         srv_name: str,
         qos_profile: QoSProfile,
@@ -50,8 +49,7 @@ class Client:
         :param node_handle: Capsule pointing to the ``rcl_node_t`` object for the node associated
             with the service client.
         :param context: The context associated with the service client.
-        :param client_handle: Capsule pointing to the underlying ``rcl_client_t`` object.
-        :param client_pointer: Memory address of the ``rcl_client_t`` implementation.
+        :param client_handle: :class:`Handle` wrapping the underlying ``rcl_client_t`` object.
         :param srv_type: The service type.
         :param srv_name: The name of the service.
         :param qos_profile: The quality of service profile to apply the service client.
@@ -60,8 +58,7 @@ class Client:
         """
         self.node_handle = node_handle
         self.context = context
-        self.client_handle = client_handle
-        self.client_pointer = client_pointer
+        self.__handle = client_handle
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.qos_profile = qos_profile
@@ -129,7 +126,8 @@ class Client:
         if not isinstance(request, self.srv_type.Request):
             raise TypeError()
 
-        sequence_number = _rclpy.rclpy_send_request(self.client_handle, request)
+        with self.handle as capsule:
+            sequence_number = _rclpy.rclpy_send_request(capsule, request)
         if sequence_number in self._pending_requests:
             raise RuntimeError('Sequence (%r) conflicts with pending request' % sequence_number)
 
@@ -146,8 +144,8 @@ class Client:
 
         :return: ``True`` if a server is ready, ``False`` otherwise.
         """
-        with self.node_handle as node_capsule:
-            return _rclpy.rclpy_service_server_is_available(node_capsule, self.client_handle)
+        with self.handle as capsule, self.node_handle as node_capsule:
+            return _rclpy.rclpy_service_server_is_available(node_capsule, capsule)
 
     def wait_for_service(self, timeout_sec: float = None) -> bool:
         """
@@ -168,3 +166,16 @@ class Client:
             timeout_sec -= sleep_time
 
         return self.service_is_ready()
+
+    @property
+    def handle(self):
+        return self.__handle
+
+    def destroy(self):
+        self.handle.destroy()
+
+    def __eq__(self, other):
+        return self.handle == other.handle
+
+    def __hash__(self):
+        return self.handle.pointer

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -151,9 +151,8 @@ class Executor:
         self._tasks: List[Tuple[Task, Optional[WaitableEntityType], Optional[Node]]] = []
         self._tasks_lock = Lock()
         # This is triggered when wait_for_ready_callbacks should rebuild the wait list
-        gc, gc_handle = _rclpy.rclpy_create_guard_condition(self._context.handle)
-        self._guard_condition = gc
-        self._guard_condition_handle = gc_handle
+        self._guard = GuardCondition(
+            callback=None, callback_group=None, context=self._context)
         # True if shutdown has been called
         self._is_shutdown = False
         self._work_tracker = _WorkTracker()
@@ -181,7 +180,7 @@ class Executor:
         task = Task(callback, args, kwargs, executor=self)
         with self._tasks_lock:
             self._tasks.append((task, None, None))
-            _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+            self._guard.trigger()
         # Task inherits from Future
         return task
 
@@ -198,7 +197,7 @@ class Executor:
             if not self._is_shutdown:
                 self._is_shutdown = True
                 # Tell executor it's been shut down
-                _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+                self._guard.trigger()
 
         if not self._work_tracker.wait(timeout_sec):
             return False
@@ -208,9 +207,9 @@ class Executor:
             self._nodes = set()
 
         with self._shutdown_lock:
-            if self._guard_condition:
-                _rclpy.rclpy_destroy_entity(self._guard_condition)
-                self._guard_condition = None
+            if self._guard:
+                self._guard.destroy()
+                self._guard = None
             if self._sigint_gc:
                 self._sigint_gc.destroy()
                 self._sigint_gc = None
@@ -220,8 +219,6 @@ class Executor:
         return True
 
     def __del__(self):
-        if self._guard_condition is not None:
-            _rclpy.rclpy_destroy_entity(self._guard_condition)
         if self._sigint_gc is not None:
             self._sigint_gc.destroy()
 
@@ -237,7 +234,7 @@ class Executor:
                 self._nodes.add(node)
                 node.executor = self
                 # Rebuild the wait set so it includes this new node
-                _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+                self._guard.trigger()
                 return True
             return False
 
@@ -254,7 +251,7 @@ class Executor:
                 pass
             else:
                 # Rebuild the wait set so it doesn't include this node
-                _rclpy.rclpy_trigger_guard_condition(self._guard_condition)
+                self._guard.trigger()
 
     def get_nodes(self) -> List['Node']:
         """Return nodes that have been added to this executor."""
@@ -374,14 +371,14 @@ class Executor:
             if is_shutdown or not entity.callback_group.beginning_execution(entity):
                 # Didn't get the callback, or the executor has been ordered to stop
                 entity._executor_event = False
-                _rclpy.rclpy_trigger_guard_condition(gc)
+                gc.trigger()
                 return
             with work_tracker:
                 arg = take_from_wait_list(entity)
 
                 # Signal that this has been 'taken' and can be added back to the wait list
                 entity._executor_event = False
-                _rclpy.rclpy_trigger_guard_condition(gc)
+                gc.trigger()
 
                 try:
                     await call_coroutine(entity, arg)
@@ -389,9 +386,9 @@ class Executor:
                     entity.callback_group.ending_execution(entity)
                     # Signal that work has been done so the next callback in a mutually exclusive
                     # callback group can get executed
-                    _rclpy.rclpy_trigger_guard_condition(gc)
+                    gc.trigger()
         task = Task(
-            handler, (entity, self._guard_condition, self._is_shutdown, self._work_tracker),
+            handler, (entity, self._guard, self._is_shutdown, self._work_tracker),
             executor=self)
         with self._tasks_lock:
             self._tasks.append((task, entity, node))
@@ -469,10 +466,11 @@ class Executor:
             if timeout_timer is not None:
                 timers.append(timeout_timer)
 
-            node_entity_count = NumberOfEntities(
+            guards.append(self._guard)
+            guards.append(self._sigint_gc)
+
+            entity_count = NumberOfEntities(
                 len(subscriptions), len(guards), len(timers), len(clients), len(services))
-            executor_entity_count = NumberOfEntities(0, 2, 0, 0, 0)
-            entity_count = node_entity_count + executor_entity_count
             for waitable in waitables:
                 entity_count += waitable.get_num_entities()
 
@@ -506,6 +504,13 @@ class Executor:
                     except InvalidHandle:
                         entity_count.num_timers -= 1
 
+                guard_capsules = []
+                for gc in guards:
+                    try:
+                        guard_capsules.append(context_stack.enter_context(gc.handle))
+                    except InvalidHandle:
+                        entity_count.num_guard_conditions -= 1
+
                 _rclpy.rclpy_wait_set_init(
                     wait_set,
                     entity_count.num_subscriptions,
@@ -515,15 +520,7 @@ class Executor:
                     entity_count.num_services,
                     self._context.handle)
 
-                entities = {
-                    'guard_condition': (guards, 'guard_handle'),
-                }
                 _rclpy.rclpy_wait_set_clear_entities(wait_set)
-                for entity, (handles, handle_name) in entities.items():
-                    for h in handles:
-                        _rclpy.rclpy_wait_set_add_entity(
-                            entity, wait_set, h.__getattribute__(handle_name)
-                        )
                 for sub_capsule in sub_capsules:
                     _rclpy.rclpy_wait_set_add_entity('subscription', wait_set, sub_capsule)
                 for cli_capsule in client_capsules:
@@ -532,13 +529,10 @@ class Executor:
                     _rclpy.rclpy_wait_set_add_entity('service', wait_set, srv_capsule)
                 for tmr_capsule in timer_capsules:
                     _rclpy.rclpy_wait_set_add_entity('timer', wait_set, tmr_capsule)
+                for gc_capsule in guard_capsules:
+                    _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, gc_capsule)
                 for waitable in waitables:
                     waitable.add_to_wait_set(wait_set)
-
-                sigint_gc = self._sigint_gc.guard_handle
-                _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, sigint_gc)
-                _rclpy.rclpy_wait_set_add_entity(
-                    'guard_condition', wait_set, self._guard_condition)
 
                 # Wait for something to become ready
                 _rclpy.rclpy_wait(wait_set, timeout_nsec)
@@ -554,7 +548,7 @@ class Executor:
 
                 # Mark all guards as triggered before yielding since they're auto-taken
                 for gc in guards:
-                    if gc.guard_pointer in guards_ready:
+                    if gc.handle.pointer in guards_ready:
                         gc._executor_triggered = True
 
                 # Check waitables before wait set is destroyed

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -34,6 +34,7 @@ from rclpy.executors import Executor
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.guard_condition import GuardCondition
 from rclpy.handle import Handle
+from rclpy.handle import InvalidHandle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.logging import get_logger
 from rclpy.parameter import Parameter
@@ -569,7 +570,10 @@ class Node:
         """
         if publisher in self.publishers:
             self.publishers.remove(publisher)
-            publisher.destroy()
+            try:
+                publisher.destroy()
+            except InvalidHandle:
+                return False
             return True
         return False
 
@@ -581,7 +585,10 @@ class Node:
         """
         if subscription in self.subscriptions:
             self.subscriptions.remove(subscription)
-            subscription.destroy()
+            try:
+                subscription.destroy()
+            except InvalidHandle:
+                return False
             return True
         return False
 
@@ -593,7 +600,10 @@ class Node:
         """
         if client in self.clients:
             self.clients.remove(client)
-            client.destroy()
+            try:
+                client.destroy()
+            except InvalidHandle:
+                return False
             return True
         return False
 
@@ -605,7 +615,10 @@ class Node:
         """
         if service in self.services:
             self.services.remove(service)
-            service.destroy()
+            try:
+                service.destroy()
+            except InvalidHandle:
+                return False
             return True
         return False
 
@@ -617,7 +630,10 @@ class Node:
         """
         if timer in self.timers:
             self.timers.remove(timer)
-            timer.destroy()
+            try:
+                timer.destroy()
+            except InvalidHandle:
+                return False
             return True
         return False
 
@@ -629,7 +645,10 @@ class Node:
         """
         if guard in self.guards:
             self.guards.remove(guard)
-            guard.destroy()
+            try:
+                guard.destroy()
+            except InvalidHandle:
+                return False
             return True
         return False
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -670,12 +670,12 @@ class Node:
         # It will be destroyed with other publishers below.
         self._parameter_event_publisher = None
 
-        self.publishers = ()
-        self.subscriptions = ()
-        self.clients = ()
-        self.services = ()
-        self.timers = ()
-        self.guards = ()
+        self.publishers.clear()
+        self.subscriptions.clear()
+        self.clients.clear()
+        self.services.clear()
+        self.timers.clear()
+        self.guards.clear()
         self.handle.destroy()
 
     def get_publisher_names_and_types_by_node(

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -611,13 +611,12 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        for tmr in self.timers:
-            if tmr.timer_handle == timer.timer_handle:
-                _rclpy.rclpy_destroy_entity(tmr.timer_handle)
-                # TODO(sloretz) Store clocks on node and destroy them separately
-                _rclpy.rclpy_destroy_entity(tmr.clock._clock_handle)
-                self.timers.remove(tmr)
-                return True
+        if timer in self.timers:
+            self.timers.remove(timer)
+            timer.destroy()
+            # TODO(sloretz) Store clocks on node and destroy them separately
+            _rclpy.rclpy_destroy_entity(timer.clock._clock_handle)
+            return True
         return False
 
     def destroy_guard_condition(self, guard: GuardCondition) -> bool:
@@ -665,7 +664,7 @@ class Node:
                 srv.destroy()
             while self.timers:
                 tmr = self.timers.pop()
-                _rclpy.rclpy_destroy_entity(tmr.timer_handle)
+                tmr.destroy()
                 # TODO(sloretz) Store clocks on node and destroy them separately
                 _rclpy.rclpy_destroy_entity(tmr.clock._clock_handle)
             while self.guards:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -625,11 +625,10 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        for gc in self.guards:
-            if gc.guard_handle == guard.guard_handle:
-                _rclpy.rclpy_destroy_entity(gc.guard_handle)
-                self.guards.remove(gc)
-                return True
+        if guard in self.guards:
+            self.guards.remove(guard)
+            guard.destroy()
+            return True
         return False
 
     def destroy_node(self) -> bool:
@@ -650,26 +649,25 @@ class Node:
         # It will be destroyed with other publishers below.
         self._parameter_event_publisher = None
 
-        with self.handle as capsule:
 
-            while self.publishers:
-                pub = self.publishers.pop()
-                pub.destroy()
-            self.subscriptions = ()
-            while self.clients:
-                cli = self.clients.pop()
-                cli.destroy()
-            while self.services:
-                srv = self.services.pop()
-                srv.destroy()
-            while self.timers:
-                tmr = self.timers.pop()
-                tmr.destroy()
-                # TODO(sloretz) Store clocks on node and destroy them separately
-                _rclpy.rclpy_destroy_entity(tmr.clock._clock_handle)
-            while self.guards:
-                gc = self.guards.pop()
-                _rclpy.rclpy_destroy_entity(gc.guard_handle)
+        while self.publishers:
+            pub = self.publishers.pop()
+            pub.destroy()
+        self.subscriptions = ()
+        while self.clients:
+            cli = self.clients.pop()
+            cli.destroy()
+        while self.services:
+            srv = self.services.pop()
+            srv.destroy()
+        while self.timers:
+            tmr = self.timers.pop()
+            tmr.destroy()
+            # TODO(sloretz) Store clocks on node and destroy them separately
+            _rclpy.rclpy_destroy_entity(tmr.clock._clock_handle)
+        while self.guards:
+            gc = self.guards.pop()
+            gc.destroy()
 
         self.handle.destroy()
 

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -46,7 +46,7 @@ class Publisher:
         :param node_handle: Capsule pointing to the ``rcl_node_t`` object for the node the
             publisher is associated with.
         """
-        self.publisher_handle = publisher_handle
+        self.__handle = publisher_handle
         self.msg_type = msg_type
         self.topic = topic
         self.qos_profile = qos_profile
@@ -62,4 +62,18 @@ class Publisher:
         """
         if not isinstance(msg, self.msg_type):
             raise TypeError()
-        _rclpy.rclpy_publish(self.publisher_handle, msg)
+        with self.handle as capsule:
+            _rclpy.rclpy_publish(capsule, msg)
+
+    @property
+    def handle(self):
+        return self.__handle
+
+    def destroy(self):
+        self.handle.destroy()
+
+    def __eq__(self, other):
+        return self.handle == other.handle
+
+    def __hash__(self):
+        return self.handle.pointer

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -71,9 +71,3 @@ class Publisher:
 
     def destroy(self):
         self.handle.destroy()
-
-    def __eq__(self, other):
-        return self.handle == other.handle
-
-    def __hash__(self):
-        return self.handle.pointer

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -83,9 +83,3 @@ class Service:
 
     def destroy(self):
         self.handle.destroy()
-
-    def __eq__(self, other):
-        return self.handle == other.handle
-
-    def __hash__(self):
-        return self.handle.pointer

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -41,12 +41,6 @@ class WallTimer:
     def destroy(self):
         self.handle.destroy()
 
-    def __eq__(self, other):
-        return self.handle == other.handle
-
-    def __hash__(self):
-        return self.handle.pointer
-
     @property
     def clock(self):
         return self._clock

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -26,8 +26,10 @@ class WallTimer:
         self._context = get_default_context() if context is None else context
         # TODO(sloretz) Allow passing clocks in via timer constructor
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
-        self.__handle = Handle(_rclpy.rclpy_create_timer(
-            self._clock._clock_handle, self._context.handle, timer_period_ns))
+        with self._clock.handle as clock_capsule:
+            self.__handle = Handle(_rclpy.rclpy_create_timer(
+                clock_capsule, self._context.handle, timer_period_ns))
+        self.__handle.requires(self._clock.handle)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
         self.callback_group = callback_group

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1278,6 +1278,7 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
   pub->publisher = rcl_get_zero_initialized_publisher();
+  pub->node = node;
 
   rcl_ret_t ret = rcl_publisher_init(&(pub->publisher), node, ts, topic, &publisher_ops);
   if (ret != RCL_RET_OK) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -49,9 +49,6 @@ typedef struct
 
 typedef struct
 {
-  // Important: a pointer to a structure is also a pointer to its first member.
-  // The publisher must be first in the struct to compare pub.handle.pointer to an address
-  // in a wait set.
   rcl_publisher_t publisher;
   rcl_node_t * node;
 } rclpy_publisher_t;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -164,8 +164,6 @@ _rclpy_destroy_guard_condition(PyObject * pyentity)
  *
  * Raises RuntimeError if initializing the guard condition fails
  *
- * \remark Call rclpy_destroy_entity() to destroy a guard condition
- * \sa rclpy_destroy_entity()
  * \return a capsule, or
  * \return NULL on failure
  */
@@ -1201,16 +1199,27 @@ rclpy_expand_topic_name(PyObject * Py_UNUSED(self), PyObject * args)
 static void
 _rclpy_destroy_publisher(PyObject * pyentity)
 {
-  if (PyCapsule_IsValid(pyentity, "rclpy_publisher_t")) {
-    rclpy_publisher_t * pub = (rclpy_publisher_t *)PyCapsule_GetPointer(
+  rclpy_publisher_t * pub = (rclpy_publisher_t *)PyCapsule_GetPointer(
       pyentity, "rclpy_publisher_t");
-    if (!pub) {
-      return;
-    }
-    rcl_ret_t ret = rcl_publisher_fini(&(pub->publisher), pub->node);
-    (void)ret;
-    PyMem_Free(pub);
+  if (!pub) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_publisher failed to get pointer");
+    return;
   }
+
+  rcl_ret_t ret = rcl_publisher_fini(&(pub->publisher), pub->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini publisher: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(pub);
 }
 
 /// Create a publisher
@@ -1887,16 +1896,27 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
 static void
 _rclpy_destroy_client(PyObject * pyentity)
 {
-  if (PyCapsule_IsValid(pyentity, "rclpy_client_t")) {
-    rclpy_client_t * client = (rclpy_client_t *)PyCapsule_GetPointer(
+  rclpy_client_t * cli = (rclpy_client_t *)PyCapsule_GetPointer(
       pyentity, "rclpy_client_t");
-    if (!client) {
-      return;
-    }
-    rcl_ret_t ret = rcl_client_fini(&(client->client), client->node);
-    (void)ret;
-    PyMem_Free(client);
+  if (!cli) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_client failed to get pointer");
+    return;
   }
+
+  rcl_ret_t ret = rcl_client_fini(&(cli->client), cli->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini client: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(cli);
 }
 
 /// Create a client
@@ -2052,16 +2072,27 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
 static void
 _rclpy_destroy_service(PyObject * pyentity)
 {
-  if (PyCapsule_IsValid(pyentity, "rclpy_service_t")) {
-    rclpy_service_t * srv = (rclpy_service_t *)PyCapsule_GetPointer(
+  rclpy_service_t * srv = (rclpy_service_t *)PyCapsule_GetPointer(
       pyentity, "rclpy_service_t");
-    if (!srv) {
-      return;
-    }
-    rcl_ret_t ret = rcl_service_fini(&(srv->service), srv->node);
-    (void)ret;
-    PyMem_Free(srv);
+  if (!srv) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_service failed to get pointer");
+    return;
   }
+
+  rcl_ret_t ret = rcl_service_fini(&(srv->service), srv->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini service: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(srv);
 }
 
 /// Create a service server

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1200,7 +1200,7 @@ static void
 _rclpy_destroy_publisher(PyObject * pyentity)
 {
   rclpy_publisher_t * pub = (rclpy_publisher_t *)PyCapsule_GetPointer(
-      pyentity, "rclpy_publisher_t");
+    pyentity, "rclpy_publisher_t");
   if (!pub) {
     // Don't want to raise an exception, who knows where it will get raised.
     PyErr_Clear();
@@ -1897,7 +1897,7 @@ static void
 _rclpy_destroy_client(PyObject * pyentity)
 {
   rclpy_client_t * cli = (rclpy_client_t *)PyCapsule_GetPointer(
-      pyentity, "rclpy_client_t");
+    pyentity, "rclpy_client_t");
   if (!cli) {
     // Don't want to raise an exception, who knows where it will get raised.
     PyErr_Clear();
@@ -2073,7 +2073,7 @@ static void
 _rclpy_destroy_service(PyObject * pyentity)
 {
   rclpy_service_t * srv = (rclpy_service_t *)PyCapsule_GetPointer(
-      pyentity, "rclpy_service_t");
+    pyentity, "rclpy_service_t");
   if (!srv) {
     // Don't want to raise an exception, who knows where it will get raised.
     PyErr_Clear();

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2464,22 +2464,37 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
   if (0 == strcmp(entity_type, "subscription")) {
     rclpy_subscription_t * sub =
       (rclpy_subscription_t *)PyCapsule_GetPointer(pyentity, "rclpy_subscription_t");
+    if (!sub) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_subscription(wait_set, &(sub->subscription), &index);
   } else if (0 == strcmp(entity_type, "client")) {
     rclpy_client_t * client =
       (rclpy_client_t *)PyCapsule_GetPointer(pyentity, "rclpy_client_t");
+    if (!client) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_client(wait_set, &(client->client), &index);
   } else if (0 == strcmp(entity_type, "service")) {
     rclpy_service_t * srv =
       (rclpy_service_t *)PyCapsule_GetPointer(pyentity, "rclpy_service_t");
+    if (!srv) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_service(wait_set, &(srv->service), &index);
   } else if (0 == strcmp(entity_type, "timer")) {
     rcl_timer_t * timer =
       (rcl_timer_t *)PyCapsule_GetPointer(pyentity, "rcl_timer_t");
+    if (!timer) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_timer(wait_set, timer, &index);
   } else if (0 == strcmp(entity_type, "guard_condition")) {
     rcl_guard_condition_t * guard_condition =
       (rcl_guard_condition_t *)PyCapsule_GetPointer(pyentity, "rcl_guard_condition_t");
+    if (!guard_condition) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_guard_condition(wait_set, guard_condition, &index);
   } else {
     ret = RCL_RET_ERROR;  // to avoid a linter warning

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -75,7 +75,6 @@ class TestActionClient(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.node.destroy_node()
-        cls.executor.shutdown()
         rclpy.shutdown(context=cls.context)
 
     def setUp(self):
@@ -279,7 +278,6 @@ class TestActionClient(unittest.TestCase):
             self.assertTrue(future_2.result().accepted)
         finally:
             ac.destroy()
-            executor.shutdown()
 
     def test_send_goal_async_no_server(self):
         ac = ActionClient(self.node, Fibonacci, 'not_fibonacci')

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -75,6 +75,7 @@ class TestActionClient(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.node.destroy_node()
+        cls.executor.shutdown()
         rclpy.shutdown(context=cls.context)
 
     def setUp(self):
@@ -278,6 +279,7 @@ class TestActionClient(unittest.TestCase):
             self.assertTrue(future_2.result().accepted)
         finally:
             ac.destroy()
+            executor.shutdown()
 
     def test_send_goal_async_no_server(self):
         ac = ActionClient(self.node, Fibonacci, 'not_fibonacci')

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -144,3 +144,28 @@ def test_destroy_node_asap():
                 pass
     finally:
         rclpy.shutdown(context=context)
+
+
+def test_destroy_publisher_asap():
+        node = rclpy.create_node('test_destroy_publisher_asap', context=context)
+        try:
+            pub = node.create_publisher(Primitives, 'pub_topic')
+
+            # handle valid
+            with pub.handle:
+                pass
+
+            with pub.handle:
+                node.destroy_publisher(pub)
+                # handle valid because it's still being used
+                with pub.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with pub.handle:
+                    pass
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -228,3 +228,32 @@ def test_destroy_service_asap():
             node.destroy_node()
     finally:
         rclpy.shutdown(context=context)
+
+
+def test_destroy_timer_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_timer_asap', context=context)
+        try:
+            timer = node.create_timer(1.0, lambda: ...)
+
+            # handle valid
+            with timer.handle:
+                pass
+
+            with timer.handle:
+                node.destroy_timer(timer)
+                # handle valid because it's still being used
+                with timer.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with timer.handle:
+                    pass
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -199,3 +199,32 @@ def test_destroy_client_asap():
             node.destroy_node()
     finally:
         rclpy.shutdown(context=context)
+
+
+def test_destroy_service_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_service_asap', context=context)
+        try:
+            service = node.create_service(PrimitivesSrv, 'srv_service', lambda req, res: ...)
+
+            # handle valid
+            with service.handle:
+                pass
+
+            with service.handle:
+                node.destroy_service(service)
+                # handle valid because it's still being used
+                with service.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with service.handle:
+                    pass
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -148,6 +148,10 @@ def test_destroy_node_asap():
 
 
 def test_destroy_publisher_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
         node = rclpy.create_node('test_destroy_publisher_asap', context=context)
         try:
             pub = node.create_publisher(Primitives, 'pub_topic')

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -172,10 +172,6 @@ class SubscriptionWaitable(Waitable):
     def __init__(self, node):
         super().__init__(ReentrantCallbackGroup())
 
-        self.guard_condition = _rclpy.rclpy_create_guard_condition(node.context.handle)[0]
-        self.guard_condition_index = None
-        self.guard_is_ready = False
-
         with node.handle as node_capsule:
             self.subscription = _rclpy.rclpy_create_subscription(
                 node_capsule, EmptyMsg, 'test_topic', qos_profile_default.get_c_qos_profile())
@@ -220,7 +216,7 @@ class GuardConditionWaitable(Waitable):
     def __init__(self, node):
         super().__init__(ReentrantCallbackGroup())
 
-        self.guard_condition = _rclpy.rclpy_create_guard_condition(node.context.handle)[0]
+        self.guard_condition = _rclpy.rclpy_create_guard_condition(node.context.handle)
         self.guard_condition_index = None
         self.guard_is_ready = False
 

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -129,8 +129,9 @@ class TimerWaitable(Waitable):
 
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         period_nanoseconds = 10000
-        self.timer = _rclpy.rclpy_create_timer(
-            self._clock._clock_handle, node.context.handle, period_nanoseconds)
+        with self._clock.handle as clock_capsule:
+            self.timer = _rclpy.rclpy_create_timer(
+                clock_capsule, node.context.handle, period_nanoseconds)
         self.timer_index = None
         self.timer_is_ready = False
 

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -86,7 +86,7 @@ class ServerWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.server = _rclpy.rclpy_create_service(
-                node_capsule, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())[0]
+                node_capsule, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())
         self.server_index = None
         self.server_is_ready = False
 

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -130,8 +130,7 @@ class TimerWaitable(Waitable):
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         period_nanoseconds = 10000
         self.timer = _rclpy.rclpy_create_timer(
-            self._clock._clock_handle, node.context.handle, period_nanoseconds
-        )[0]
+            self._clock._clock_handle, node.context.handle, period_nanoseconds)
         self.timer_index = None
         self.timer_is_ready = False
 

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -43,7 +43,7 @@ class ClientWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.client = _rclpy.rclpy_create_client(
-                node_capsule, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())[0]
+                node_capsule, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())
         self.client_index = None
         self.client_is_ready = False
 


### PR DESCRIPTION
Follow up to ros2/rclpy#318 and ros2/rclpy#330. This PR applies the changes done to `Subscription` to the rest of the entities on the node so they can all be destroyed safely.

- [x] destroy_publisher
- [x] destroy_client
- [x] destroy_service
- [x] destroy_timer
  - [x] Clock used by timer safely destroyed
- [x] destroy_guard_condition


Not done in this PR. These might require a change to the waitable API.

* action server
* action client