### PR TITLE
Make `destroy_node` thread safe

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -190,6 +190,7 @@ if(BUILD_TESTING)
     test/test_executor.py
     test/test_expand_topic_name.py
     test/test_guard_condition.py
+    test/test_handle.py
     test/test_init_shutdown.py
     test/test_logging.py
     test/test_messages.py

--- a/rclpy/rclpy/action/graph.py
+++ b/rclpy/rclpy/action/graph.py
@@ -32,8 +32,9 @@ def get_action_client_names_and_types_by_node(
     :param node_namespace: Namespace of the remote node.
     :return: List of tuples containing two strings: the action name and action type.
     """
-    return _rclpy_action.rclpy_action_get_client_names_and_types_by_node(
-        node.handle, remote_node_name, remote_node_namespace)
+    with node.handle as node_capsule:
+        return _rclpy_action.rclpy_action_get_client_names_and_types_by_node(
+            node_capsule, remote_node_name, remote_node_namespace)
 
 
 def get_action_server_names_and_types_by_node(
@@ -49,8 +50,9 @@ def get_action_server_names_and_types_by_node(
     :param node_namespace: Namespace of the remote node.
     :return: List of tuples containing two strings: the action name and action type.
     """
-    return _rclpy_action.rclpy_action_get_server_names_and_types_by_node(
-        node.handle, remote_node_name, remote_node_namespace)
+    with node.handle as node_capsule:
+        return _rclpy_action.rclpy_action_get_server_names_and_types_by_node(
+            node_capsule, remote_node_name, remote_node_namespace)
 
 
 def get_action_names_and_types(node: Node) -> List[Tuple[str, str]]:
@@ -61,4 +63,5 @@ def get_action_names_and_types(node: Node) -> List[Tuple[str, str]]:
     :return: List of action names and types in the ROS graph as tuples containing two
        strings: the action name and action type.
     """
-    return _rclpy_action.rclpy_action_get_names_and_types(node.handle)
+    with node.handle as node_capsule:
+        return _rclpy_action.rclpy_action_get_names_and_types(node_capsule)

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -146,7 +146,8 @@ class Client:
 
         :return: ``True`` if a server is ready, ``False`` otherwise.
         """
-        return _rclpy.rclpy_service_server_is_available(self.node_handle, self.client_handle)
+        with self.node_handle as node_capsule:
+            return _rclpy.rclpy_service_server_is_available(node_capsule, self.client_handle)
 
     def wait_for_service(self, timeout_sec: float = None) -> bool:
         """

--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -96,12 +96,12 @@ class Handle:
 
     def requires(self, req_handle):
         """
-        Indicate that this handle requires another handle to out live it.
+        Indicate that this handle requires another handle to live longer than itself.
 
         Calling :meth:`destroy` on the passed in handle will cause this handle to be
         destroyed first.
-        This handle will hold a reference to the passed in handle so that this one is garbage
-        collected before the passed in handle if :meth:`destroy` is not called.
+        This handle will hold a reference to the passed in handle so the required handle is
+        garbage collected after this handle in case :meth:`destroy` is not called.
         """
         assert isinstance(req_handle, Handle)
         with self.__lock, req_handle.__lock:

--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -105,13 +105,14 @@ class Handle:
         """
         assert isinstance(req_handle, Handle)
         with self.__lock, req_handle.__lock:
-            if self.__valid:
-                if req_handle.__valid:
-                    self.__required_handles.append(req_handle)
-                    req_handle.__dependent_handles.add(self)
-                else:
-                    # required handle destroyed before we could link to it, destroy self
-                    self.destroy()
+            if not self.__valid:
+                raise InvalidHandle('Cannot require a new handle if already destroyed')
+            if req_handle.__valid:
+                self.__required_handles.append(req_handle)
+                req_handle.__dependent_handles.add(self)
+            else:
+                # required handle destroyed before we could link to it, destroy self
+                self.destroy()
 
     def _get_capsule(self):
         """

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -28,7 +28,7 @@ class Publisher:
         msg_type: MsgType,
         topic: str,
         qos_profile: QoSProfile,
-        node_handle,
+        node_handle
     ) -> None:
         """
         Create a container for a ROS publisher.

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -28,7 +28,7 @@ class Publisher:
         msg_type: MsgType,
         topic: str,
         qos_profile: QoSProfile,
-        node_handle
+        node_handle,
     ) -> None:
         """
         Create a container for a ROS publisher.

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -32,7 +32,6 @@ class Subscription:
          callback: Callable,
          callback_group: CallbackGroup,
          qos_profile: QoSProfile,
-         node_handle,
          raw: bool
     ) -> None:
         """
