### PR TITLE
Awake waitables on shutdown, check if context is valid

### DIFF
--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -28,10 +28,31 @@ class Context:
         from rclpy.impl.implementation_singleton import rclpy_implementation
         self._handle = rclpy_implementation.rclpy_create_context()
         self._lock = threading.Lock()
+        self._guard_lock = threading.RLock()
+        self._guard_conditions = {}
 
     @property
     def handle(self):
         return self._handle
+
+    def get_interrupt_guard_condition(self, wait_set):
+        with self._guard_lock:
+            from .guard_condition import GuardCondition
+            if wait_set not in self._guard_conditions:
+                self._guard_conditions[wait_set] = GuardCondition(
+                    callback=None, callback_group=None, context=self)
+            return self._guard_conditions[wait_set]
+
+    def release_interrupt_guard_condition(self, wait_set):
+        with self._guard_lock:
+            if wait_set in self._guard_conditions:
+                self._guard_conditions[wait_set].destroy()
+                del self._guard_conditions[wait_set]
+
+    def interrupt_wait_sets(self):
+        with self._guard_lock:
+            for gc in self._guard_conditions.values():
+                gc.trigger()
 
     def ok(self):
         # imported locally to avoid loading extensions on module import
@@ -43,7 +64,8 @@ class Context:
         # imported locally to avoid loading extensions on module import
         from rclpy.impl.implementation_singleton import rclpy_implementation
         with self._lock:
-            return rclpy_implementation.rclpy_shutdown(self._handle)
+            rclpy_implementation.rclpy_shutdown(self._handle)
+            self.interrupt_wait_sets()
 
     def try_shutdown(self):
         """Shutdown rclpy if not already shutdown."""

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -69,10 +69,6 @@ class Context:
     def on_shutdown(self, callback: Callable[[], None]):
         """Add a callback to be called on shutdown."""
         if not callable(callback):
-            raise ValueError('callback should be a callable, got {}', type(callback))
+            raise TypeError('callback should be a callable, got {}', type(callback))
         with self._callbacks_lock:
             self._callbacks.append(callback)
-
-    def get_on_shutdown_callbacks(self):
-        """Get registered on shutdown callbacks."""
-        return self._callbacks

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -47,6 +47,7 @@ class Context:
         with self._callbacks_lock:
             for callback in self._callbacks:
                 callback()
+            self._callbacks = []
 
     def shutdown(self):
         """Shutdown this context."""
@@ -63,7 +64,7 @@ class Context:
         with self._lock:
             if rclpy_implementation.rclpy_ok(self._handle):
                 rclpy_implementation.rclpy_shutdown(self._handle)
-        self._call_on_shutdown_callbacks()
+                self._call_on_shutdown_callbacks()
 
     def on_shutdown(self, callback: Callable[[], None]):
         """Add a callback to be called on shutdown."""

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -67,6 +67,9 @@ class _WaitSet:
     def __enter__(self):
         self.wait_set = _rclpy.rclpy_get_zero_initialized_wait_set()
         self.gc = self.context.get_interrupt_guard_condition(self)
+        return self
+
+    def get_capsule(self):
         return self.wait_set
 
     def __exit__(self, t, v, tb):
@@ -489,10 +492,10 @@ class Executor:
             guards.append(self._guard)
             guards.append(self._sigint_gc)
 
-            wait_set_wrapper = _WaitSet(self.context)
             # Construct a wait set
-            with wait_set_wrapper as wait_set, ExitStack() as context_stack:
-                guards.append(wait_set_wrapper.gc)
+            with _WaitSet(self.context) as wait_set, ExitStack() as context_stack:
+                guards.append(wait_set.gc)
+                wait_set = wait_set.get_capsule()
                 entity_count = NumberOfEntities(
                    len(subscriptions), len(guards), len(timers), len(clients), len(services))
 


### PR DESCRIPTION
Replaces https://github.com/ros2/rclpy/pull/402.
Fixes #398.

It solves two problems:

- The executor wasn't awaken when shutdown
- `_wait_for_ready_callbacks` was looping until yielding work, without checking if the context is valid.

Some error messages may still appear when shutting down contexts (similar to https://github.com/ros2/rclcpp/issues/812), but they are harder to reproduce.