### PR TITLE
Ignore ValueError in SignalHandlerGuardCondition.__del__

### DIFF
--- a/rclpy/rclpy/signals.py
+++ b/rclpy/rclpy/signals.py
@@ -31,7 +31,7 @@ class SignalHandlerGuardCondition(GuardCondition):
             # already destroyed
             pass
         except ValueError:
-            # ValueError: Guard condition was not registered
+            # Guard condition was not registered
             pass
 
     def destroy(self):

--- a/rclpy/rclpy/signals.py
+++ b/rclpy/rclpy/signals.py
@@ -30,6 +30,9 @@ class SignalHandlerGuardCondition(GuardCondition):
         except InvalidHandle:
             # already destroyed
             pass
+        except ValueError:
+            # ValueError: Guard condition was not registered
+            pass
 
     def destroy(self):
         with self.handle as capsule:


### PR DESCRIPTION
This catches an exception that causes a warning to be printed during interpreter shutdown.

# Steps to reproduce

```
ros2 run examples_rclcpp_minimal_action_server action_server_not_composable
```

```
ros2 action send_goal /fibonacci example_interfaces/Fibonacci '{order: 10}'
```


# expected

```
$ ros2 action send_goal /fibonacci example_interfaces/Fibonacci '{order: 10}'
Waiting for an action server to become available...
Sending goal:
     order: 10

Goal accepted with ID: 7569e0d6d7624a59b80bd1960ce5c8ee

Result:
    sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]

Goal finished with status: SUCCEEDED
```

# actual

```
$ ros2 action send_goal /fibonacci example_interfaces/Fibonacci '{order: 10}'
Waiting for an action server to become available...
Sending goal:
     order: 10

Goal accepted with ID: 88ed3bca54be425b981be303eee95c27

Result:
    sequence: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]

Goal finished with status: SUCCEEDED
Canceling goal...
Failed to cancel goal
Exception ignored in: <bound method SignalHandlerGuardCondition.__del__ of <rclpy.signals.SignalHandlerGuardCondition object at 0x7f761c19c748>>
Traceback (most recent call last):
  File "/home/sloretz/ws/ros2/install/rclpy/lib/python3.6/site-packages/rclpy/signals.py", line 29, in __del__
  File "/home/sloretz/ws/ros2/install/rclpy/lib/python3.6/site-packages/rclpy/signals.py", line 36, in destroy
ValueError: Guard condition was not registered
```