### PR TITLE
Fix assert_liveliness use of node and publisher capsules

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1149,4 +1149,5 @@ class Node:
         If the QoS Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE, the
         application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
         """
-        _rclpy.rclpy_assert_liveliness(self.node_handle)
+        with self.handle as capsule:
+            _rclpy.rclpy_assert_liveliness(capsule)

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -75,4 +75,5 @@ class Publisher:
         If the QoS Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC, the
         application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
         """
-        _rclpy.rclpy_assert_liveliness(self.publisher_handle)
+        with self.handle as capsule:
+            _rclpy.rclpy_assert_liveliness(capsule)


### PR DESCRIPTION
I overlooked this when merging #313. The publisher and node pycapsules are managed by `self.handle` instead of using `node_handle` and `publisher_handle`.

There are no tests for these APIs at the moment.