### PR TITLE
Make Future result() and __await__ raise exceptions

### DIFF
--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -54,7 +54,7 @@ class Future:
         # Yield if the task is not finished
         while not self._done:
             yield
-        return self._result
+        return self.result()
 
     def cancel(self):
         """Request cancellation of the running task if it is not done already."""
@@ -85,8 +85,12 @@ class Future:
         """
         Get the result of a done task.
 
+        This raises an exception if one was set during the task.
+
         :return: The result set by the task
         """
+        if self._exception:
+            raise self.exception()
         return self._result
 
     def exception(self):

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -85,7 +85,7 @@ class Future:
         """
         Get the result of a done task.
 
-        This raises an exception if one was set during the task.
+        :raises: Exception if one was set during the task.
 
         :return: The result set by the task
         """

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -138,7 +138,8 @@ class TestTask(unittest.TestCase):
         t()
         self.assertTrue(t.done())
         self.assertEqual('Sentinel Exception', t.exception().sentinel_value)
-        self.assertEqual(None, t.result())
+        with self.assertRaises(Exception):
+            t.result()
 
     def test_coroutine_exception(self):
 
@@ -151,7 +152,8 @@ class TestTask(unittest.TestCase):
         t()
         self.assertTrue(t.done())
         self.assertEqual('Sentinel Exception', t.exception().sentinel_value)
-        self.assertEqual(None, t.result())
+        with self.assertRaises(Exception):
+            t.result()
 
     def test_task_normal_callable_args(self):
         arg_in = 'Sentinel Arg'
@@ -237,6 +239,19 @@ class TestFuture(unittest.TestCase):
             c.send(None)
         except StopIteration as e:
             self.assertEqual('Sentinel Result', e.value)
+
+    def test_await_exception(self):
+        f = Future()
+
+        async def coro():
+            nonlocal f
+            return await f
+
+        c = coro()
+        c.send(None)
+        f.set_exception(RuntimeError('test exception'))
+        with self.assertRaises(RuntimeError):
+            c.send(None)
 
     def test_cancel_schedules_callbacks(self):
         executor = DummyExecutor()


### PR DESCRIPTION
This matches the behavior of `result` and `__await__` on asyncio Future's, and makes them a little more convenient to use in other coroutines.

* [`asyncio.futures.Future.result()`](https://github.com/python/cpython/blob/96b4087ce784ee7434dffdf69c475f5b40543982/Lib/asyncio/futures.py#L174-L175)
* [`asyncio.futures.Future.__await__`](https://github.com/python/cpython/blob/96b4087ce784ee7434dffdf69c475f5b40543982/Lib/asyncio/futures.py#L260)


Before

```python3
result = await future
if result is None:
   # Do something with exception
   raise future.exception()
```

After
```python3 
# Exception is raised if task fails
result = await future
```