### PR TITLE
Wait set uses pointers to rcl types not rcl->impl types

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -167,7 +167,7 @@ rclpy_create_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pygc_impl_reference = PyLong_FromUnsignedLongLong((uint64_t)&gc->impl);
+  PyObject * pygc_impl_reference = PyLong_FromVoidPtr(gc);
   if (!pygc_impl_reference) {
     ret = rcl_guard_condition_fini(gc);
     PyMem_Free(gc);

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2624,7 +2624,7 @@ rclpy_destroy_wait_set(PyObject * Py_UNUSED(self), PyObject * args)
   const rcl_ ## ENTITY_TYPE ## _t ** struct_ptr = wait_set->ENTITY_TYPE ## s; \
   for (idx = 0; idx < idx_max; idx ++) { \
     if (struct_ptr[idx]) { \
-      PyObject * obj = PyLong_FromUnsignedLongLong((uint64_t) & struct_ptr[idx]->impl); \
+      PyObject * obj = PyLong_FromVoidPtr((void *) struct_ptr[idx]); \
       if (obj) { \
         int rc = PyList_Append(entity_ready_list, obj); \
         Py_DECREF(obj); \

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -167,8 +167,8 @@ rclpy_create_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pygc_impl_reference = PyLong_FromVoidPtr(gc);
-  if (!pygc_impl_reference) {
+  PyObject * pygc_reference = PyLong_FromVoidPtr(gc);
+  if (!pygc_reference) {
     ret = rcl_guard_condition_fini(gc);
     PyMem_Free(gc);
     Py_DECREF(pylist);
@@ -177,7 +177,7 @@ rclpy_create_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   PyList_SET_ITEM(pylist, 0, pygc);
-  PyList_SET_ITEM(pylist, 1, pygc_impl_reference);
+  PyList_SET_ITEM(pylist, 1, pygc_reference);
   return pylist;
 }
 


### PR DESCRIPTION
`rclpy_get_ready_entities` is returning a list of pointers to the `entity->impl` pointer, but it should be returning a list of pointers to the `entity`. For most entities this doesn't matter because the `impl` object is the first member of the struct, so the addresses are the same. `rcl_guard_condition_t` is different because the [first member is a pointer to the context](https://github.com/ros2/rcl/blob/64610d254864b87d7b35a6c9473b97a03598c3e2/rcl/include/rcl/guard_condition.h#L36).

This fixes the macro used by `rcl_get_ready_entities` and removes the workaround to the bug in `rclpy_create_guard_condition`.

Blocks #319