### PR TITLE
Changelog version to master

### DIFF
--- a/rclpy/CHANGELOG.rst
+++ b/rclpy/CHANGELOG.rst
@@ -1,5 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.6 (2019-08-28)
+------------------
+* Fix missing raise (`#390 <https://github.com/ros2/rclpy/pull/390>`_)
+* Fix time conversion for big nanoseconds value (`#384 <https://github.com/ros2/rclpy/pull/384>`_)
+* Contributors: Daniel Wang, Vinnam Kim
 
 0.7.5 (2019-08-01)
 ------------------

--- a/rclpy/CHANGELOG.rst
+++ b/rclpy/CHANGELOG.rst
@@ -1,8 +1,8 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-Forthcoming
------------
+0.7.4 (2019-06-12)
+------------------
 * Fix API documentation related to ROS graph methods (`#366 <https://github.com/ros2/rclpy/issues/366>`_)
 * Contributors: Jacob Perron
 

--- a/rclpy/CHANGELOG.rst
+++ b/rclpy/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+Forthcoming
+-----------
+* Fix API documentation related to ROS graph methods (`#366 <https://github.com/ros2/rclpy/issues/366>`_)
+* Contributors: Jacob Perron
+
 0.7.3 (2019-05-29)
 ------------------
 * Rename parameter options (`#363 <https://github.com/ros2/rclpy/issues/363>`_)

--- a/rclpy/CHANGELOG.rst
+++ b/rclpy/CHANGELOG.rst
@@ -1,6 +1,16 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.7.5 (2019-08-01)
+------------------
+* Updated to use params from node '/**' from parameter YAML file. (`#399 <https://github.com/ros2/rclpy/issues/399>`_)
+* Updated to declare 'use_sim_time' when attaching node to time source. (`#401 <https://github.com/ros2/rclpy/issues/401>`_)
+* Fixed an errant conversion to nsecs in executors timeout.` (`#397 <https://github.com/ros2/rclpy/issues/397>`_)
+* Fixed parameter handling issues. (`#394 <https://github.com/ros2/rclpy/issues/394>`_)
+  * Fixing namespace expansion for declare_parameters. (`#377 <https://github.com/ros2/rclpy/issues/377>`_)
+  * Allowing parameter declaration without a given value. (`#382 <https://github.com/ros2/rclpy/issues/382>`_)
+* Contributors: Juan Ignacio Ubeira, Scott K Logan
+
 0.7.4 (2019-06-12)
 ------------------
 * Fix API documentation related to ROS graph methods (`#366 <https://github.com/ros2/rclpy/issues/366>`_)

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclpy</name>
-  <version>0.7.3</version>
+  <version>0.7.4</version>
   <description>Package containing the Python client.</description>
 
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclpy</name>
-  <version>0.7.4</version>
+  <version>0.7.5</version>
   <description>Package containing the Python client.</description>
 
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rclpy</name>
-  <version>0.7.5</version>
+  <version>0.7.6</version>
   <description>Package containing the Python client.</description>
 
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>


### PR DESCRIPTION
This brings the version and CHANGELOG on `master` up to date with the `dashing` branch.

@nuclearsandwich what's your opinion on keeping `master`'s version up to date with the latest release? 