### PR TITLE
Check if context is ok when initializing wait set in executor

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -521,6 +521,9 @@ class Executor:
                     except InvalidHandle:
                         entity_count.num_guard_conditions -= 1
 
+                if not self._context.ok():
+                    raise ShutdownException()
+
                 _rclpy.rclpy_wait_set_init(
                     wait_set,
                     entity_count.num_subscriptions,


### PR DESCRIPTION
Fixes https://github.com/ros2/rclpy/issues/398.

The context is being shutdown externally https://github.com/ros-visualization/rqt/blob/3911625f95cc14a751c91fa2712d78ab1a6854cc/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py#L81-L85.
But the executor is using it for creating a wait_set:
https://github.com/ros2/rclpy/blob/1588d0753ecddb149c22db33883763cb4b0de69e/rclpy/rclpy/executors.py#L524-L532
So when the context is shut down externally, this error happens:
```
Traceback (most recent call last):
  File "/Users/karsten/workspace/osrf/ros2_full/build/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py", line 32, in run
    executor.spin_once(timeout_sec=1.0)
  File "/Users/karsten/workspace/osrf/ros2_full/install/lib/python3.7/site-packages/rclpy/executors.py", line 695, in spin_once
    handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
  File "/Users/karsten/workspace/osrf/ros2_full/install/lib/python3.7/site-packages/rclpy/executors.py", line 649, in wait_for_ready_callbacks
    return next(self._cb_iter)
  File "/Users/karsten/workspace/osrf/ros2_full/install/lib/python3.7/site-packages/rclpy/executors.py", line 532, in _wait_for_ready_callbacks
    self._context.handle)
RuntimeError: Failed to initialize wait set: the given context is not valid, either rcl_init() was not called or rcl_shutdown() was called., at /Users/karsten/workspace/osrf/ros2_full/src/ros2/rcl/rcl/src/rcl/wait.c:130
```

This avoids the error, by checking if the context is ok. If not it raises a `ShutdownException`.

----

rclcpp is doing something much cleaner: It doesn't use the executor when waiting for a new executable. It only uses the context when creating/destructing the executor. Why?
Because rclcpp doesn't create a wait set each time, but resizes it:
https://github.com/ros2/rclcpp/blob/9be3e08cd4d04193fb76cb6dd8f5db11d7199e2f/rclcpp/src/rclcpp/executor.cpp#L451-L459
A context is not needed for resizing.

If we want to do the same, we will need to add some functions from rcl to rclpy (I think that's subject of a follow up).

----

rqt_publisher still fails when closing it, but with a failure not related to rclpy:
```
Exception ignored in: <bound method DockWidgetTitleBar.__del__ of <qt_gui.dock_widget_title_bar.DockWidgetTitleBar object at 0x7fe914174678>>
Traceback (most recent call last):
  File "/home/ivanpauno/ros2_ws/install/qt_gui/lib/python3.6/site-packages/qt_gui/dock_widget_title_bar.py", line 109, in __del__
    self._dock_widget.removeEventFilter(self)
RuntimeError: wrapped C/C++ object of type DockWidget has been deleted
```