### PR TITLE
Declaring 'use_sim_time' when attaching node to time source.

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -181,6 +181,8 @@ class Node:
             self._descriptors.update({p: ParameterDescriptor() for p in self._parameters})
 
         # Clock that has support for ROS time.
+        # Note: parameter overrides and parameter event publisher need to be ready at this point
+        # to be able to declare 'use_sim_time' if it was not declared yet.
         self._clock = ROSClock()
         self._time_source = TimeSource(node=self)
         self._time_source.attach_clock(self._clock)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -164,11 +164,6 @@ class Node:
         with self.handle as capsule:
             self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(capsule))
 
-        # Clock that has support for ROS time.
-        self._clock = ROSClock()
-        self._time_source = TimeSource(node=self)
-        self._time_source.attach_clock(self._clock)
-
         self.__executor_weakref = None
 
         self._parameter_event_publisher = self.create_publisher(
@@ -184,6 +179,11 @@ class Node:
         if automatically_declare_parameters_from_overrides:
             self._parameters.update(self._parameter_overrides)
             self._descriptors.update({p: ParameterDescriptor() for p in self._parameters})
+
+        # Clock that has support for ROS time.
+        self._clock = ROSClock()
+        self._time_source = TimeSource(node=self)
+        self._time_source.attach_clock(self._clock)
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -36,6 +36,7 @@ from rclpy.executors import SingleThreadedExecutor
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
+from rclpy.time_source import USE_SIM_TIME_NAME
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'
@@ -586,6 +587,24 @@ class TestNode(unittest.TestCase):
         rejected_parameters = (param for param in parameter_list if 'reject' in param.name)
         return SetParametersResult(successful=(not any(rejected_parameters)))
 
+    def test_use_sim_time(self):
+        self.assertTrue(self.node.has_parameter(USE_SIM_TIME_NAME))
+        self.assertFalse(self.node.get_parameter(USE_SIM_TIME_NAME).value)
+
+        temp_node = rclpy.create_node(
+            TEST_NODE + '2',
+            namespace=TEST_NAMESPACE,
+            context=self.context,
+            parameter_overrides=[
+                Parameter(USE_SIM_TIME_NAME, value=True),
+            ],
+            automatically_declare_parameters_from_overrides=False
+        )
+        # use_sim_time is declared automatically anyways; in this case using override value.
+        self.assertTrue(temp_node.has_parameter(USE_SIM_TIME_NAME))
+        self.assertTrue(temp_node.get_parameter(USE_SIM_TIME_NAME).value)
+        temp_node.destroy_node()
+
     def test_node_undeclare_parameter_has_parameter(self):
         # Undeclare unexisting parameter.
         with self.assertRaises(ParameterNotDeclaredException):
@@ -681,7 +700,7 @@ class TestNode(unittest.TestCase):
 
         parameters = self.node.get_parameters_by_prefix('')
         self.assertIsInstance(parameters, dict)
-        self.assertEqual(len(parameters), 6)
+        # use_sim_time is automatically declared.
         self.assertDictEqual(
             parameters,
             {
@@ -690,7 +709,8 @@ class TestNode(unittest.TestCase):
                 'foo_prefix.baz': self.node.get_parameter('foo_prefix.baz'),
                 'bar_prefix.foo': self.node.get_parameter('bar_prefix.foo'),
                 'bar_prefix.bar': self.node.get_parameter('bar_prefix.bar'),
-                'bar_prefix.baz': self.node.get_parameter('bar_prefix.baz')
+                'bar_prefix.baz': self.node.get_parameter('bar_prefix.baz'),
+                USE_SIM_TIME_NAME : self.node.get_parameter(USE_SIM_TIME_NAME)
             }
         )
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -710,7 +710,7 @@ class TestNode(unittest.TestCase):
                 'bar_prefix.foo': self.node.get_parameter('bar_prefix.foo'),
                 'bar_prefix.bar': self.node.get_parameter('bar_prefix.bar'),
                 'bar_prefix.baz': self.node.get_parameter('bar_prefix.baz'),
-                USE_SIM_TIME_NAME : self.node.get_parameter(USE_SIM_TIME_NAME)
+                USE_SIM_TIME_NAME: self.node.get_parameter(USE_SIM_TIME_NAME)
             }
         )
 


### PR DESCRIPTION
Closes #395.

Signed-off-by: Juan Ignacio Ubeira <jubeira@ekumenlabs.com>