### PR TITLE
Wake executor when entities created or destroyed

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -186,6 +186,7 @@ if(BUILD_TESTING)
     test/test_client.py
     test/test_clock.py
     test/test_create_node.py
+    test/test_create_while_spinning.py
     test/test_destruction.py
     test/test_executor.py
     test/test_expand_topic_name.py

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -253,6 +253,15 @@ class Executor:
                 # Rebuild the wait set so it doesn't include this node
                 self._guard.trigger()
 
+    def wake(self) -> None:
+        """
+        Wake the executor because something changed.
+
+        This is used to tell the executor when entities are created or destroyed.
+        """
+        if self._guard:
+            self._guard.trigger()
+
     def get_nodes(self) -> List['Node']:
         """Return nodes that have been added to this executor."""
         with self._nodes_lock:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -210,6 +210,11 @@ class Node:
             new_executor.add_node(self)
             self.__executor_weakref = weakref.ref(new_executor)
 
+    def _wake_executor(self):
+        executor = self.executor
+        if executor:
+            executor.wake()
+
     @property
     def context(self) -> Context:
         """Get the context associated with the node."""
@@ -376,6 +381,7 @@ class Node:
         :param waitable: An instance of a waitable that the node will add to the waitset.
         """
         self.__waitables.append(waitable)
+        self._wake_executor()
 
     def remove_waitable(self, waitable: Waitable) -> None:
         """
