### PR TITLE
Parameter handling improvements.

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -96,7 +96,7 @@ class InvalidParameterException(ParameterException):
 
 
 class InvalidParameterValueException(ParameterException):
-    """Raised when a parameter to be declared is rejected by a callback."""
+    """Raised when a parameter is rejected by a user callback or when applying a descriptor."""
 
     def __init__(self, parameter, value, *args):
         Exception.__init__(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -15,7 +15,11 @@
 import unittest
 from unittest.mock import Mock
 
+from rcl_interfaces.msg import FloatingPointRange
+from rcl_interfaces.msg import IntegerRange
+from rcl_interfaces.msg import Parameter as ParameterMsg
 from rcl_interfaces.msg import ParameterDescriptor
+from rcl_interfaces.msg import ParameterType
 from rcl_interfaces.msg import ParameterValue
 from rcl_interfaces.msg import SetParametersResult
 from rcl_interfaces.srv import GetParameters
@@ -26,6 +30,7 @@ from rclpy.exceptions import InvalidParameterValueException
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
 from rclpy.exceptions import ParameterAlreadyDeclaredException
+from rclpy.exceptions import ParameterImmutableException
 from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.parameter import Parameter
@@ -246,6 +251,23 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertIsInstance(result, SetParametersResult)
         self.assertTrue(result.successful)
 
+    def test_describe_undeclared_parameter(self):
+        self.assertFalse(self.node.has_parameter('foo'))
+
+        descriptor = self.node.describe_parameter('foo')
+        self.assertEqual(descriptor, ParameterDescriptor())
+
+    def test_describe_undeclared_parameters(self):
+        self.assertFalse(self.node.has_parameter('foo'))
+        self.assertFalse(self.node.has_parameter('bar'))
+
+        # Check list.
+        descriptor_list = self.node.describe_parameters(['foo', 'bar'])
+        self.assertIsInstance(descriptor_list, list)
+        self.assertEqual(len(descriptor_list), 2)
+        self.assertEqual(descriptor_list[0], ParameterDescriptor())
+        self.assertEqual(descriptor_list[1], ParameterDescriptor())
+
     def test_node_get_parameter(self):
         self.node.set_parameters([Parameter('foo', Parameter.Type.INTEGER, 42)])
         self.assertIsInstance(self.node.get_parameter('foo'), Parameter)
@@ -355,17 +377,17 @@ class TestNode(unittest.TestCase):
                 'reject_me', ParameterValue(
                     type=Parameter.Type.STRING.value, string_value='raise'), ParameterDescriptor())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.node.declare_parameter(
                 1,
                 ParameterValue(type=Parameter.Type.STRING.value, string_value='wrong_name_type'),
                 ParameterDescriptor())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.node.declare_parameter(
                 'wrong_parameter_value_type', 1234, ParameterDescriptor())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.node.declare_parameter(
                 'wrong_parameter_descriptor_type', ParameterValue(), ParameterValue())
 
