### PR TITLE
[executors] don't convert a timeout_sec to nsecs

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -280,7 +280,7 @@ class Executor:
         else:
             start = time.monotonic()
             end = start + timeout_sec
-            timeout_left = timeout_sec_to_nsec(timeout_sec)
+            timeout_left = timeout_sec
 
             while self._context.ok() and not future.done():
                 self.spin_once(timeout_sec=timeout_left)


### PR DESCRIPTION
Certainly something fishy here - I was getting unduly long blocks when the service server was not available. 