### PR TITLE
Ignore flake8 error 'imported but unused'

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -48,15 +48,15 @@ from rclpy.context import Context
 from rclpy.parameter import Parameter
 from rclpy.task import Future
 from rclpy.utilities import get_default_context
-from rclpy.utilities import get_rmw_implementation_identifier  # noqa
-from rclpy.utilities import ok  # noqa: forwarding to this module
+from rclpy.utilities import get_rmw_implementation_identifier  # noqa: F401
+from rclpy.utilities import ok  # noqa: F401 forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
-from rclpy.utilities import try_shutdown  # noqa
+from rclpy.utilities import try_shutdown  # noqa: F401
 
 # Avoid loading extensions on module import
 if TYPE_CHECKING:
-    from rclpy.executors import Executor
-    from rclpy.node import Node
+    from rclpy.executors import Executor  # noqa: F401
+    from rclpy.node import Node  # noqa: F401
 
 
 def init(*, args: List[str] = None, context: Context = None) -> None:

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -134,7 +134,7 @@ def create_node(
     :return: An instance of the newly created node.
     """
     # imported locally to avoid loading extensions on module import
-    from rclpy.node import Node
+    from rclpy.node import Node  # noqa: F811
     return Node(
         node_name, context=context, cli_args=cli_args, namespace=namespace,
         use_global_arguments=use_global_arguments,

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -55,7 +55,7 @@ WaitableEntityType = TypeVar('WaitableEntityType')
 
 # Avoid import cycle
 if TYPE_CHECKING:
-    from rclpy.node import Node
+    from rclpy.node import Node  # noqa: F401
 
 
 class _WaitSet:


### PR DESCRIPTION
Fixes http://build.ros2.org/job/Ddev__rclpy__ubuntu_bionic_amd64/27/testReport/

Build up to rclpy; test rclpy:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7038)](http://ci.ros2.org/job/ci_linux/7038/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3272)](http://ci.ros2.org/job/ci_linux-aarch64/3272/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5767)](http://ci.ros2.org/job/ci_osx/5767/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6858)](http://ci.ros2.org/job/ci_windows/6858/)