### PR TITLE
accept tuples as parameter arrays

### DIFF
--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -52,7 +52,7 @@ class Parameter:
                 return Parameter.Type.DOUBLE
             elif isinstance(parameter_value, str):
                 return Parameter.Type.STRING
-            elif isinstance(parameter_value, list):
+            elif isinstance(parameter_value, (list, tuple)):
                 if all(isinstance(v, bytes) for v in parameter_value):
                     return Parameter.Type.BYTE_ARRAY
                 elif all(isinstance(v, bool) for v in parameter_value):
@@ -80,19 +80,19 @@ class Parameter:
             if Parameter.Type.STRING == self:
                 return isinstance(parameter_value, str)
             if Parameter.Type.BYTE_ARRAY == self:
-                return isinstance(parameter_value, list) and \
+                return isinstance(parameter_value, (list, tuple)) and \
                     all(isinstance(v, bytes) and len(v) == 1 for v in parameter_value)
             if Parameter.Type.BOOL_ARRAY == self:
-                return isinstance(parameter_value, list) and \
+                return isinstance(parameter_value, (list, tuple)) and \
                     all(isinstance(v, bool) for v in parameter_value)
             if Parameter.Type.INTEGER_ARRAY == self:
-                return isinstance(parameter_value, list) and \
+                return isinstance(parameter_value, (list, tuple)) and \
                     all(isinstance(v, int) for v in parameter_value)
             if Parameter.Type.DOUBLE_ARRAY == self:
-                return isinstance(parameter_value, list) and \
+                return isinstance(parameter_value, (list, tuple)) and \
                     all(isinstance(v, float) for v in parameter_value)
             if Parameter.Type.STRING_ARRAY == self:
-                return isinstance(parameter_value, list) and \
+                return isinstance(parameter_value, (list, tuple)) and \
                     all(isinstance(v, str) for v in parameter_value)
             return False
 

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -123,10 +123,20 @@ class TestParameter(unittest.TestCase):
             Parameter('illegaltype', 'mytype', 'myvalue')
 
         with self.assertRaises(TypeError):
-            Parameter('illegaltype', value=('invalid', 'type'))
-
-        with self.assertRaises(TypeError):
             Parameter('illegaltype', value={'invalid': 'type'})
+
+    def test_integer_tuple_array(self):
+        # list
+        int_list = [1, 2, 3]
+        self.assertEqual(
+            Parameter.Type.INTEGER_ARRAY, Parameter.Type.from_parameter_value(int_list))
+        self.assertTrue(Parameter.Type.check(Parameter.Type.INTEGER_ARRAY, int_list))
+
+        # tuple
+        int_tuple = (1, 2, 3)
+        self.assertEqual(
+            Parameter.Type.INTEGER_ARRAY, Parameter.Type.from_parameter_value(int_tuple))
+        self.assertTrue(Parameter.Type.check(Parameter.Type.INTEGER_ARRAY, int_tuple))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Providing a python dict inside a launch file that contains a list parameter, e.g.
```Python
composable_node = ComposableNode(parameters=[{"tag_ids": [9, 14]}])
```
or loading a YAML file (that contains `tag_ids: [9, 14]`)
```Python
composable_node = ComposableNode(parameters=["path/to/configuration.yaml"])
```
results in an error like:
`[ERROR] [launch]: Caught exception in launch (see debug for traceback): invalid parameter value (9, 14)`
because `[9, 14]` is recognised as `tuple` and not as `list`.
However, the parameter list logic only expects python lists.

This PR simply extends the parameter check to tuples to allow them to be used as iterables. There might be more places where a type check against list should be extended to all iterables.