### PR TITLE
Initialize QoSProfile with values from rmw_qos_profile_default

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from argparse import Namespace
 from enum import Enum
 from enum import IntEnum
 import warnings
@@ -19,6 +20,10 @@ import warnings
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+# "Forward-declare" this value so that it can be used in the QoSProfile initializer.
+# It will have a value by the end of definitions, before user code runs.
+_qos_default_value_for_init = []
 
 
 class QoSProfile:
@@ -39,6 +44,17 @@ class QoSProfile:
     def __init__(self, **kwargs):
         assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
             'Invalid arguments passed to constructor: %r' % kwargs.keys()
+
+        if not len(_qos_default_value_for_init):
+            # Any of the setters, upon receiving these None values, would assert.
+            # This can't happen though, because this is only used at definition time, when
+            # we are initializing fully-defined preset profiles.
+            from_profile = Namespace(**{
+                slot[1:]: None for slot in self.__slots__
+            })
+        else:
+            from_profile = _qos_default_value_for_init[0]
+
         if 'history' not in kwargs:
             if 'depth' in kwargs:
                 kwargs['history'] = QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST
@@ -46,9 +62,7 @@ class QoSProfile:
                 warnings.warn(
                     "QoSProfile needs a 'history' and/or 'depth' setting when constructed",
                     stacklevel=2)
-        self.history = kwargs.get(
-            'history',
-            QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT)
+        self.history = kwargs.get('history', from_profile.history)
         if (
             QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST == self.history and
             'depth' not in kwargs
@@ -56,22 +70,17 @@ class QoSProfile:
             warnings.warn(
                 'A QoSProfile with history set to KEEP_LAST needs a depth specified',
                 stacklevel=2)
-        self.depth = kwargs.get('depth', int())
-        self.reliability = kwargs.get(
-            'reliability',
-            QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT)
-        self.durability = kwargs.get(
-            'durability',
-            QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT)
-        self.lifespan = kwargs.get('lifespan', Duration())
-        self.deadline = kwargs.get('deadline', Duration())
-        self.liveliness = kwargs.get(
-            'liveliness',
-            QoSLivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT)
-        self.liveliness_lease_duration = kwargs.get('liveliness_lease_duration', Duration())
+
+        self.depth = kwargs.get('depth', from_profile.depth)
+        self.reliability = kwargs.get('reliability', from_profile.reliability)
+        self.durability = kwargs.get('durability', from_profile.durability)
+        self.lifespan = kwargs.get('lifespan', from_profile.lifespan)
+        self.deadline = kwargs.get('deadline', from_profile.deadline)
+        self.liveliness = kwargs.get('liveliness', from_profile.liveliness)
+        self.liveliness_lease_duration = kwargs.get(
+            'liveliness_lease_duration', from_profile.liveliness_lease_duration)
         self.avoid_ros_namespace_conventions = kwargs.get(
-            'avoid_ros_namespace_conventions',
-            False)
+            'avoid_ros_namespace_conventions', from_profile.avoid_ros_namespace_conventions)
 
     @property
     def history(self):
@@ -325,9 +334,11 @@ class DeprecatedQoSProfile(QoSProfile):
         self.name = profile_name
 
 
