### PR TITLE
Fix subscription pycapsule not being destroyed

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1681,10 +1681,9 @@ _rclpy_destroy_subscription(PyObject * pyentity)
 
   rclpy_subscription_t * sub = (rclpy_subscription_t *)PyCapsule_GetPointer(
     pyentity, "rclpy_subscription_t");
-  if (!sub) {
-    // Impossible, ...GetPointer() guaranteed to return non NULL if PyCapsule_IsValid check passes
-    return;
-  }
+  // ...GetPointer() is guaranteed to return non NULL if PyCapsule_IsValid passes
+  assert(sub);
+
   rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);
   if (RCL_RET_OK != ret) {
     // Warning should use line number of the current stack frame

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1671,18 +1671,16 @@ rclpy_time_since_last_call(PyObject * Py_UNUSED(self), PyObject * args)
 static void
 _rclpy_destroy_subscription(PyObject * pyentity)
 {
-  if (!PyCapsule_IsValid(pyentity, "rclpy_subscription_t")) {
+  rclpy_subscription_t * sub = (rclpy_subscription_t *)PyCapsule_GetPointer(
+    pyentity, "rclpy_subscription_t");
+  if (!sub) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
     // Warning should use line number of the current stack frame
     int stack_level = 1;
     PyErr_WarnFormat(
       PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_subscrition failed to get pointer");
-    return;
   }
-
-  rclpy_subscription_t * sub = (rclpy_subscription_t *)PyCapsule_GetPointer(
-    pyentity, "rclpy_subscription_t");
-  // ...GetPointer() is guaranteed to return non NULL if PyCapsule_IsValid passes
-  assert(sub);
 
   rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);
   if (RCL_RET_OK != ret) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1671,16 +1671,29 @@ rclpy_time_since_last_call(PyObject * Py_UNUSED(self), PyObject * args)
 static void
 _rclpy_destroy_subscription(PyObject * pyentity)
 {
-  if (PyCapsule_IsValid(pyentity, "rclpy_subscription_t")) {
-    rclpy_subscription_t * sub = (rclpy_subscription_t *)PyCapsule_GetPointer(
-      pyentity, "rclpy_subscription_t");
-    if (!sub) {
-      return;
-    }
-    rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);
-    (void)ret;
-    PyMem_Free(sub);
+  if (!PyCapsule_IsValid(pyentity, "rclpy_subscription_t")) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_subscrition failed to get pointer");
+    return;
   }
+
+  rclpy_subscription_t * sub = (rclpy_subscription_t *)PyCapsule_GetPointer(
+    pyentity, "rclpy_subscription_t");
+  if (!sub) {
+    // Impossible, ...GetPointer() guaranteed to return non NULL if PyCapsule_IsValid check passes
+    return;
+  }
+  rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini subscription: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(sub);
 }
 
 /// Create a subscription

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1680,6 +1680,7 @@ _rclpy_destroy_subscription(PyObject * pyentity)
     int stack_level = 1;
     PyErr_WarnFormat(
       PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_subscrition failed to get pointer");
+    return;
   }
 
   rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);

--- a/rclpy/src/rclpy/_rclpy_pycapsule.c
+++ b/rclpy/src/rclpy/_rclpy_pycapsule.c
@@ -97,20 +97,7 @@ rclpy_pycapsule_destroy(PyObject * Py_UNUSED(self), PyObject * args)
     PyErr_Format(PyExc_ValueError, "PyCapsule does not have a destructor.");
   }
 
-  // Need name to get pointer
-  const char * name = PyCapsule_GetName(pycapsule);
-
-  if (PyErr_Occurred()) {
-    return NULL;
-  }
-
-  void * pointer = PyCapsule_GetPointer(pycapsule, name);
-
-  if (NULL == pointer) {
-    return NULL;
-  }
-
-  destructor(pointer);
+  destructor(pycapsule);
 
   if (0 != PyCapsule_SetDestructor(pycapsule, NULL)) {
     return NULL;


### PR DESCRIPTION
Fixes bug in #318.

The subscription is never being destroyed because `rclpy_pycapsule_destroy` was passing the destructor the pointer held by the pycapsule rather than the pycapsule itself. This fixes the issue and adds a warning to `_rclpy_destroy_subscription` to make this visible if it happens again.