@@ -50,12 +49,9 @@ class Subscription:
         :param callback_group: The callback group for the subscription. If ``None``, then the
             nodes default callback group is used.
         :param qos_profile: The quality of service profile to apply to the subscription.
-        :node_handle: Capsule pointing to the underlying ``rcl_node_t`` object for the node the
-            subscription is associated with.
         :param raw: If ``True``, then received messages will be stored in raw binary
             representation.
         """
-        self.node_handle = node_handle
         self.__handle = subscription_handle
         self.msg_type = msg_type
         self.topic = topic

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -23,7 +23,7 @@ def test_destroy_node():
     rclpy.init(context=context)
     try:
         node = rclpy.create_node('test_node1', context=context)
-        assert node.destroy_node()
+        node.destroy_node()
     finally:
         rclpy.shutdown(context=context)
 
@@ -33,8 +33,9 @@ def test_destroy_node_twice():
     rclpy.init(context=context)
     try:
         node = rclpy.create_node('test_node2', context=context)
-        assert node.destroy_node()
-        assert node.destroy_node()
+        node.destroy_node()
+        with pytest.raises(InvalidHandle):
+            node.destroy_node()
     finally:
         rclpy.shutdown(context=context)
 
@@ -121,5 +122,25 @@ def test_destroy_subscription_asap():
                     pass
         finally:
             node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_destroy_node_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_subscription_asap', context=context)
+        with node.handle:
+            node.destroy_node()
+            # handle valid because it's still being used
+            with node.handle:
+                pass
+
+        with pytest.raises(InvalidHandle):
+            # handle invalid because it was destroyed when no one was using it
+            with node.handle:
+                pass
     finally:
         rclpy.shutdown(context=context)

--- a/rclpy/test/test_handle.py
+++ b/rclpy/test/test_handle.py
@@ -1,0 +1,98 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import rclpy
+from rclpy.handle import InvalidHandle
+
+
+def test_handle_destroyed_immediately():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_handle_destroyed_immediately', context=context)
+        node.handle.destroy()
+        with pytest.raises(InvalidHandle):
+            with node.handle:
+                pass
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_handle_destroyed_when_not_used():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_handle_destroyed_when_not_used', context=context)
+        with node.handle:
+            node.handle.destroy()
+            with node.handle:
+                pass
+
+        with pytest.raises(InvalidHandle):
+            with node.handle:
+                pass
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_handle_destroys_dependents():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node1 = rclpy.create_node('test_handle_destroys_dependents1', context=context)
+        node2 = rclpy.create_node('test_handle_destroys_dependents2', context=context)
+        node2.handle.requires(node1.handle)
+
+        with node1.handle:
+            pass
+        with node2.handle:
+            pass
+
+        node1.handle.destroy()
+        with pytest.raises(InvalidHandle):
+            with node1.handle:
+                pass
+        with pytest.raises(InvalidHandle):
+            with node2.handle:
+                pass
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_handle_does_not_destroy_requirements():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node1 = rclpy.create_node('test_handle_does_not_destroy_requirements1', context=context)
+        node2 = rclpy.create_node('test_handle_does_not_destroy_requirements2', context=context)
+        node2.handle.requires(node1.handle)
+
+        with node1.handle:
+            pass
+        with node2.handle:
+            pass
+
+        node2.handle.destroy()
+        with pytest.raises(InvalidHandle):
+            with node2.handle:
+                pass
+        with node1.handle:
+            pass
+    finally:
+        rclpy.shutdown(context=context)

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -41,8 +41,9 @@ class ClientWaitable(Waitable):
     def __init__(self, node):
         super().__init__(ReentrantCallbackGroup())
 
-        self.client = _rclpy.rclpy_create_client(
-            node.handle, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())[0]
+        with node.handle as node_capsule:
+            self.client = _rclpy.rclpy_create_client(
+                node_capsule, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())[0]
         self.client_index = None
         self.client_is_ready = False
 
@@ -83,8 +84,9 @@ class ServerWaitable(Waitable):
     def __init__(self, node):
         super().__init__(ReentrantCallbackGroup())
 
-        self.server = _rclpy.rclpy_create_service(
-            node.handle, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())[0]
+        with node.handle as node_capsule:
+            self.server = _rclpy.rclpy_create_service(
+                node_capsule, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())[0]
         self.server_index = None
         self.server_is_ready = False
 
@@ -175,8 +177,9 @@ class SubscriptionWaitable(Waitable):
         self.guard_condition_index = None
         self.guard_is_ready = False
 
-        self.subscription = _rclpy.rclpy_create_subscription(
-            node.handle, EmptyMsg, 'test_topic', qos_profile_default.get_c_qos_profile())
+        with node.handle as node_capsule:
+            self.subscription = _rclpy.rclpy_create_subscription(
+                node_capsule, EmptyMsg, 'test_topic', qos_profile_default.get_c_qos_profile())
         self.subscription_index = None
         self.subscription_is_ready = False
 
@@ -311,8 +314,9 @@ class TestWaitable(unittest.TestCase):
 
         server = self.node.create_service(EmptySrv, 'test_client', lambda req, resp: resp)
 
-        while not _rclpy.rclpy_service_server_is_available(self.node.handle, self.waitable.client):
-            time.sleep(0.1)
+        with self.node.handle as node_capsule:
+            while not _rclpy.rclpy_service_server_is_available(node_capsule, self.waitable.client):
+                time.sleep(0.1)
 
         thr = self.start_spin_thread(self.waitable)
         _rclpy.rclpy_send_request(self.waitable.client, EmptySrv.Request())


### PR DESCRIPTION
Blocks #319

I was going to make this part of #319, but I think it would be easier to review separately. This makes `Node.handle` use the `Handle` class from #308. It also adds `handle.requires(another_handle)` to make sure `handle` is destroyed before `another_handle`.

## Problem this solves

#308 makes `destroy_subscription` thread safe by delaying destruction if the handle is currently being used. This makes it possible for a subscription to be destroyed after the node; which crashes when doing the same strategy with services using fast-rtps. See https://github.com/ros2/rclpy/pull/319#issuecomment-486860562 for a better explanation.

## Breaking changes
* Previously `node.destroy_node()` either returned `True` or raised an exception. I removed the return value since it was only ever `True`.
* Previously `node.handle` was set to `None` after the node was destroyed. Now it raises `InvalidHandle` when someone tries to use it after it is destroyed.
* previously `node.handle` was a pycapsule and could be used directly. Now one must use:
   ```python3
   with node.handle as node_capsule:
      ...
   ```

## How handle.requires() works
Subscriptions must be destroyed before the node that created them, so

```
subscription.handle.requires(node.handle)
```

When `node.handle.destroy()` is called the subscription handle is destroyed first. Once the node handle is no longer being used it will mark itself invalid so no one else can use it. Then the node handle tells the subscription handle to destroy itself. Once the subscription handle is no longer in use it will delete itself, and then tell the node it can destroy itself.

If the user does not call `destroy()` on either handle, the subscription handle holds a reference to the node handle so the subscription handle will be garbage collected first. The node handle only holds a weak reference to the subscription handle.


## Next steps

After incorporating feedback, assuming this approach is OK I would like to merge this PR. Then I'll rebase #319 to make all the other entities require the `node` so everything can be destroyed safely.