### PR TITLE
Don't wrap QoS Event callback argument in a list

### DIFF
--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -140,7 +140,7 @@ class QoSEventHandler(Waitable):
         """Execute work after data has been taken from a ready wait set."""
         if not taken_data:
             return
-        await rclpy.executors.await_or_execute(self.callback, [taken_data])
+        await rclpy.executors.await_or_execute(self.callback, taken_data)
 
     def get_num_entities(self):
         """Return number of each type of entity used."""


### PR DESCRIPTION
It was a mistake introduced in a review feedback on the original PR https://github.com/ros2/rclpy/pull/316

Signed-off-by: Emerson Knapp <eknapp@amazon.com>