### PR TITLE
Remove __eq__ and __hash__ from Subscription

### DIFF
--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -72,9 +72,3 @@ class Subscription:
 
     def destroy(self):
         self.handle.destroy()
-
-    def __eq__(self, other):
-        return self.handle == other.handle
-
-    def __hash__(self):
-        return self.handle.pointer


### PR DESCRIPTION
Fixes #322

**TL;DR** the default `__eq__` and `__hash__` work just fine.

The Subscription class was using the address held by the pycapsule as the hash. However, that address is `free`'d when `Subscription.destroy()` is called. This makes it possible for a new subscription to be created using the same address, and therefore having the same hash as a `destroy()`'d subscription.

This is a problem in the unit tests that reuse the same node for multiple tests. After the subscription is destroyed in one test, a new test can create a subscription that has the same memory address. Callback groups keep a `set()` of weak references to entities (including subscriptions) that are in them. This prevents the new subscription from being added to the node's default callback group, because a weak reference with that hash already exists. The weak reference to the `destroy()`'d entity stays in the callback group's `set()` until it is garbage collected.

After the garbage collector runs the callback group's weakref to the old subscription is deleted. This leads to an assertion error in `callback_group.can_execute` because there is no weak reference with the same hash as the newly created subscription.