### PR TITLE
Remove extra references to node handle

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -32,7 +32,6 @@ SrvTypeResponse = TypeVar('SrvTypeResponse')
 class Client:
     def __init__(
         self,
-        node_handle,
         context: Context,
         client_handle,
         srv_type: SrvType,
@@ -46,8 +45,6 @@ class Client:
         .. warning:: Users should not create a service client with this constuctor, instead they
            should call :meth:`.Node.create_client`.
 
-        :param node_handle: Capsule pointing to the ``rcl_node_t`` object for the node associated
-            with the service client.
         :param context: The context associated with the service client.
         :param client_handle: :class:`Handle` wrapping the underlying ``rcl_client_t`` object.
         :param srv_type: The service type.
@@ -56,7 +53,6 @@ class Client:
         :param callback_group: The callback group for the service client. If ``None``, then the
             nodes default callback group is used.
         """
-        self.node_handle = node_handle
         self.context = context
         self.__handle = client_handle
         self.srv_type = srv_type
@@ -144,8 +140,8 @@ class Client:
 
         :return: ``True`` if a server is ready, ``False`` otherwise.
         """
-        with self.handle as capsule, self.node_handle as node_capsule:
-            return _rclpy.rclpy_service_server_is_available(node_capsule, capsule)
+        with self.handle as capsule:
+            return _rclpy.rclpy_service_server_is_available(capsule)
 
     def wait_for_service(self, timeout_sec: float = None) -> bool:
         """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -415,7 +415,7 @@ class Node:
         publisher_handle = Handle(publisher_capsule)
         publisher_handle.requires(self.handle)
 
-        publisher = Publisher(publisher_handle, msg_type, topic, qos_profile, self.handle)
+        publisher = Publisher(publisher_handle, msg_type, topic, qos_profile)
         self.__publishers.append(publisher)
         return publisher
 
@@ -503,7 +503,7 @@ class Node:
         client_handle.requires(self.handle)
 
         client = Client(
-            self.handle, self.context,
+            self.context,
             client_handle, srv_type, srv_name, qos_profile,
             callback_group)
         self.__clients.append(client)
@@ -550,7 +550,7 @@ class Node:
         service_handle.requires(self.handle)
 
         service = Service(
-            self.handle, service_handle,
+            service_handle,
             srv_type, srv_name, callback, callback_group, qos_profile)
         self.__services.append(service)
         callback_group.add_entity(service)

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -28,7 +28,6 @@ class Publisher:
         msg_type: MsgType,
         topic: str,
         qos_profile: QoSProfile,
-        node_handle
     ) -> None:
         """
         Create a container for a ROS publisher.
@@ -43,14 +42,11 @@ class Publisher:
         :param msg_type: The type of ROS messages the publisher will publish.
         :param topic: The name of the topic the publisher will publish to.
         :param qos_profile: The quality of service profile to apply to the publisher.
-        :param node_handle: Capsule pointing to the ``rcl_node_t`` object for the node the
-            publisher is associated with.
         """
         self.__handle = publisher_handle
         self.msg_type = msg_type
         self.topic = topic
         self.qos_profile = qos_profile
-        self.node_handle = node_handle
 
     def publish(self, msg: MsgType) -> None:
         """

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -28,7 +28,6 @@ SrvTypeResponse = TypeVar('SrvTypeResponse')
 class Service:
     def __init__(
         self,
-        node_handle,
         service_handle,
         srv_type: SrvType,
         srv_name: str,
@@ -42,8 +41,6 @@ class Service:
         .. warning:: Users should not create a service server with this constuctor, instead they
            should call :meth:`.Node.create_service`.
 
-        :param node_handle: Capsule pointing to the ``rcl_node_t`` object for the node associated
-            with the service server.
         :param context: The context associated with the service server.
         :param service_handle: Capsule pointing to the underlying ``rcl_service_t`` object.
         :param srv_type: The service type.
@@ -52,7 +49,6 @@ class Service:
             nodes default callback group is used.
         :param qos_profile: The quality of service profile to apply the service server.
         """
-        self.node_handle = node_handle
         self.__handle = service_handle
         self.srv_type = srv_type
         self.srv_name = srv_name

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2255,31 +2255,25 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
 /**
  * Raises ValueError if the arguments are not capsules
  *
- * \param[in] pynode Capsule pointing to the node the entity belongs to
  * \param[in] pyclient Capsule pointing to the client
  * \return True if the service server is available
  */
 static PyObject *
 rclpy_service_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
 {
-  PyObject * pynode;
   PyObject * pyclient;
 
-  if (!PyArg_ParseTuple(args, "OO", &pynode, &pyclient)) {
+  if (!PyArg_ParseTuple(args, "O", &pyclient)) {
     return NULL;
   }
 
-  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, "rcl_node_t");
-  if (!node) {
-    return NULL;
-  }
   rclpy_client_t * client = (rclpy_client_t *)PyCapsule_GetPointer(pyclient, "rclpy_client_t");
   if (!client) {
     return NULL;
   }
 
   bool is_ready;
-  rcl_ret_t ret = rcl_service_server_is_available(node, &(client->client), &is_ready);
+  rcl_ret_t ret = rcl_service_server_is_available(client->node, &(client->client), &is_ready);
 
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -310,9 +310,8 @@ class TestWaitable(unittest.TestCase):
 
         server = self.node.create_service(EmptySrv, 'test_client', lambda req, resp: resp)
 
-        with self.node.handle as node_capsule:
-            while not _rclpy.rclpy_service_server_is_available(node_capsule, self.waitable.client):
-                time.sleep(0.1)
+        while not _rclpy.rclpy_service_server_is_available(self.waitable.client):
+            time.sleep(0.1)
 
         thr = self.start_spin_thread(self.waitable)
         _rclpy.rclpy_send_request(self.waitable.client, EmptySrv.Request())


### PR DESCRIPTION
After #319 entities don't need a reference to the node handle. The entity's pycapsule has the pointer already. This PR removes the extra references.