### PR TITLE
Encourage users to always provide a QoS history depth

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -23,7 +23,8 @@ from action_msgs.srv import CancelGoal
 from rclpy.executors import await_or_execute
 from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
 from rclpy.qos import qos_profile_action_status_default
-from rclpy.qos import qos_profile_default, qos_profile_services_default
+from rclpy.qos import qos_profile_services_default
+from rclpy.qos import QoSProfile
 from rclpy.task import Future
 from rclpy.type_support import check_for_type_support
 from rclpy.waitable import NumberOfEntities, Waitable
@@ -120,7 +121,7 @@ class ActionClient(Waitable):
         goal_service_qos_profile=qos_profile_services_default,
         result_service_qos_profile=qos_profile_services_default,
         cancel_service_qos_profile=qos_profile_services_default,
-        feedback_sub_qos_profile=qos_profile_default,
+        feedback_sub_qos_profile=QoSProfile(depth=10),
         status_sub_qos_profile=qos_profile_action_status_default
     ):
         """

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -21,7 +21,8 @@ from action_msgs.msg import GoalInfo, GoalStatus
 from rclpy.executors import await_or_execute
 from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
 from rclpy.qos import qos_profile_action_status_default
-from rclpy.qos import qos_profile_default, qos_profile_services_default
+from rclpy.qos import qos_profile_services_default
+from rclpy.qos import QoSProfile
 from rclpy.task import Future
 from rclpy.type_support import check_for_type_support
 from rclpy.waitable import NumberOfEntities, Waitable
@@ -203,7 +204,7 @@ class ActionServer(Waitable):
         goal_service_qos_profile=qos_profile_services_default,
         result_service_qos_profile=qos_profile_services_default,
         cancel_service_qos_profile=qos_profile_services_default,
-        feedback_pub_qos_profile=qos_profile_default,
+        feedback_pub_qos_profile=QoSProfile(depth=10),
         status_pub_qos_profile=qos_profile_action_status_default,
         result_timeout=900
     ):

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -50,6 +50,7 @@ from rclpy.logging import get_logger
 from rclpy.parameter import Parameter
 from rclpy.parameter_service import ParameterService
 from rclpy.publisher import Publisher
+from rclpy.qos import DeprecatedQoSProfile
 from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_services_default
@@ -679,6 +680,10 @@ class Node:
 
     def _validate_qos_or_depth_parameter(self, qos_or_depth) -> QoSProfile:
         if isinstance(qos_or_depth, QoSProfile):
+            if isinstance(qos_or_depth, DeprecatedQoSProfile):
+                warnings.warn(
+                    "Using deprecated QoSProfile '{qos_or_depth.name}'".format_map(locals()),
+                    DeprecationWarning)
             return qos_or_depth
         elif isinstance(qos_or_depth, int):
             if qos_or_depth < 0:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -682,8 +682,7 @@ class Node:
         if isinstance(qos_or_depth, QoSProfile):
             if isinstance(qos_or_depth, DeprecatedQoSProfile):
                 warnings.warn(
-                    "Using deprecated QoSProfile '{qos_or_depth.name}'".format_map(locals()),
-                    DeprecationWarning)
+                    "Using deprecated QoSProfile '{qos_or_depth.name}'".format_map(locals()))
             return qos_or_depth
         elif isinstance(qos_or_depth, int):
             if qos_or_depth < 0:
@@ -740,7 +739,7 @@ class Node:
         """
         # if the new API is not used, issue a deprecation warning and continue with the old API
         if qos_or_depth is None:
-            warnings.warn("Use the new 'qos_or_depth' parameter", DeprecationWarning)
+            warnings.warn("Use the new 'qos_or_depth' parameter, instead of 'qos_profile'")
         else:
             qos_profile = self._validate_qos_or_depth_parameter(qos_or_depth)
 
