### PR TITLE
Force explicit --ros-args in cli args.

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -115,8 +115,8 @@ class Node:
         :param context: The context to be associated with, or ``None`` for the default global
             context.
         :param cli_args: A list of strings of command line args to be used only by this node.
-            Being specific to a ROS node, an implicit `--ros-args` scope flag always precedes
-            these arguments.
+            These arguments are used to extract remappings used by the node and other ROS specific
+            settings, as well as user defined non-ROS arguments.
         :param namespace: The namespace to which relative topic and service names will be prefixed.
             Validated by :func:`validate_namespace`.
         :param use_global_arguments: ``False`` if the node should ignore process-wide command line
@@ -146,8 +146,6 @@ class Node:
         self._parameter_overrides = {}
         self._descriptors = {}
 
-        if cli_args is not None and '--ros-args' not in cli_args:
-            cli_args = ['--ros-args', *cli_args]
         namespace = namespace or ''
         if not self._context.ok():
             raise NotInitializedException('cannot create node')

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1550,7 +1550,11 @@ class TestCreateNode(unittest.TestCase):
         rclpy.init(context=context)
         try:
             node = rclpy.create_node(
-                'my_node', namespace='/my_ns', cli_args=['-r', '__ns:=/foo/bar'], context=context)
+                'my_node',
+                namespace='/my_ns',
+                cli_args=['--ros-args', '-r', '__ns:=/foo/bar'],
+                context=context
+            )
             self.assertEqual('/foo/bar', node.get_namespace())
             node.destroy_node()
         finally:


### PR DESCRIPTION
Precisely what the title says. Follow-up after https://github.com/ros2/rclcpp/pull/816 and https://github.com/ros2/rclpy/pull/405#discussion_r319069482. Necessary for https://github.com/ros2/rcl/pull/493 considering https://github.com/ros2/rclcpp/pull/784.