-__qos_profile_default = _rclpy.rclpy_get_rmw_qos_profile(
+_qos_profile_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_default')
-qos_profile_default = DeprecatedQoSProfile(__qos_profile_default, 'qos_profile_default')
+_qos_default_value_for_init.append(_qos_profile_default)
+
+qos_profile_default = DeprecatedQoSProfile(_qos_profile_default, 'qos_profile_default')
 qos_profile_system_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_system_default')
 qos_profile_sensor_data = _rclpy.rclpy_get_rmw_qos_profile(
@@ -343,6 +354,7 @@ qos_profile_action_status_default = _rclpy_action.rclpy_action_get_rmw_qos_profi
 
 
 class QoSPresetProfiles(Enum):
+    DEFAULT = _qos_profile_default
     SYSTEM_DEFAULT = qos_profile_system_default
     SENSOR_DATA = qos_profile_sensor_data
     SERVICES_DEFAULT = qos_profile_services_default

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -46,12 +46,12 @@ class QoSProfile:
             'Invalid arguments passed to constructor: %r' % kwargs.keys()
 
         if not _qos_profile_default:
-            # Any of the setters, upon receiving these None values, would assert.
-            # This can't happen though, because this is only used at definition time, when
-            # we are initializing fully-defined preset profiles.
-            from_profile = Namespace(**{
-                slot[1:]: None for slot in self.__slots__
-            })
+            # It is still definition time, and all calls to this initializer are expected to be
+            # fully-defined preset profiles from the C side.
+            assert all(kwargs[slot[1:]] is not None for slot in self.__slots__)
+            # Any of the setters, upon receiving these None values, would assert
+            # if the above assertion failed.
+            from_profile = Namespace(**{slot[1:]: None for slot in self.__slots__})
         else:
             from_profile = _qos_profile_default
 

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -352,7 +352,6 @@ qos_profile_action_status_default = _rclpy_action.rclpy_action_get_rmw_qos_profi
 
 
 class QoSPresetProfiles(Enum):
-    DEFAULT = _qos_profile_default
     SYSTEM_DEFAULT = qos_profile_system_default
     SENSOR_DATA = qos_profile_sensor_data
     SERVICES_DEFAULT = qos_profile_services_default

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -23,7 +23,7 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 # "Forward-declare" this value so that it can be used in the QoSProfile initializer.
 # It will have a value by the end of definitions, before user code runs.
-_qos_default_value_for_init = []
+_qos_profile_default = None
 
 
 class QoSProfile:
@@ -45,7 +45,7 @@ class QoSProfile:
         assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
             'Invalid arguments passed to constructor: %r' % kwargs.keys()
 
-        if not len(_qos_default_value_for_init):
+        if not _qos_profile_default:
             # Any of the setters, upon receiving these None values, would assert.
             # This can't happen though, because this is only used at definition time, when
             # we are initializing fully-defined preset profiles.
@@ -53,7 +53,7 @@ class QoSProfile:
                 slot[1:]: None for slot in self.__slots__
             })
         else:
-            from_profile = _qos_default_value_for_init[0]
+            from_profile = _qos_profile_default
 
         if 'history' not in kwargs:
             if 'depth' in kwargs:
@@ -336,8 +336,6 @@ class DeprecatedQoSProfile(QoSProfile):
 
 _qos_profile_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_default')
-_qos_default_value_for_init.append(_qos_profile_default)
-
 qos_profile_default = DeprecatedQoSProfile(_qos_profile_default, 'qos_profile_default')
 qos_profile_system_default = _rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_system_default')

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -102,7 +102,6 @@ class TestQosProfile(unittest.TestCase):
             QoSProfile()
             assert len(w) == 2  # must supply depth or history, _and_ KEEP_LAST needs depth
             assert issubclass(w[0].category, UserWarning)
-
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             # No deprecation if history is supplied

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -17,6 +17,7 @@ import warnings
 
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.qos import _qos_profile_default
 from rclpy.qos import qos_profile_system_default
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSHistoryPolicy
@@ -145,7 +146,9 @@ class TestQosProfile(unittest.TestCase):
             QoSPresetProfiles.get_from_short_key('system_default'))
 
     def test_default_profile(self):
-        profile = QoSProfile(depth=10)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always')
+            profile = QoSProfile()
         assert all(
-            profile.__getattribute__(k) == QoSPresetProfiles.DEFAULT.value.__getattribute__(k)
+            profile.__getattribute__(k) == _qos_profile_default.__getattribute__(k)
             for k in profile.__slots__)

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -99,8 +99,9 @@ class TestQosProfile(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             QoSProfile()
-            assert len(w) == 1
+            assert len(w) == 2  # must supply depth or history, _and_ KEEP_LAST needs depth
             assert issubclass(w[0].category, UserWarning)
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             # No deprecation if history is supplied
@@ -142,3 +143,9 @@ class TestQosProfile(unittest.TestCase):
         assert (
             QoSPresetProfiles.SYSTEM_DEFAULT.value ==
             QoSPresetProfiles.get_from_short_key('system_default'))
+
+    def test_default_profile(self):
+        profile = QoSProfile(depth=10)
+        assert all(
+            profile.__getattribute__(k) == QoSPresetProfiles.DEFAULT.value.__getattribute__(k)
+            for k in profile.__slots__)


### PR DESCRIPTION
To match behavior in rclcpp.

Fixes https://github.com/ros2/rclpy/issues/353

Would like some feedback on the approach, it feels a little kludgy. It's an awkward situation though, where the default profile values we want are only exposed via a QoSProfile instance from _rclpy.c, so we have a circular dependency.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>