@@ -449,7 +471,7 @@ class TestNode(unittest.TestCase):
         with self.assertRaises(InvalidParameterValueException):
             self.node.declare_parameters('', parameters)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.node.declare_parameters(
                 '',
                 [(
@@ -460,7 +482,7 @@ class TestNode(unittest.TestCase):
                 )]
             )
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.node.declare_parameters(
                 '',
                 [(
@@ -470,7 +492,7 @@ class TestNode(unittest.TestCase):
                 )]
             )
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.node.declare_parameters(
                 '',
                 [(
@@ -483,6 +505,38 @@ class TestNode(unittest.TestCase):
     def reject_parameter_callback(self, parameter_list):
         rejected_parameters = (param for param in parameter_list if 'reject' in param.name)
         return SetParametersResult(successful=(not any(rejected_parameters)))
+
+    def test_node_undeclare_parameter_has_parameter(self):
+        # Undeclare unexisting parameter.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.undeclare_parameter('foo')
+
+        # Verify that it doesn't exist.
+        self.assertFalse(self.node.has_parameter('foo'))
+
+        # Declare parameter, verify existance, undeclare, and verify again.
+        self.node.declare_parameter(
+            'foo',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+            ParameterDescriptor()
+        )
+        self.assertTrue(self.node.has_parameter('foo'))
+        self.node.undeclare_parameter('foo')
+        self.assertFalse(self.node.has_parameter('foo'))
+
+        # Try with a read only parameter.
+        self.assertFalse(self.node.has_parameter('immutable_foo'))
+        self.node.declare_parameter(
+            'immutable_foo',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='I am immutable'),
+            ParameterDescriptor(read_only=True)
+        )
+        with self.assertRaises(ParameterImmutableException):
+            self.node.undeclare_parameter('immutable_foo')
+
+        # Verify that it still exists with the same value.
+        self.assertTrue(self.node.has_parameter('immutable_foo'))
+        self.assertEqual(self.node.get_parameter('immutable_foo').value, 'I am immutable')
 
     def test_node_set_undeclared_parameters(self):
         with self.assertRaises(ParameterNotDeclaredException):
@@ -509,6 +563,528 @@ class TestNode(unittest.TestCase):
             'initial_foo', Parameter('foo', Parameter.Type.INTEGER, 152))
         self.assertEqual(result.name, 'foo')
         self.assertEqual(result.value, 152)
+
+    def test_node_set_parameters(self):
+        parameter_tuples = [
+            (
+                'foo',
+                ParameterValue(type=Parameter.Type.INTEGER.value, integer_value=42),
+                ParameterDescriptor()
+            ),
+            (
+                'bar',
+                ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+                ParameterDescriptor()
+            ),
+            (
+                'baz',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.41),
+                ParameterDescriptor()
+            )
+        ]
+
+        # Create rclpy.Parameter list from tuples.
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+        ]
+
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_parameters(parameters)
+
+        self.node.declare_parameters('', parameter_tuples)
+        result = self.node.set_parameters(parameters)
+
+        # OK cases: check successful result and parameter value for each parameter set.
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], SetParametersResult)
+        self.assertIsInstance(result[1], SetParametersResult)
+        self.assertIsInstance(result[2], SetParametersResult)
+        self.assertTrue(result[0].successful)
+        self.assertTrue(result[1].successful)
+        self.assertTrue(result[2].successful)
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+        # Now we modify the declared parameters, add a new one and set them again.
+        parameter_tuples[0][1].integer_value = 24
+        parameter_tuples[1][1].string_value = 'bye'
+        parameter_tuples[2][1].double_value = 1.42
+        parameter_tuples.append(
+            (
+                'foobar',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.71),
+                ParameterDescriptor())
+            )
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[3][0], value=parameter_tuples[3][1])),
+        ]
+        # The first three parameters should have been set; the fourth one causes the exception.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_parameters(parameters)
+
+        # Validate first three.
+        self.assertEqual(self.node.get_parameter('foo').value, 24)
+        self.assertEqual(self.node.get_parameter('bar').value, 'bye')
+        self.assertEqual(self.node.get_parameter('baz').value, 1.42)
+
+        # Confirm that the fourth one does not exist.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.get_parameter('foobar')
+
+    def test_node_set_parameters_rejection(self):
+        # Declare a new parameter and set a callback so that it's rejected when set.
+        reject_parameter_tuple = (
+            'reject_me',
+            ParameterValue(type=Parameter.Type.BOOL.value, bool_value=True),
+            ParameterDescriptor()
+        )
+
+        self.node.declare_parameter(*reject_parameter_tuple)
+        self.node.set_parameters_callback(self.reject_parameter_callback)
+        result = self.node.set_parameters(
+            [
+                Parameter.from_parameter_msg(
+                    ParameterMsg(name=reject_parameter_tuple[0], value=reject_parameter_tuple[1]))
+            ]
+        )
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], SetParametersResult)
+        self.assertFalse(result[0].successful)
+
+    def test_node_set_parameters_read_only(self):
+        parameter_tuples = [
+            (
+                'immutable_foo',
+                ParameterValue(type=Parameter.Type.INTEGER.value, integer_value=42),
+                ParameterDescriptor(read_only=True)
+            ),
+            (
+                'bar',
+                ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+                ParameterDescriptor()
+            ),
+            (
+                'immutable_baz',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.41),
+                ParameterDescriptor(read_only=True)
+            )
+        ]
+
+        # Create rclpy.Parameter list from tuples.
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+        ]
+
+        self.node.declare_parameters('', parameter_tuples)
+
+        # Try setting a different value to the declared parameters.
+        parameter_tuples[0][1].integer_value = 24
+        parameter_tuples[1][1].string_value = 'bye'
+        parameter_tuples[2][1].double_value = 1.42
+
+        # Re-create parameters from modified tuples.
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+        ]
+
+        result = self.node.set_parameters(parameters)
+
+        # Only the parameter that is not read_only should have succeeded.
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], SetParametersResult)
+        self.assertIsInstance(result[1], SetParametersResult)
+        self.assertIsInstance(result[2], SetParametersResult)
+        self.assertFalse(result[0].successful)
+        self.assertTrue(result[1].successful)
+        self.assertFalse(result[2].successful)
+        self.assertEqual(self.node.get_parameter('immutable_foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'bye')
+        self.assertEqual(self.node.get_parameter('immutable_baz').value, 2.41)
+
+    def test_node_set_parameters_implicit_undeclare(self):
+        parameter_tuples = [
+            (
+                'foo',
+                ParameterValue(type=Parameter.Type.INTEGER.value, integer_value=42),
+                ParameterDescriptor()
+            ),
+            (
+                'bar',
+                ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+                ParameterDescriptor()
+            ),
+            (
+                'baz',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.41),
+                ParameterDescriptor()
+            )
+        ]
+
+        self.node.declare_parameters('', parameter_tuples)
+
+        # Verify that the parameters are set.
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+        # Now undeclare one of them implicitly.
+        self.node.set_parameters([Parameter('bar', Parameter.Type.NOT_SET, None)])
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertFalse(self.node.has_parameter('bar'))
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+    def test_node_set_parameters_atomically(self):
+        parameter_tuples = [
+            (
+                'foo',
+                ParameterValue(type=Parameter.Type.INTEGER.value, integer_value=42),
+                ParameterDescriptor()
+            ),
+            (
+                'bar',
+                ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+                ParameterDescriptor()
+            ),
+            (
+                'baz',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.41),
+                ParameterDescriptor()
+            )
+        ]
+
+        # Create rclpy.Parameter list from tuples.
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+        ]
+
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_parameters_atomically(parameters)
+
+        self.node.declare_parameters('', parameter_tuples)
+        result = self.node.set_parameters_atomically(parameters)
+
+        # OK case: check successful aggregated result.
+        self.assertIsInstance(result, SetParametersResult)
+        self.assertTrue(result.successful)
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+        # Now we modify the declared parameters, add a new one and set them again.
+        parameter_tuples[0][1].integer_value = 24
+        parameter_tuples[1][1].string_value = 'bye'
+        parameter_tuples[2][1].double_value = 1.42
+        parameter_tuples.append(
+            (
+                'foobar',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.71),
+                ParameterDescriptor())
+            )
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[3][0], value=parameter_tuples[3][1])),
+        ]
+
+        # The fourth parameter causes the exception, hence none is set.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_parameters_atomically(parameters)
+
+        # Confirm that the first three were not modified.
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+        # Confirm that the fourth one does not exist.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.get_parameter('foobar')
+
+    def test_node_set_parameters_atomically_rejection(self):
+        # Declare a new parameter and set a callback so that it's rejected when set.
+        reject_parameter_tuple = (
+            'reject_me',
+            ParameterValue(type=Parameter.Type.BOOL.value, bool_value=True),
+            ParameterDescriptor()
+        )
+
+        self.node.declare_parameter(*reject_parameter_tuple)
+        self.node.set_parameters_callback(self.reject_parameter_callback)
+        result = self.node.set_parameters_atomically(
+            [
+                Parameter.from_parameter_msg(
+                    ParameterMsg(name=reject_parameter_tuple[0], value=reject_parameter_tuple[1]))
+            ]
+        )
+        self.assertIsInstance(result, SetParametersResult)
+        self.assertFalse(result.successful)
+
+    def test_node_set_parameters_atomically_read_only(self):
+        parameter_tuples = [
+            (
+                'foo',
+                ParameterValue(type=Parameter.Type.INTEGER.value, integer_value=42),
+                ParameterDescriptor()
+            ),
+            (
+                'bar',
+                ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+                ParameterDescriptor()
+            ),
+            (
+                'immutable_baz',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.41),
+                ParameterDescriptor(read_only=True)
+            )
+        ]
+
+        # Create rclpy.Parameter list from tuples.
+        parameters = [
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[0][0], value=parameter_tuples[0][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[1][0], value=parameter_tuples[1][1])),
+            Parameter.from_parameter_msg(
+                ParameterMsg(name=parameter_tuples[2][0], value=parameter_tuples[2][1])),
+        ]
+
+        self.node.declare_parameters('', parameter_tuples)
+
+        # Try setting a different value to the declared parameters.
+        parameter_tuples[0][1].integer_value = 24
+        parameter_tuples[1][1].string_value = 'bye'
+        parameter_tuples[2][1].double_value = 1.42
+
+        result = self.node.set_parameters_atomically(parameters)
+
+        # At least one parameter is read-only, so the overall result should be a failure.
+        # All the parameters should have their original value.
+        self.assertIsInstance(result, SetParametersResult)
+        self.assertFalse(result.successful)
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('immutable_baz').value, 2.41)
+
+    def test_node_set_parameters_atomically_implicit_undeclare(self):
+        parameter_tuples = [
+            (
+                'foo',
+                ParameterValue(type=Parameter.Type.INTEGER.value, integer_value=42),
+                ParameterDescriptor()
+            ),
+            (
+                'bar',
+                ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+                ParameterDescriptor()
+            ),
+            (
+                'baz',
+                ParameterValue(type=Parameter.Type.DOUBLE.value, double_value=2.41),
+                ParameterDescriptor()
+            )
+        ]
+
+        self.node.declare_parameters('', parameter_tuples)
+
+        # Verify that the parameters are set.
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertEqual(self.node.get_parameter('bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+        # Now undeclare one of them implicitly.
+        self.node.set_parameters_atomically([Parameter('bar', Parameter.Type.NOT_SET, None)])
+        self.assertEqual(self.node.get_parameter('foo').value, 42)
+        self.assertFalse(self.node.has_parameter('bar'))
+        self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+
+    def test_describe_parameter(self):
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.describe_parameter('foo')
+
+        # Declare parameter with descriptor.
+        self.node.declare_parameter(
+            'foo',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+            ParameterDescriptor(
+                name='foo',
+                type=ParameterType.PARAMETER_STRING,
+                additional_constraints='some constraints',
+                read_only=True,
+                floating_point_range=[FloatingPointRange(from_value=-2.0, to_value=2.0, step=0.1)],
+                integer_range=[IntegerRange(from_value=-10, to_value=10, step=2)]
+            )
+        )
+
+        descriptor = self.node.describe_parameter('foo')
+        self.assertEqual(descriptor.name, 'foo')
+        self.assertEqual(descriptor.type, ParameterType.PARAMETER_STRING)
+        self.assertEqual(descriptor.additional_constraints, 'some constraints')
+        self.assertEqual(descriptor.read_only, True)
+        self.assertEqual(descriptor.floating_point_range[0].from_value, -2.0)
+        self.assertEqual(descriptor.floating_point_range[0].to_value, 2.0)
+        self.assertEqual(descriptor.floating_point_range[0].step, 0.1)
+        self.assertEqual(descriptor.integer_range[0].from_value, -10)
+        self.assertEqual(descriptor.integer_range[0].to_value, 10)
+        self.assertEqual(descriptor.integer_range[0].step, 2)
+
+    def test_describe_parameters(self):
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.describe_parameter('foo')
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.describe_parameter('bar')
+
+        # Declare parameters with descriptors.
+        self.node.declare_parameter(
+            'foo',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+            ParameterDescriptor(
+                name='foo',
+                type=ParameterType.PARAMETER_STRING,
+                additional_constraints='some constraints',
+                read_only=True,
+                floating_point_range=[FloatingPointRange(from_value=-2.0, to_value=2.0, step=0.1)],
+                integer_range=[IntegerRange(from_value=-10, to_value=10, step=2)]
+            )
+        )
+        self.node.declare_parameter(
+            'bar',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+            ParameterDescriptor(
+                name='bar',
+                type=ParameterType.PARAMETER_INTEGER,
+                additional_constraints='some more constraints',
+                read_only=True,
+                floating_point_range=[FloatingPointRange(from_value=-3.0, to_value=3.0, step=0.3)],
+                integer_range=[IntegerRange(from_value=-20, to_value=20, step=3)]
+            )
+        )
+
+        # Check list.
+        descriptor_list = self.node.describe_parameters(['foo', 'bar'])
+        self.assertIsInstance(descriptor_list, list)
+        self.assertEqual(len(descriptor_list), 2)
+
+        # Check individual descriptors.
+        foo_descriptor = descriptor_list[0]
+        self.assertEqual(foo_descriptor.name, 'foo')
+        self.assertEqual(foo_descriptor.type, ParameterType.PARAMETER_STRING)
+        self.assertEqual(foo_descriptor.additional_constraints, 'some constraints')
+        self.assertEqual(foo_descriptor.read_only, True)
+        self.assertEqual(foo_descriptor.floating_point_range[0].from_value, -2.0)
+        self.assertEqual(foo_descriptor.floating_point_range[0].to_value, 2.0)
+        self.assertEqual(foo_descriptor.floating_point_range[0].step, 0.1)
+        self.assertEqual(foo_descriptor.integer_range[0].from_value, -10)
+        self.assertEqual(foo_descriptor.integer_range[0].to_value, 10)
+        self.assertEqual(foo_descriptor.integer_range[0].step, 2)
+
+        bar_descriptor = descriptor_list[1]
+        self.assertEqual(bar_descriptor.name, 'bar')
+        self.assertEqual(bar_descriptor.type, ParameterType.PARAMETER_INTEGER)
+        self.assertEqual(bar_descriptor.additional_constraints, 'some more constraints')
+        self.assertEqual(bar_descriptor.read_only, True)
+        self.assertEqual(bar_descriptor.floating_point_range[0].from_value, -3.0)
+        self.assertEqual(bar_descriptor.floating_point_range[0].to_value, 3.0)
+        self.assertEqual(bar_descriptor.floating_point_range[0].step, 0.3)
+        self.assertEqual(bar_descriptor.integer_range[0].from_value, -20)
+        self.assertEqual(bar_descriptor.integer_range[0].to_value, 20)
+        self.assertEqual(bar_descriptor.integer_range[0].step, 3)
+
+    # TODO(jubeira): test cases failing because of non-compliant existing parameter values
+    # once the feature is implemented.
+    def test_set_descriptor(self):
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_descriptor('foo', ParameterDescriptor())
+
+        # Declare parameter with default descriptor.
+        self.node.declare_parameter(
+            'foo',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+            ParameterDescriptor()
+        )
+        self.assertEqual(self.node.describe_parameter('foo'), ParameterDescriptor())
+
+        # Now modify the descriptor and check again.
+        value = self.node.set_descriptor(
+            'foo',
+            ParameterDescriptor(
+                name='foo',
+                type=ParameterType.PARAMETER_STRING,
+                additional_constraints='some constraints',
+                read_only=True,
+                floating_point_range=[FloatingPointRange(from_value=-2.0, to_value=2.0, step=0.1)],
+                integer_range=[IntegerRange(from_value=-10, to_value=10, step=2)]
+            )
+        )
+        self.assertEqual(value.type, Parameter.Type.STRING.value)
+        self.assertEqual(value.string_value, 'hello')
+
+        descriptor = self.node.describe_parameter('foo')
+        self.assertEqual(descriptor.name, 'foo')
+        self.assertEqual(descriptor.type, ParameterType.PARAMETER_STRING)
+        self.assertEqual(descriptor.additional_constraints, 'some constraints')
+        self.assertEqual(descriptor.read_only, True)
+        self.assertEqual(descriptor.floating_point_range[0].from_value, -2.0)
+        self.assertEqual(descriptor.floating_point_range[0].to_value, 2.0)
+        self.assertEqual(descriptor.floating_point_range[0].step, 0.1)
+        self.assertEqual(descriptor.integer_range[0].from_value, -10)
+        self.assertEqual(descriptor.integer_range[0].to_value, 10)
+        self.assertEqual(descriptor.integer_range[0].step, 2)
+
+    def test_set_descriptor_read_only(self):
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_descriptor('foo', ParameterDescriptor())
+
+        # Declare parameter with a read_only descriptor.
+        self.node.declare_parameter(
+            'foo',
+            ParameterValue(type=Parameter.Type.STRING.value, string_value='hello'),
+            ParameterDescriptor(read_only=True)
+        )
+        self.assertEqual(self.node.describe_parameter('foo'), ParameterDescriptor(read_only=True))
+
+        # Try modifying the descriptor.
+        with self.assertRaises(ParameterImmutableException):
+            self.node.set_descriptor(
+                'foo',
+                ParameterDescriptor(
+                    name='foo',
+                    type=ParameterType.PARAMETER_STRING,
+                    additional_constraints='some constraints',
+                    read_only=False,
+                )
+            )
 
 
 class TestCreateNode(unittest.TestCase):


### PR DESCRIPTION
Closes #341.

There are some details that still need a bit of attention (see https://github.com/ros2/rclpy/issues/341#issuecomment-491292717). The PR includes a proposal for `set_descriptor` as described in the comment.

On the other hand, I'd like some input about the optional signature using `Parameter` as input for `declare_parameter` (see [comment](https://github.com/ros2/rclpy/pull/325#discussion_r280534305)). Is it worth implementing it even if it only applies to `declare_parameter` but not `declare_parameters`?

Other than that, this should be ready for an initial review.