### PR TITLE
Fixing namespace expansion for declare_parameters.

### DIFF
--- a/rclpy/rclpy/validate_parameter_name.py
+++ b/rclpy/rclpy/validate_parameter_name.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from rclpy.exceptions import InvalidParameterException
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
 def validate_parameter_name(name: str) -> bool:
@@ -28,10 +27,8 @@ def validate_parameter_name(name: str) -> bool:
     :param name str: parameter name to be validated.
     :raises: InvalidParameterException: when the name is invalid.
     """
-    # TODO(jubeira): define whether this is an appropriate method to validate
-    # parameter names.
-    result = _rclpy.rclpy_get_validation_error_for_topic_name(name)
-    if result is None:
-        return True
-    error_msg, invalid_index = result
-    raise InvalidParameterException(name, error_msg, invalid_index)
+    # TODO(jubeira): add parameter name check to be implemented at RCL level.
+    if not name:
+        raise InvalidParameterException(name)
+
+    return True

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -399,15 +399,17 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
 
         # Error cases.
+        # TODO(@jubeira): add failing test cases with invalid names once name
+        # validation is implemented.
         with self.assertRaises(ParameterAlreadyDeclaredException):
             self.node.declare_parameter(
                 'foo', 'raise', ParameterDescriptor())
         with self.assertRaises(InvalidParameterException):
             self.node.declare_parameter(
-                '123foo', 'raise', ParameterDescriptor())
+                '', 'raise', ParameterDescriptor())
         with self.assertRaises(InvalidParameterException):
             self.node.declare_parameter(
-                'foo??', 'raise', ParameterDescriptor())
+                '', 'raise', ParameterDescriptor())
 
         self.node.set_parameters_callback(self.reject_parameter_callback)
         with self.assertRaises(InvalidParameterValueException):
@@ -449,7 +451,7 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_parameter('bar').value, 'hello')
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
 
-        result = self.node.declare_parameters('/namespace/', parameters)
+        result = self.node.declare_parameters('namespace', parameters)
 
         # OK cases.
         self.assertIsInstance(result, list)
@@ -459,9 +461,9 @@ class TestNode(unittest.TestCase):
         self.assertEqual(result[0].value, 42)
         self.assertEqual(result[1].value, 'hello')
         self.assertEqual(result[2].value, 2.41)
-        self.assertEqual(self.node.get_parameter('/namespace/foo').value, 42)
-        self.assertEqual(self.node.get_parameter('/namespace/bar').value, 'hello')
-        self.assertEqual(self.node.get_parameter('/namespace/baz').value, 2.41)
+        self.assertEqual(self.node.get_parameter('namespace.foo').value, 42)
+        self.assertEqual(self.node.get_parameter('namespace.bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('namespace.baz').value, 2.41)
 
         # Error cases.
         with self.assertRaises(ParameterAlreadyDeclaredException):
@@ -481,7 +483,7 @@ class TestNode(unittest.TestCase):
         parameters = [
             ('foobarbar', 44, ParameterDescriptor()),
             ('barbarbar', 'world', ParameterDescriptor()),
-            ('baz??wrong_name', 2.41, ParameterDescriptor()),
+            ('', 2.41, ParameterDescriptor()),
         ]
         with self.assertRaises(InvalidParameterException):
             self.node.declare_parameters('', parameters)


### PR DESCRIPTION
Closes #375.

Partially addresses #373 considering the first option described in https://github.com/ros2/rclpy/issues/373#issuecomment-504408873.

The complete parameter name validation has yet to be implemented; removing the current (incorrect) check is required to address #375. If this patch is accepted, the next step would be implementing the correct check at RCL level so that it can be used both in `rclpy` and `rclcpp` like the current topic name check.

Finally, note that in `rclcpp` the current [parameter name validation](https://github.com/ros2/rclcpp/blob/e7c463dc74849aa64cb8a74e13f2a57b4ed59862/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp#L376-L379) is also a 'non-empty' check.