### PR TITLE
Fix time conversion for a big nanoseconds value

### DIFF
--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -18,6 +18,9 @@ from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
+CONVERSION_CONSTANT = 10 ** 9
+
+
 class Time:
 
     def __init__(self, *, seconds=0, nanoseconds=0, clock_type=ClockType.SYSTEM_TIME):
@@ -27,7 +30,7 @@ class Time:
             raise ValueError('Seconds value must not be negative')
         if nanoseconds < 0:
             raise ValueError('Nanoseconds value must not be negative')
-        total_nanoseconds = int(seconds * 1e9)
+        total_nanoseconds = int(seconds * CONVERSION_CONSTANT)
         total_nanoseconds += int(nanoseconds)
         try:
             self._time_handle = _rclpy.rclpy_create_time_point(total_nanoseconds, clock_type)
@@ -48,7 +51,7 @@ class Time:
         :rtype: tuple(int, int)
         """
         nanoseconds = self.nanoseconds
-        return (int(nanoseconds / 1e9), nanoseconds % 1e9)
+        return (nanoseconds // CONVERSION_CONSTANT, nanoseconds % CONVERSION_CONSTANT)
 
     @property
     def clock_type(self):
@@ -133,8 +136,7 @@ class Time:
         return NotImplemented
 
     def to_msg(self):
-        seconds = int(self.nanoseconds * 1e-9)
-        nanoseconds = int(self.nanoseconds % 1e9)
+        seconds, nanoseconds = self.seconds_nanoseconds()
         return builtin_interfaces.msg.Time(sec=seconds, nanosec=nanoseconds)
 
     @classmethod

--- a/rclpy/test/test_time.py
+++ b/rclpy/test/test_time.py
@@ -215,9 +215,6 @@ class TestTime(unittest.TestCase):
         time2 = Time.from_msg(builtins_msg.time_value)
         assert isinstance(time2, Time)
         assert time1 == time2
-        # Clock type can be specified if appropriate
-        time3 = Time.from_msg(builtins_msg.time_value, clock_type=ClockType.SYSTEM_TIME)
-        assert time3.clock_type == ClockType.SYSTEM_TIME
 
     def test_duration_message_conversions(self):
         duration = Duration(nanoseconds=1)

--- a/rclpy/test/test_time.py
+++ b/rclpy/test/test_time.py
@@ -206,6 +206,19 @@ class TestTime(unittest.TestCase):
         time3 = Time.from_msg(builtins_msg.time_value, clock_type=ClockType.SYSTEM_TIME)
         assert time3.clock_type == ClockType.SYSTEM_TIME
 
+    def test_time_message_conversions_big_nanoseconds(self):
+        time1 = Time(nanoseconds=1553575413247045598, clock_type=ClockType.ROS_TIME)
+        builtins_msg = Builtins()
+        builtins_msg.time_value = time1.to_msg()
+
+        # Default clock type resulting from from_msg will be ROS time
+        time2 = Time.from_msg(builtins_msg.time_value)
+        assert isinstance(time2, Time)
+        assert time1 == time2
+        # Clock type can be specified if appropriate
+        time3 = Time.from_msg(builtins_msg.time_value, clock_type=ClockType.SYSTEM_TIME)
+        assert time3.clock_type == ClockType.SYSTEM_TIME
+
     def test_duration_message_conversions(self):
         duration = Duration(nanoseconds=1)
         builtins_msg = Builtins()


### PR DESCRIPTION
Related to #293

 - Change from the floating constant value(1e9) to the integer constant value(10 ** 9)

Signed-off-by: vinnamkim <vinnam.kim@gmail.com>