### PR TITLE
[Backport] Fixes for parameter handling

### DIFF
--- a/rclpy/rclpy/validate_parameter_name.py
+++ b/rclpy/rclpy/validate_parameter_name.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from rclpy.exceptions import InvalidParameterException
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
 def validate_parameter_name(name: str) -> bool:
@@ -28,10 +27,8 @@ def validate_parameter_name(name: str) -> bool:
     :param name str: parameter name to be validated.
     :raises: InvalidParameterException: when the name is invalid.
     """
-    # TODO(jubeira): define whether this is an appropriate method to validate
-    # parameter names.
-    result = _rclpy.rclpy_get_validation_error_for_topic_name(name)
-    if result is None:
-        return True
-    error_msg, invalid_index = result
-    raise InvalidParameterException(name, error_msg, invalid_index)
+    # TODO(jubeira): add parameter name check to be implemented at RCL level.
+    if not name:
+        raise InvalidParameterException(name)
+
+    return True

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -383,20 +383,25 @@ class TestNode(unittest.TestCase):
             'bar', 'hello', ParameterDescriptor())
         result_baz = self.node.declare_parameter(
             'baz', 2.41, ParameterDescriptor())
+        result_value_not_set = self.node.declare_parameter('value_not_set')
 
         # OK cases.
         self.assertIsInstance(result_initial_foo, Parameter)
         self.assertIsInstance(result_foo, Parameter)
         self.assertIsInstance(result_bar, Parameter)
         self.assertIsInstance(result_baz, Parameter)
+        self.assertIsInstance(result_value_not_set, Parameter)
         self.assertEqual(result_initial_foo.value, 4321)
         self.assertEqual(result_foo.value, 42)
         self.assertEqual(result_bar.value, 'hello')
         self.assertEqual(result_baz.value, 2.41)
+        self.assertIsNone(result_value_not_set.value)
         self.assertEqual(self.node.get_parameter('initial_foo').value, 4321)
         self.assertEqual(self.node.get_parameter('foo').value, 42)
         self.assertEqual(self.node.get_parameter('bar').value, 'hello')
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+        self.assertIsNone(self.node.get_parameter('value_not_set').value)
+        self.assertTrue(self.node.has_parameter('value_not_set'))
 
         # Error cases.
         # TODO(@jubeira): add failing test cases with invalid names once name
@@ -434,7 +439,8 @@ class TestNode(unittest.TestCase):
         parameters = [
             ('foo', 42, ParameterDescriptor()),
             ('bar', 'hello', ParameterDescriptor()),
-            ('baz', 2.41, ParameterDescriptor()),
+            ('baz', 2.41),
+            ('value_not_set',)
         ]
 
         result = self.node.declare_parameters('', parameters)
@@ -444,12 +450,16 @@ class TestNode(unittest.TestCase):
         self.assertIsInstance(result[0], Parameter)
         self.assertIsInstance(result[1], Parameter)
         self.assertIsInstance(result[2], Parameter)
+        self.assertIsInstance(result[3], Parameter)
         self.assertEqual(result[0].value, 42)
         self.assertEqual(result[1].value, 'hello')
         self.assertEqual(result[2].value, 2.41)
+        self.assertIsNone(result[3].value)
         self.assertEqual(self.node.get_parameter('foo').value, 42)
         self.assertEqual(self.node.get_parameter('bar').value, 'hello')
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
+        self.assertIsNone(self.node.get_parameter('value_not_set').value)
+        self.assertTrue(self.node.has_parameter('value_not_set'))
 
         result = self.node.declare_parameters('namespace', parameters)
 
@@ -458,12 +468,16 @@ class TestNode(unittest.TestCase):
         self.assertIsInstance(result[0], Parameter)
         self.assertIsInstance(result[1], Parameter)
         self.assertIsInstance(result[2], Parameter)
+        self.assertIsInstance(result[3], Parameter)
         self.assertEqual(result[0].value, 42)
         self.assertEqual(result[1].value, 'hello')
         self.assertEqual(result[2].value, 2.41)
+        self.assertIsNone(result[3].value)
         self.assertEqual(self.node.get_parameter('namespace.foo').value, 42)
         self.assertEqual(self.node.get_parameter('namespace.bar').value, 'hello')
         self.assertEqual(self.node.get_parameter('namespace.baz').value, 2.41)
+        self.assertIsNone(self.node.get_parameter('namespace.value_not_set').value)
+        self.assertTrue(self.node.has_parameter('namespace.value_not_set'))
 
         # Error cases.
         with self.assertRaises(ParameterAlreadyDeclaredException):

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -399,15 +399,17 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
 
         # Error cases.
+        # TODO(@jubeira): add failing test cases with invalid names once name
+        # validation is implemented.
         with self.assertRaises(ParameterAlreadyDeclaredException):
             self.node.declare_parameter(
                 'foo', 'raise', ParameterDescriptor())
         with self.assertRaises(InvalidParameterException):
             self.node.declare_parameter(
-                '123foo', 'raise', ParameterDescriptor())
+                '', 'raise', ParameterDescriptor())
         with self.assertRaises(InvalidParameterException):
             self.node.declare_parameter(
-                'foo??', 'raise', ParameterDescriptor())
+                '', 'raise', ParameterDescriptor())
 
         self.node.set_parameters_callback(self.reject_parameter_callback)
         with self.assertRaises(InvalidParameterValueException):
@@ -449,7 +451,7 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_parameter('bar').value, 'hello')
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
 
-        result = self.node.declare_parameters('/namespace/', parameters)
+        result = self.node.declare_parameters('namespace', parameters)
 
         # OK cases.
         self.assertIsInstance(result, list)
@@ -459,9 +461,9 @@ class TestNode(unittest.TestCase):
         self.assertEqual(result[0].value, 42)
         self.assertEqual(result[1].value, 'hello')
         self.assertEqual(result[2].value, 2.41)
-        self.assertEqual(self.node.get_parameter('/namespace/foo').value, 42)
-        self.assertEqual(self.node.get_parameter('/namespace/bar').value, 'hello')
-        self.assertEqual(self.node.get_parameter('/namespace/baz').value, 2.41)
+        self.assertEqual(self.node.get_parameter('namespace.foo').value, 42)
+        self.assertEqual(self.node.get_parameter('namespace.bar').value, 'hello')
+        self.assertEqual(self.node.get_parameter('namespace.baz').value, 2.41)
 
         # Error cases.
         with self.assertRaises(ParameterAlreadyDeclaredException):
@@ -481,7 +483,7 @@ class TestNode(unittest.TestCase):
         parameters = [
             ('foobarbar', 44, ParameterDescriptor()),
             ('barbarbar', 'world', ParameterDescriptor()),
-            ('baz??wrong_name', 2.41, ParameterDescriptor()),
+            ('', 2.41, ParameterDescriptor()),
         ]
         with self.assertRaises(InvalidParameterException):
             self.node.declare_parameters('', parameters)


### PR DESCRIPTION
This PR is a backport of:

- #377 (namespace expansion check; commit https://github.com/ros2/rclpy/commit/d6291cf5bbe682cf0beb18dc5556724829edb9ce).
- #382 (allowing parameter declaration without a value; commit https://github.com/ros2/rclpy/commit/72f55462e7fb9c0011904da9949557996ba56396).