@@ -384,6 +390,7 @@ class Node:
         :param waitable: The Waitable to remove.
         """
         self.__waitables.remove(waitable)
+        self._wake_executor()
 
     def create_publisher(
         self,
@@ -417,6 +424,7 @@ class Node:
 
         publisher = Publisher(publisher_handle, msg_type, topic, qos_profile, self.handle)
         self.__publishers.append(publisher)
+        self._wake_executor()
         return publisher
 
     def create_subscription(
@@ -464,6 +472,7 @@ class Node:
             topic, callback, callback_group, qos_profile, raw)
         self.__subscriptions.append(subscription)
         callback_group.add_entity(subscription)
+        self._wake_executor()
         return subscription
 
     def create_client(
@@ -508,6 +517,7 @@ class Node:
             callback_group)
         self.__clients.append(client)
         callback_group.add_entity(client)
+        self._wake_executor()
         return client
 
     def create_service(
@@ -554,6 +564,7 @@ class Node:
             srv_type, srv_name, callback, callback_group, qos_profile)
         self.__services.append(service)
         callback_group.add_entity(service)
+        self._wake_executor()
         return service
 
     def create_timer(
@@ -581,6 +592,7 @@ class Node:
 
         self.__timers.append(timer)
         callback_group.add_entity(timer)
+        self._wake_executor()
         return timer
 
     def create_guard_condition(
@@ -596,6 +608,7 @@ class Node:
 
         self.__guards.append(guard)
         callback_group.add_entity(guard)
+        self._wake_executor()
         return guard
 
     def destroy_publisher(self, publisher: Publisher) -> bool:
@@ -610,6 +623,7 @@ class Node:
                 publisher.destroy()
             except InvalidHandle:
                 return False
+            self._wake_executor()
             return True
         return False
 
@@ -625,6 +639,7 @@ class Node:
                 subscription.destroy()
             except InvalidHandle:
                 return False
+            self._wake_executor()
             return True
         return False
 
@@ -640,6 +655,7 @@ class Node:
                 client.destroy()
             except InvalidHandle:
                 return False
+            self._wake_executor()
             return True
         return False
 
@@ -655,6 +671,7 @@ class Node:
                 service.destroy()
             except InvalidHandle:
                 return False
+            self._wake_executor()
             return True
         return False
 
@@ -670,6 +687,7 @@ class Node:
                 timer.destroy()
             except InvalidHandle:
                 return False
+            self._wake_executor()
             return True
         return False
 
@@ -685,6 +703,7 @@ class Node:
                 guard.destroy()
             except InvalidHandle:
                 return False
+            self._wake_executor()
             return True
         return False
 
@@ -713,6 +732,7 @@ class Node:
         self.__timers.clear()
         self.__guards.clear()
         self.handle.destroy()
+        self._wake_executor()
 
     def get_publisher_names_and_types_by_node(
         self,

--- a/rclpy/test/test_create_while_spinning.py
+++ b/rclpy/test/test_create_while_spinning.py
@@ -1,0 +1,119 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+import unittest
+
+import rclpy
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.waitable import NumberOfEntities
+from rclpy.waitable import Waitable
+from test_msgs.msg import BasicTypes
+from test_msgs.srv import BasicTypes as BasicTypesSrv
+
+
+# Arbitrary sleep time
+TIMEOUT = 0.5
+
+
+class TestCreateWhileSpinning(unittest.TestCase):
+    """
+    Test that the executor wakes after an entity is created.
+
+    This is a regression test for ros2/rclpy#188.
+    """
+
+    def setUp(self):
+        rclpy.init()
+        self.node = rclpy.create_node('TestCreateWhileSpinning', namespace='/rclpy')
+        self.executor = SingleThreadedExecutor()
+        self.executor.add_node(self.node)
+        self.exec_thread = threading.Thread(target=self.executor.spin)
+        self.exec_thread.start()
+        # Make sure executor is blocked by rcl_wait
+        time.sleep(TIMEOUT)
+
+    def tearDown(self):
+        self.executor.shutdown()
+        self.node.destroy_node()
+        rclpy.shutdown()
+        self.exec_thread.join()
+
+    def test_publish_subscribe(self):
+        evt = threading.Event()
+        sub = self.node.create_subscription(BasicTypes, 'foo', lambda msg: evt.set())
+        pub = self.node.create_publisher(BasicTypes, 'foo')
+        pub.publish(BasicTypes())
+        assert evt.wait(TIMEOUT)
+
+    def test_client_server(self):
+        evt = threading.Event()
+
+        def trigger_event(req, resp):
+            nonlocal evt
+            evt.set()
+            return resp
+
+        srv = self.node.create_service(BasicTypesSrv, 'foo', trigger_event)
+        cli = self.node.create_client(BasicTypesSrv, 'foo')
+        cli.wait_for_service()
+        cli.call_async(BasicTypesSrv.Request())
+        assert evt.wait(TIMEOUT)
+
+    def test_guard_condition(self):
+        evt = threading.Event()
+
+        guard = self.node.create_guard_condition(lambda: evt.set())
+        guard.trigger()
+        assert evt.wait(TIMEOUT)
+
+    def test_timer(self):
+        evt = threading.Event()
+
+        tmr = self.node.create_timer(TIMEOUT / 10, lambda: evt.set())
+        assert evt.wait(TIMEOUT)
+
+    def test_waitable(self):
+        evt = threading.Event()
+
+        class DummyWaitable(Waitable):
+
+            def __init__(self):
+                super().__init__(ReentrantCallbackGroup())
+
+            def is_ready(self, wait_set):
+                return False
+
+            def take_data(self):
+                return None
+
+            async def execute(self, taken_data):
+                pass
+
+            def get_num_entities(self):
+                return NumberOfEntities(0, 0, 0, 0, 0)
+
+            def add_to_wait_set(self, wait_set):
+                nonlocal evt
+                evt.set()
+                pass
+
+        self.node.add_waitable(DummyWaitable())
+        assert evt.wait(TIMEOUT)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_create_while_spinning.py
+++ b/rclpy/test/test_create_while_spinning.py
@@ -54,7 +54,7 @@ class TestCreateWhileSpinning(unittest.TestCase):
 
     def test_publish_subscribe(self):
         evt = threading.Event()
-        sub = self.node.create_subscription(BasicTypes, 'foo', lambda msg: evt.set())
+        self.node.create_subscription(BasicTypes, 'foo', lambda msg: evt.set())
         pub = self.node.create_publisher(BasicTypes, 'foo')
         pub.publish(BasicTypes())
         assert evt.wait(TIMEOUT)
@@ -67,7 +67,7 @@ class TestCreateWhileSpinning(unittest.TestCase):
             evt.set()
             return resp
 
-        srv = self.node.create_service(BasicTypesSrv, 'foo', trigger_event)
+        self.node.create_service(BasicTypesSrv, 'foo', trigger_event)
         cli = self.node.create_client(BasicTypesSrv, 'foo')
         cli.wait_for_service()
         cli.call_async(BasicTypesSrv.Request())
@@ -83,7 +83,7 @@ class TestCreateWhileSpinning(unittest.TestCase):
     def test_timer(self):
         evt = threading.Event()
 
-        tmr = self.node.create_timer(TIMEOUT / 10, lambda: evt.set())
+        self.node.create_timer(TIMEOUT / 10, lambda: evt.set())
         assert evt.wait(TIMEOUT)
 
     def test_waitable(self):


### PR DESCRIPTION
Replaces #206 
Fixes #188 

This wakes the executor when entities are created or destroyed. I added tests for creating entities waking the executor, but I haven't figured out how to add tests for destroying entities waking the executor.

This was unblocked by #308 which made it possible to write a test for creating entities.