### PR TITLE
[Backport - dashing] Declaring 'use_sim_time' when attaching node to time source

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -164,11 +164,6 @@ class Node:
         with self.handle as capsule:
             self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(capsule))
 
-        # Clock that has support for ROS time.
-        self._clock = ROSClock()
-        self._time_source = TimeSource(node=self)
-        self._time_source.attach_clock(self._clock)
-
         self.__executor_weakref = None
 
         self._parameter_event_publisher = self.create_publisher(
@@ -184,6 +179,13 @@ class Node:
         if automatically_declare_parameters_from_overrides:
             self._parameters.update(self._parameter_overrides)
             self._descriptors.update({p: ParameterDescriptor() for p in self._parameters})
+
+        # Clock that has support for ROS time.
+        # Note: parameter overrides and parameter event publisher need to be ready at this point
+        # to be able to declare 'use_sim_time' if it was not declared yet.
+        self._clock = ROSClock()
+        self._time_source = TimeSource(node=self)
+        self._time_source.attach_clock(self._clock)
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -36,6 +36,7 @@ from rclpy.executors import SingleThreadedExecutor
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
+from rclpy.time_source import USE_SIM_TIME_NAME
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'
@@ -545,6 +546,24 @@ class TestNode(unittest.TestCase):
     def reject_parameter_callback(self, parameter_list):
         rejected_parameters = (param for param in parameter_list if 'reject' in param.name)
         return SetParametersResult(successful=(not any(rejected_parameters)))
+
+    def test_use_sim_time(self):
+        self.assertTrue(self.node.has_parameter(USE_SIM_TIME_NAME))
+        self.assertFalse(self.node.get_parameter(USE_SIM_TIME_NAME).value)
+
+        temp_node = rclpy.create_node(
+            TEST_NODE + '2',
+            namespace=TEST_NAMESPACE,
+            context=self.context,
+            parameter_overrides=[
+                Parameter(USE_SIM_TIME_NAME, value=True),
+            ],
+            automatically_declare_parameters_from_overrides=False
+        )
+        # use_sim_time is declared automatically anyways; in this case using override value.
+        self.assertTrue(temp_node.has_parameter(USE_SIM_TIME_NAME))
+        self.assertTrue(temp_node.get_parameter(USE_SIM_TIME_NAME).value)
+        temp_node.destroy_node()
 
     def test_node_undeclare_parameter_has_parameter(self):
         # Undeclare unexisting parameter.


### PR DESCRIPTION
Backports #396 to `dashing`.