### PR TITLE
Create RLock() early to avoid exception at shutdown

### DIFF
--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -46,6 +46,8 @@ class Handle:
         self.__request_invalidation = False
         self.__valid = True
         self.__rlock = RLock()
+        # Create this early because RLock() can raise during interpeter shutdown
+        self.__dependents_rlock = RLock()
         self.__required_handles = []
         self.__dependent_handles = weakref.WeakSet()
         self.__destroy_callbacks = []
@@ -157,7 +159,7 @@ class Handle:
 
     def __destroy_dependents(self, then):
         # assumes self.__rlock is held
-        deps_lock = RLock()
+        deps_lock = self.__dependents_rlock
         # Turn weak references to regular references
         dependent_handles = [dep for dep in self.__dependent_handles]
 


### PR DESCRIPTION
This is attempt to fix an exception raised in interpreter shutdown: https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1194/testReport/launch_testing_ros.test/test_examples/test_examples_talker_listener_test_py_/

<details><summary>Traceback</summary>

```
[listener-2] Exception ignored in: <bound method Executor.__del__ of <rclpy.executors.SingleThreadedExecutor object at 0x7f6c2fbacc50>>
[listener-2] Traceback (most recent call last):
[listener-2]   File "/home/jenkins-agent/workspace/nightly_linux_debug/ws/install/rclpy/lib/python3.6/site-packages/rclpy/executors.py", line 223, in __del__
[listener-2]   File "/home/jenkins-agent/workspace/nightly_linux_debug/ws/install/rclpy/lib/python3.6/site-packages/rclpy/signals.py", line 40, in destroy
[listener-2]   File "/home/jenkins-agent/workspace/nightly_linux_debug/ws/install/rclpy/lib/python3.6/site-packages/rclpy/guard_condition.py", line 41, in destroy
[listener-2]   File "/home/jenkins-agent/workspace/nightly_linux_debug/ws/install/rclpy/lib/python3.6/site-packages/rclpy/handle.py", line 95, in destroy
[listener-2]   File "/home/jenkins-agent/workspace/nightly_linux_debug/ws/install/rclpy/lib/python3.6/site-packages/rclpy/handle.py", line 156, in __destroy
[listener-2]   File "/home/jenkins-agent/workspace/nightly_linux_debug/ws/install/rclpy/lib/python3.6/site-packages/rclpy/handle.py", line 160, in __destroy_dependents
[listener-2]   File "/usr/lib/python3.6/threading.py", line 84, in RLock
[listener-2] TypeError: 'NoneType' object is not callable
```
</details>

I think this is happening because it's calling `threading.RLock()` at interpreter shutdown (via `Executor.__del__`).

https://github.com/ros2/rclpy/blob/bfcb40c0dc3f410bc4cb1e8b871726bdbe769ce4/rclpy/rclpy/handle.py#L160

`threading.RLock()` is a method that [uses a module scope variable beginning with a single underscore](https://github.com/python/cpython/blob/2b9d7abdbd4b41e2c624858f5bc80da59d8a681d/Lib/threading.py#L84).

```python3
 return _PyRLock(*args, **kwargs)
```

Python guarantees that [module variables beginning with a single underscore are garbage collected before the rest of the module](https://docs.python.org/3.6/reference/datamodel.html#object.__del__).

> __del__() can be executed during interpreter shutdown. As a consequence, the global variables it
> needs to access (including other modules) may already have been deleted or set to None. Python 
> guarantees that globals whose name begins with a single underscore are deleted from their module 
> before other globals are deleted ...

I think `threading._PyRLock` was garbage collected and set to `None` before the executor was garbage collected. This PR tries to fix it by calling `RLock()` when the handle is created and holding onto it.