### PR TITLE
Prevent rcutils_log from accessing invalid memory

### DIFF
--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -165,7 +165,7 @@ rclpy_logging_rcutils_log(PyObject * Py_UNUSED(self), PyObject * args)
 
   RCUTILS_LOGGING_AUTOINIT
   rcutils_log_location_t logging_location = {function_name, file_name, line_number};
-  rcutils_log(&logging_location, severity, name, message);
+  rcutils_log(&logging_location, severity, name, "%s", message);
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Before this fix, rclpy_logging_rcutils_log was using
rcutils_log without a format string (log message was
passed directly as the foramt).

This is unsafe because if the log message contains
a sequence of character which can be interpreted by
snprintf ("%d" for instance), snprintf will look for
this argument value which was never passed.
This leads to reading invalid memory and may cause a crash
or corrupted log messages.

The simple fix is to always pass "%s" when a static log
string needs to be logged.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>