@@ -807,7 +806,7 @@ class Node:
         """
         # if the new API is not used, issue a deprecation warning and continue with the old API
         if qos_or_depth is None:
-            warnings.warn("Use the new 'qos_or_depth' parameter", DeprecationWarning)
+            warnings.warn("Use the new 'qos_or_depth' parameter, instead of 'qos_profile'")
         else:
             qos_profile = self._validate_qos_or_depth_parameter(qos_or_depth)
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -163,7 +163,7 @@ class Node:
         self.__executor_weakref = None
 
         self._parameter_event_publisher = self.create_publisher(
-            ParameterEvent, 'parameter_events', qos_profile=qos_profile_parameter_events)
+            ParameterEvent, 'parameter_events', qos_profile_parameter_events)
 
         with self.handle as capsule:
             self._initial_parameters = _rclpy.rclpy_get_node_parameters(Parameter, capsule)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -53,7 +53,6 @@ from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_services_default
-from rclpy.qos import QoSHistoryPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
 from rclpy.qos_event import SubscriptionEventCallbacks
@@ -684,9 +683,7 @@ class Node:
         elif isinstance(qos_or_depth, int):
             if qos_or_depth < 0:
                 raise ValueError('history depth must be greater than or equal to zero')
-            return QoSProfile(
-                history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
-                depth=qos_or_depth)
+            return QoSProfile(depth=qos_or_depth)
         else:
             raise TypeError(
                 'Expected QoSProfile or int, but received {!r}'.format(type(qos_or_depth)))

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -51,7 +51,6 @@ from rclpy.parameter import Parameter
 from rclpy.parameter_service import ParameterService
 from rclpy.publisher import Publisher
 from rclpy.qos import DeprecatedQoSProfile
-from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
@@ -716,7 +715,7 @@ class Node:
         topic: str,
         qos_or_depth: Union[QoSProfile, int] = None,
         *,
-        qos_profile: QoSProfile = qos_profile_default,
+        qos_profile: QoSProfile = QoSProfile(depth=10),
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[PublisherEventCallbacks] = None,
     ) -> Publisher:
@@ -779,7 +778,7 @@ class Node:
         callback: Callable[[MsgType], None],
         qos_or_depth: Union[QoSProfile, int] = None,
         *,
-        qos_profile: QoSProfile = qos_profile_default,
+        qos_profile: QoSProfile = QoSProfile(depth=10),
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[SubscriptionEventCallbacks] = None,
         raw: bool = False

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -44,7 +44,8 @@ class QoSProfile:
             else:
                 warnings.warn(
                     "QoSProfile needs a 'history' and/or 'depth' setting when constructed",
-                    DeprecationWarning)
+                    DeprecationWarning,
+                    stacklevel=2)
         self.history = kwargs.get(
             'history',
             QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT)
@@ -54,7 +55,8 @@ class QoSProfile:
         ):
             warnings.warn(
                 'A QoSProfile with history set to KEEP_LAST needs a depth specified',
-                DeprecationWarning)
+                DeprecationWarning,
+                stacklevel=2)
         self.depth = kwargs.get('depth', int())
         self.reliability = kwargs.get(
             'reliability',
@@ -277,8 +279,25 @@ class QoSLivelinessPolicy(IntEnum):
     RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC = 3
 
 
-qos_profile_default = _rclpy.rclpy_get_rmw_qos_profile(
+class DeprecatedQoSProfile(QoSProfile):
+
+    def __init__(self, qos_profile: QoSProfile, profile_name: str):
+        super().__init__(
+            history=qos_profile.history,
+            depth=qos_profile.depth,
+            reliability=qos_profile.reliability,
+            durability=qos_profile.durability,
+            lifespan=qos_profile.lifespan,
+            deadline=qos_profile.deadline,
+            liveliness=qos_profile.liveliness,
+            liveliness_lease_duration=qos_profile.liveliness_lease_duration,
+            avoid_ros_namespace_conventions=qos_profile.avoid_ros_namespace_conventions)
+        self.name = profile_name
+
+
+__qos_profile_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_default')
+qos_profile_default = DeprecatedQoSProfile(__qos_profile_default, 'qos_profile_default')
 qos_profile_system_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_system_default')
 qos_profile_sensor_data = _rclpy.rclpy_get_rmw_qos_profile(

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -39,8 +39,12 @@ class QoSProfile:
         assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
             'Invalid arguments passed to constructor: %r' % kwargs.keys()
         if 'history' not in kwargs:
-            warnings.warn(
-                "QoSProfile needs a 'history' setting when constructed", DeprecationWarning)
+            if 'depth' in kwargs:
+                kwargs['history'] = QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST
+            else:
+                warnings.warn(
+                    "QoSProfile needs a 'history' and/or 'depth' setting when constructed",
+                    DeprecationWarning)
         self.history = kwargs.get(
             'history',
             QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT)

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -44,7 +44,6 @@ class QoSProfile:
             else:
                 warnings.warn(
                     "QoSProfile needs a 'history' and/or 'depth' setting when constructed",
-                    DeprecationWarning,
                     stacklevel=2)
         self.history = kwargs.get(
             'history',
@@ -55,7 +54,6 @@ class QoSProfile:
         ):
             warnings.warn(
                 'A QoSProfile with history set to KEEP_LAST needs a depth specified',
-                DeprecationWarning,
                 stacklevel=2)
         self.depth = kwargs.get('depth', int())
         self.reliability = kwargs.get(

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from enum import IntEnum
+import warnings
 
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
@@ -37,9 +38,19 @@ class QoSProfile:
     def __init__(self, **kwargs):
         assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
             'Invalid arguments passed to constructor: %r' % kwargs.keys()
+        if 'history' not in kwargs:
+            warnings.warn(
+                "QoSProfile needs a 'history' setting when constructed", DeprecationWarning)
         self.history = kwargs.get(
             'history',
             QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT)
+        if (
+            QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST == self.history and
+            'depth' not in kwargs
+        ):
+            warnings.warn(
+                'A QoSProfile with history set to KEEP_LAST needs a depth specified',
+                DeprecationWarning)
         self.depth = kwargs.get('depth', int())
         self.reliability = kwargs.get(
             'reliability',

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -57,7 +57,8 @@ class TimeSource:
             self._clock_sub = self._node.create_subscription(
                 rosgraph_msgs.msg.Clock,
                 CLOCK_TOPIC,
-                self.clock_callback
+                self.clock_callback,
+                10
             )
 
     def attach_node(self, node):

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -98,11 +98,11 @@ class TestActionClient(unittest.TestCase):
             self.node,
             Fibonacci,
             'fibonacci',
-            goal_service_qos_profile=rclpy.qos.qos_profile_default,
-            result_service_qos_profile=rclpy.qos.qos_profile_default,
-            cancel_service_qos_profile=rclpy.qos.qos_profile_default,
-            feedback_sub_qos_profile=rclpy.qos.qos_profile_default,
-            status_sub_qos_profile=rclpy.qos.qos_profile_default
+            goal_service_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            result_service_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            cancel_service_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            feedback_sub_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            status_sub_qos_profile=rclpy.qos.QoSProfile(depth=10)
         )
         ac.destroy()
 

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -43,7 +43,7 @@ class MockActionServer():
             Fibonacci.Impl.GetResultService, '/fibonacci/_action/get_result',
             self.result_callback)
         self.feedback_pub = node.create_publisher(
-            Fibonacci.Impl.FeedbackMessage, '/fibonacci/_action/feedback')
+            Fibonacci.Impl.FeedbackMessage, '/fibonacci/_action/feedback', 1)
 
     def goal_callback(self, request, response):
         response.accepted = True

--- a/rclpy/test/test_action_server.py
+++ b/rclpy/test/test_action_server.py
@@ -40,9 +40,12 @@ class MockActionClient():
         self.result_srv = node.create_client(
             Fibonacci.Impl.GetResultService, '/fibonacci/_action/get_result')
         self.feedback_sub = node.create_subscription(
-            Fibonacci.Impl.FeedbackMessage, '/fibonacci/_action/feedback', self.feedback_callback)
+            Fibonacci.Impl.FeedbackMessage,
+            '/fibonacci/_action/feedback',
+            self.feedback_callback,
+            1)
         self.status_sub = node.create_subscription(
-            Fibonacci.Impl.GoalStatusMessage, '/fibonacci/_action/status', self.status_callback)
+            Fibonacci.Impl.GoalStatusMessage, '/fibonacci/_action/status', self.status_callback, 1)
 
     def reset(self):
         self.feedback_msg = None

--- a/rclpy/test/test_action_server.py
+++ b/rclpy/test/test_action_server.py
@@ -112,11 +112,11 @@ class TestActionServer(unittest.TestCase):
             goal_callback=lambda req: GoalResponse.REJECT,
             handle_accepted_callback=lambda gh: None,
             cancel_callback=lambda req: CancelResponse.REJECT,
-            goal_service_qos_profile=rclpy.qos.qos_profile_default,
-            result_service_qos_profile=rclpy.qos.qos_profile_default,
-            cancel_service_qos_profile=rclpy.qos.qos_profile_default,
-            feedback_pub_qos_profile=rclpy.qos.qos_profile_default,
-            status_pub_qos_profile=rclpy.qos.qos_profile_default,
+            goal_service_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            result_service_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            cancel_service_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            feedback_pub_qos_profile=rclpy.qos.QoSProfile(depth=10),
+            status_pub_qos_profile=rclpy.qos.QoSProfile(depth=10),
             result_timeout=300,
         )
         action_server.destroy()

--- a/rclpy/test/test_callback_group.py
+++ b/rclpy/test/test_callback_group.py
@@ -71,10 +71,10 @@ class TestCallbackGroup(unittest.TestCase):
         self.assertTrue(group.has_entity(tmr2))
 
     def test_create_subscription_with_group(self):
-        sub1 = self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg))
+        sub1 = self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 1)
         group = ReentrantCallbackGroup()
         sub2 = self.node.create_subscription(
-            BasicTypes, 'chatter', lambda msg: print(msg), callback_group=group)
+            BasicTypes, 'chatter', lambda msg: print(msg), 1, callback_group=group)
 
         self.assertFalse(group.has_entity(sub1))
         self.assertTrue(group.has_entity(sub2))

--- a/rclpy/test/test_create_while_spinning.py
+++ b/rclpy/test/test_create_while_spinning.py
@@ -54,8 +54,8 @@ class TestCreateWhileSpinning(unittest.TestCase):
 
     def test_publish_subscribe(self):
         evt = threading.Event()
-        self.node.create_subscription(BasicTypes, 'foo', lambda msg: evt.set())
-        pub = self.node.create_publisher(BasicTypes, 'foo')
+        self.node.create_subscription(BasicTypes, 'foo', lambda msg: evt.set(), 1)
+        pub = self.node.create_publisher(BasicTypes, 'foo', 1)
         pub.publish(BasicTypes())
         assert evt.wait(TIMEOUT)
 

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -71,16 +71,16 @@ def test_destroy_entities():
             timer = node.create_timer(0.1, None)
             timer  # noqa
             assert 1 == len(tuple(node.timers))
-            pub1 = node.create_publisher(BasicTypes, 'pub1_topic')
+            pub1 = node.create_publisher(BasicTypes, 'pub1_topic', 1)
             assert 2 == len(tuple(node.publishers))
-            pub2 = node.create_publisher(BasicTypes, 'pub2_topic')
+            pub2 = node.create_publisher(BasicTypes, 'pub2_topic', 1)
             pub2  # noqa
             assert 3 == len(tuple(node.publishers))
             sub1 = node.create_subscription(
-                BasicTypes, 'sub1_topic', lambda msg: ...)
+                BasicTypes, 'sub1_topic', lambda msg: ..., 1)
             assert 1 == len(tuple(node.subscriptions))
             sub2 = node.create_subscription(
-                BasicTypes, 'sub2_topic', lambda msg: ...)
+                BasicTypes, 'sub2_topic', lambda msg: ..., 1)
             sub2  # noqa
             assert 2 == len(tuple(node.subscriptions))
 
@@ -105,7 +105,7 @@ def test_destroy_subscription_asap():
     try:
         node = rclpy.create_node('test_destroy_subscription_asap', context=context)
         try:
-            sub = node.create_subscription(BasicTypes, 'sub_topic', lambda msg: ...)
+            sub = node.create_subscription(BasicTypes, 'sub_topic', lambda msg: ..., 1)
 
             # handle valid
             with sub.handle:
@@ -154,7 +154,7 @@ def test_destroy_publisher_asap():
     try:
         node = rclpy.create_node('test_destroy_publisher_asap', context=context)
         try:
-            pub = node.create_publisher(BasicTypes, 'pub_topic')
+            pub = node.create_publisher(BasicTypes, 'pub_topic', 1)
 
             # handle valid
             with pub.handle:

--- a/rclpy/test/test_messages.py
+++ b/rclpy/test/test_messages.py
@@ -42,11 +42,11 @@ class TestMessages(unittest.TestCase):
     def test_invalid_string_raises(self):
         msg = Strings()
         msg.string_value = 'ñu'
-        pub = self.node.create_publisher(Strings, 'chatter')
+        pub = self.node.create_publisher(Strings, 'chatter', 1)
         with self.assertRaises(UnicodeEncodeError):
             pub.publish(msg)
 
     def test_different_type_raises(self):
-        pub = self.node.create_publisher(BasicTypes, 'chatter')
+        pub = self.node.create_publisher(BasicTypes, 'chatter', 1)
         with self.assertRaises(TypeError):
             pub.publish('different message type')

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -34,6 +34,7 @@ from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
 from test_msgs.msg import BasicTypes
 
+
 TEST_NODE = 'my_node'
 TEST_NAMESPACE = '/my_ns'
 
@@ -142,47 +143,54 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             self.node.create_service(GetParameters, 'foo/{bad_sub}', lambda req: None)
 
     def test_deprecation_warnings(self):
-        warnings.simplefilter('always')
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_publisher(BasicTypes, 'chatter')
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_publisher(BasicTypes, 'chatter', qos_profile=qos_profile_sensor_data)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_publisher(BasicTypes, 'chatter', qos_profile=qos_profile_sensor_data)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_publisher(BasicTypes, 'chatter', qos_profile_default)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg))
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_subscription(
                 BasicTypes, 'chatter', lambda msg: print(msg), qos_profile=qos_profile_sensor_data)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_subscription(
                 BasicTypes, 'chatter', lambda msg: print(msg), qos_profile=qos_profile_sensor_data)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_subscription(
                 BasicTypes, 'chatter', lambda msg: print(msg), qos_profile_default)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), raw=True)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-        warnings.simplefilter('default')
+            assert issubclass(w[0].category, UserWarning)
 
     def test_service_names_and_types(self):
         # test that it doesn't raise

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -30,6 +30,7 @@ from rclpy.exceptions import ParameterAlreadyDeclaredException
 from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.parameter import Parameter
+from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
 from test_msgs.msg import BasicTypes
 
@@ -155,6 +156,10 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
         with warnings.catch_warnings(record=True) as w:
+            self.node.create_publisher(BasicTypes, 'chatter', qos_profile_default)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+        with warnings.catch_warnings(record=True) as w:
             self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg))
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
@@ -166,6 +171,11 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             self.node.create_subscription(
                 BasicTypes, 'chatter', lambda msg: print(msg), qos_profile=qos_profile_sensor_data)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+        with warnings.catch_warnings(record=True) as w:
+            self.node.create_subscription(
+                BasicTypes, 'chatter', lambda msg: print(msg), qos_profile_default)
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
         with warnings.catch_warnings(record=True) as w:

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -34,7 +34,6 @@ from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
 from test_msgs.msg import BasicTypes
 
-
 TEST_NODE = 'my_node'
 TEST_NAMESPACE = '/my_ns'
 
@@ -63,7 +62,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertEqual(self.node.get_clock().clock_type, ClockType.ROS_TIME)
 
     def test_create_publisher(self):
-        self.node.create_publisher(BasicTypes, 'chatter')
         self.node.create_publisher(BasicTypes, 'chatter', 0)
         self.node.create_publisher(BasicTypes, 'chatter', 1)
         self.node.create_publisher(BasicTypes, 'chatter', qos_profile_sensor_data)
@@ -79,7 +77,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             self.node.create_publisher(BasicTypes, 'chatter', 'foo')
 
     def test_create_subscription(self):
-        self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg))
         self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 0)
         self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 1)
         self.node.create_subscription(
@@ -108,6 +105,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             BasicTypes,
             'raw_subscription_test',
             self.raw_subscription_callback,
+            1,
             raw=True
         )
         basic_types_msg = BasicTypes()
@@ -216,15 +214,15 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertEqual(0, self.node.count_publishers(fq_topic_name))
         self.assertEqual(0, self.node.count_subscribers(fq_topic_name))
 
-        self.node.create_publisher(BasicTypes, short_topic_name)
+        self.node.create_publisher(BasicTypes, short_topic_name, 1)
         self.assertEqual(1, self.node.count_publishers(short_topic_name))
         self.assertEqual(1, self.node.count_publishers(fq_topic_name))
 
-        self.node.create_subscription(BasicTypes, short_topic_name, lambda msg: print(msg))
+        self.node.create_subscription(BasicTypes, short_topic_name, lambda msg: print(msg), 1)
         self.assertEqual(1, self.node.count_subscribers(short_topic_name))
         self.assertEqual(1, self.node.count_subscribers(fq_topic_name))
 
-        self.node.create_subscription(BasicTypes, short_topic_name, lambda msg: print(msg))
+        self.node.create_subscription(BasicTypes, short_topic_name, lambda msg: print(msg), 1)
         self.assertEqual(2, self.node.count_subscribers(short_topic_name))
         self.assertEqual(2, self.node.count_subscribers(fq_topic_name))
 

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -94,25 +94,29 @@ class TestQosProfile(unittest.TestCase):
         self.convert_and_assert_equality(source_profile)
 
     def test_deprecation_warnings(self):
-        warnings.simplefilter('always')
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             QoSProfile()
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             # No deprecation if history is supplied
             QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL)
             assert len(w) == 0, str(w[-1].message)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             # Deprecation warning if KEEP_LAST, but no depth
             QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST)
             assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             # No deprecation if 'depth' is present
             QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=1)
             assert len(w) == 0, str(w[-1].message)
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             # No deprecation if only depth
             QoSProfile(depth=1)
             assert len(w) == 0, str(w[-1].message)

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -31,6 +31,11 @@ class TestQosProfile(unittest.TestCase):
         converted_profile = _rclpy.rclpy_convert_to_py_qos_policy(c_profile)
         self.assertEqual(qos_profile, converted_profile)
 
+    def test_depth_only_constructor(self):
+        qos = QoSProfile(depth=1)
+        assert qos.depth == 1
+        assert qos.history == QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST
+
     def test_eq_operator(self):
         profile_1 = QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=1)
         profile_same = QoSProfile(
@@ -106,4 +111,8 @@ class TestQosProfile(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             # No deprecation if 'depth' is present
             QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=1)
+            assert len(w) == 0, str(w[-1].message)
+        with warnings.catch_warnings(record=True) as w:
+            # No deprecation if only depth
+            QoSProfile(depth=1)
             assert len(w) == 0, str(w[-1].message)

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -46,7 +46,7 @@ class TestTimeSource(unittest.TestCase):
         rclpy.shutdown(context=self.context)
 
     def publish_clock_messages(self):
-        clock_pub = self.node.create_publisher(rosgraph_msgs.msg.Clock, CLOCK_TOPIC)
+        clock_pub = self.node.create_publisher(rosgraph_msgs.msg.Clock, CLOCK_TOPIC, 1)
         cycle_count = 0
         time_msg = rosgraph_msgs.msg.Clock()
         while rclpy.ok(context=self.context) and cycle_count < 5:
@@ -59,7 +59,7 @@ class TestTimeSource(unittest.TestCase):
             time.sleep(1)
 
     def publish_reversed_clock_messages(self):
-        clock_pub = self.node.create_publisher(rosgraph_msgs.msg.Clock, CLOCK_TOPIC)
+        clock_pub = self.node.create_publisher(rosgraph_msgs.msg.Clock, CLOCK_TOPIC, 1)
         cycle_count = 0
         time_msg = rosgraph_msgs.msg.Clock()
         while rclpy.ok(context=self.context) and cycle_count < 5:

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -23,7 +23,7 @@ from rclpy.clock import ClockType
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.node import check_for_type_support
-from rclpy.qos import qos_profile_default
+from rclpy.qos import QoSProfile
 from rclpy.task import Future
 from rclpy.waitable import NumberOfEntities
 from rclpy.waitable import Waitable
@@ -43,7 +43,7 @@ class ClientWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.client = _rclpy.rclpy_create_client(
-                node_capsule, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())
+                node_capsule, EmptySrv, 'test_client', QoSProfile(depth=10).get_c_qos_profile())
         self.client_index = None
         self.client_is_ready = False
 
@@ -86,7 +86,7 @@ class ServerWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.server = _rclpy.rclpy_create_service(
-                node_capsule, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())
+                node_capsule, EmptySrv, 'test_server', QoSProfile(depth=10).get_c_qos_profile())
         self.server_index = None
         self.server_is_ready = False
 
@@ -175,7 +175,7 @@ class SubscriptionWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.subscription = _rclpy.rclpy_create_subscription(
-                node_capsule, EmptyMsg, 'test_topic', qos_profile_default.get_c_qos_profile())
+                node_capsule, EmptyMsg, 'test_topic', QoSProfile(depth=10).get_c_qos_profile())
         self.subscription_index = None
         self.subscription_is_ready = False
 

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -349,7 +349,7 @@ class TestWaitable(unittest.TestCase):
     def test_waitable_with_subscription(self):
         self.waitable = SubscriptionWaitable(self.node)
         self.node.add_waitable(self.waitable)
-        pub = self.node.create_publisher(EmptyMsg, 'test_topic')
+        pub = self.node.create_publisher(EmptyMsg, 'test_topic', 1)
 
         thr = self.start_spin_thread(self.waitable)
         pub.publish(EmptyMsg())


### PR DESCRIPTION
Resolves #342 

* Added a new parameter to methods for creating publishers and subscriptions

  The new parameter is required and must be a QoSProfile object or an integer value for the history depth.
  For now, it is possible to not use the parameter for backwards compatibility, but a deprecation warning is made.

* Add deprecation warning when constructing a QoSProfile without a history depth

  If the history setting is KEEP_ALL, then it is not required to pass the depth setting.