### PR TITLE
Lazily import C extensions

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -42,7 +42,6 @@ This will invalidate all entities derived from the context.
 
 import sys
 from typing import List
-from typing import TYPE_CHECKING
 
 from rclpy.context import Context
 from rclpy.executors import Executor
@@ -67,7 +66,9 @@ def init(*, args: List[str] = None, context: Context = None) -> None:
         (see :func:`.get_default_context`).
     """
     context = get_default_context() if context is None else context
-    return get_rclpy_implementation().rclpy_init(args if args is not None else sys.argv, context.handle)
+    return get_rclpy_implementation().rclpy_init(
+        args if args is not None else sys.argv, context.handle
+    )
 
 
 # The global spin functions need an executor to do the work

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -45,6 +45,10 @@ from typing import List
 from typing import TYPE_CHECKING
 
 from rclpy.context import Context
+from rclpy.executors import Executor
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
+from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.task import Future
 from rclpy.utilities import get_default_context
@@ -52,11 +56,6 @@ from rclpy.utilities import get_rmw_implementation_identifier  # noqa: F401
 from rclpy.utilities import ok  # noqa: F401 forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
 from rclpy.utilities import try_shutdown  # noqa: F401
-
-# Avoid loading extensions on module import
-if TYPE_CHECKING:
-    from rclpy.executors import Executor  # noqa: F401
-    from rclpy.node import Node  # noqa: F401
 
 
 def init(*, args: List[str] = None, context: Context = None) -> None:
@@ -68,9 +67,7 @@ def init(*, args: List[str] = None, context: Context = None) -> None:
         (see :func:`.get_default_context`).
     """
     context = get_default_context() if context is None else context
-    # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    return rclpy_implementation.rclpy_init(args if args is not None else sys.argv, context.handle)
+    return get_rclpy_implementation().rclpy_init(args if args is not None else sys.argv, context.handle)
 
 
 # The global spin functions need an executor to do the work
@@ -78,11 +75,9 @@ def init(*, args: List[str] = None, context: Context = None) -> None:
 __executor = None
 
 
-def get_global_executor() -> 'Executor':
+def get_global_executor() -> Executor:
     global __executor
     if __executor is None:
-        # imported locally to avoid loading extensions on module import
-        from rclpy.executors import SingleThreadedExecutor
         __executor = SingleThreadedExecutor()
     return __executor
 
@@ -114,7 +109,7 @@ def create_node(
     parameter_overrides: List[Parameter] = None,
     allow_undeclared_parameters: bool = False,
     automatically_declare_parameters_from_overrides: bool = False
-) -> 'Node':
+) -> Node:
     """
     Create an instance of :class:`.Node`.
 
@@ -136,8 +131,6 @@ def create_node(
         be used to implicitly declare parameters on the node during creation, default False.
     :return: An instance of the newly created node.
     """
-    # imported locally to avoid loading extensions on module import
-    from rclpy.node import Node  # noqa: F811
     return Node(
         node_name, context=context, cli_args=cli_args, namespace=namespace,
         use_global_arguments=use_global_arguments,

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -22,8 +22,7 @@ from action_msgs.srv import CancelGoal
 
 from rclpy.executors import await_or_execute
 from rclpy.impl.implementation_singleton import get_rclpy_action_implementation
-from rclpy.qos import qos_profile_action_status_default
-from rclpy.qos import qos_profile_services_default
+from rclpy.qos import qos_profiles
 from rclpy.qos import QoSProfile
 from rclpy.task import Future
 from rclpy.type_support import check_for_type_support
@@ -118,11 +117,11 @@ class ActionClient(Waitable):
         action_name,
         *,
         callback_group=None,
-        goal_service_qos_profile=qos_profile_services_default,
-        result_service_qos_profile=qos_profile_services_default,
-        cancel_service_qos_profile=qos_profile_services_default,
-        feedback_sub_qos_profile=QoSProfile(depth=10),
-        status_sub_qos_profile=qos_profile_action_status_default
+        goal_service_qos_profile=None,
+        result_service_qos_profile=None,
+        cancel_service_qos_profile=None,
+        feedback_sub_qos_profile=None,
+        status_sub_qos_profile=None
     ):
         """
         Constructor.
@@ -139,6 +138,17 @@ class ActionClient(Waitable):
         :param feedback_sub_qos_profile: QoS profile for the feedback subscriber.
         :param status_sub_qos_profile: QoS profile for the status subscriber.
         """
+        if goal_service_qos_profile is None:
+            goal_service_qos_profile = qos_profiles.services_default
+        if result_service_qos_profile is None:
+            result_service_qos_profile = qos_profiles.services_default
+        if cancel_service_qos_profile is None:
+            cancel_service_qos_profile = qos_profiles.services_default
+        if feedback_sub_qos_profile is None:
+            feedback_sub_qos_profile = QoSProfile(depth=10)
+        if status_sub_qos_profile is None:
+            status_sub_qos_profile = qos_profiles.action_status_default
+
         if callback_group is None:
             callback_group = node.default_callback_group
 

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -21,7 +21,7 @@ from action_msgs.msg import GoalStatus
 from action_msgs.srv import CancelGoal
 
 from rclpy.executors import await_or_execute
-from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
+from rclpy.impl.implementation_singleton import get_rclpy_action_implementation
 from rclpy.qos import qos_profile_action_status_default
 from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
@@ -149,7 +149,7 @@ class ActionClient(Waitable):
         self._node = node
         self._action_type = action_type
         with node.handle as node_capsule:
-            self._client_handle = _rclpy_action.rclpy_action_create_client(
+            self._client_handle = get_rclpy_action_implementation().rclpy_action_create_client(
                 node_capsule,
                 action_type,
                 action_name,
@@ -219,7 +219,7 @@ class ActionClient(Waitable):
     # Start Waitable API
     def is_ready(self, wait_set):
         """Return True if one or more entities are ready in the wait set."""
-        ready_entities = _rclpy_action.rclpy_action_wait_set_is_ready(
+        ready_entities = get_rclpy_action_implementation().rclpy_action_wait_set_is_ready(
             self._client_handle,
             wait_set)
         self._is_feedback_ready = ready_entities[0]
@@ -233,35 +233,35 @@ class ActionClient(Waitable):
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         data = {}
         if self._is_goal_response_ready:
-            taken_data = _rclpy_action.rclpy_action_take_goal_response(
+            taken_data = get_rclpy_action_implementation().rclpy_action_take_goal_response(
                 self._client_handle, self._action_type.Impl.SendGoalService.Response)
             # If take fails, then we get (None, None)
             if all(taken_data):
                 data['goal'] = taken_data
 
         if self._is_cancel_response_ready:
-            taken_data = _rclpy_action.rclpy_action_take_cancel_response(
+            taken_data = get_rclpy_action_implementation().rclpy_action_take_cancel_response(
                 self._client_handle, self._action_type.Impl.CancelGoalService.Response)
             # If take fails, then we get (None, None)
             if all(taken_data):
                 data['cancel'] = taken_data
 
         if self._is_result_response_ready:
-            taken_data = _rclpy_action.rclpy_action_take_result_response(
+            taken_data = get_rclpy_action_implementation().rclpy_action_take_result_response(
                 self._client_handle, self._action_type.Impl.GetResultService.Response)
             # If take fails, then we get (None, None)
             if all(taken_data):
                 data['result'] = taken_data
 
         if self._is_feedback_ready:
-            taken_data = _rclpy_action.rclpy_action_take_feedback(
+            taken_data = get_rclpy_action_implementation().rclpy_action_take_feedback(
                 self._client_handle, self._action_type.Impl.FeedbackMessage)
             # If take fails, then we get None
             if taken_data is not None:
                 data['feedback'] = taken_data
 
         if self._is_status_ready:
-            taken_data = _rclpy_action.rclpy_action_take_status(
+            taken_data = get_rclpy_action_implementation().rclpy_action_take_status(
                 self._client_handle, self._action_type.Impl.GoalStatusMessage)
             # If take fails, then we get None
             if taken_data is not None:
@@ -328,12 +328,17 @@ class ActionClient(Waitable):
 
     def get_num_entities(self):
         """Return number of each type of entity used in the wait set."""
-        num_entities = _rclpy_action.rclpy_action_wait_set_get_num_entities(self._client_handle)
+        num_entities = get_rclpy_action_implementation().rclpy_action_wait_set_get_num_entities(
+            self._client_handle
+        )
         return NumberOfEntities(*num_entities)
 
     def add_to_wait_set(self, wait_set):
         """Add entities to wait set."""
-        _rclpy_action.rclpy_action_wait_set_add(self._client_handle, wait_set)
+        get_rclpy_action_implementation().rclpy_action_wait_set_add(
+            self._client_handle,
+            wait_set
+        )
     # End Waitable API
 
     def send_goal(self, goal, **kwargs):
@@ -404,7 +409,7 @@ class ActionClient(Waitable):
         request = self._action_type.Impl.SendGoalService.Request()
         request.goal_id = self._generate_random_uuid() if goal_uuid is None else goal_uuid
         request.goal = goal
-        sequence_number = _rclpy_action.rclpy_action_send_goal_request(
+        sequence_number = get_rclpy_action_implementation().rclpy_action_send_goal_request(
             self._client_handle, request)
         if sequence_number in self._pending_goal_requests:
             raise RuntimeError(
@@ -463,7 +468,7 @@ class ActionClient(Waitable):
 
         cancel_request = CancelGoal.Request()
         cancel_request.goal_info.goal_id = goal_handle.goal_id
-        sequence_number = _rclpy_action.rclpy_action_send_cancel_request(
+        sequence_number = get_rclpy_action_implementation().rclpy_action_send_cancel_request(
             self._client_handle,
             cancel_request)
         if sequence_number in self._pending_cancel_requests:
@@ -517,7 +522,7 @@ class ActionClient(Waitable):
 
         result_request = self._action_type.Impl.GetResultService.Request()
         result_request.goal_id = goal_handle.goal_id
-        sequence_number = _rclpy_action.rclpy_action_send_result_request(
+        sequence_number = get_rclpy_action_implementation().rclpy_action_send_result_request(
             self._client_handle,
             result_request)
         if sequence_number in self._pending_result_requests:
@@ -539,7 +544,7 @@ class ActionClient(Waitable):
         :return: True if an action server is ready, False otherwise.
         """
         with self._node.handle as node_capsule:
-            return _rclpy_action.rclpy_action_server_is_available(
+            return get_rclpy_action_implementation().rclpy_action_server_is_available(
                 node_capsule,
                 self._client_handle)
 
@@ -568,7 +573,10 @@ class ActionClient(Waitable):
         if self._client_handle is None:
             return
         with self._node.handle as node_capsule:
-            _rclpy_action.rclpy_action_destroy_entity(self._client_handle, node_capsule)
+            get_rclpy_action_implementation().rclpy_action_destroy_entity(
+                self._client_handle,
+                node_capsule
+            )
             self._node.remove_waitable(self)
         self._client_handle = None
 

--- a/rclpy/rclpy/action/graph.py
+++ b/rclpy/rclpy/action/graph.py
@@ -15,7 +15,7 @@
 from typing import List
 from typing import Tuple
 
-from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
+from rclpy.impl.implementation_singleton import get_rclpy_action_implementation
 from rclpy.node import Node
 
 
@@ -35,7 +35,7 @@ def get_action_client_names_and_types_by_node(
       action types.
     """
     with node.handle as node_capsule:
-        return _rclpy_action.rclpy_action_get_client_names_and_types_by_node(
+        return get_rclpy_action_implementation().rclpy_action_get_client_names_and_types_by_node(
             node_capsule, remote_node_name, remote_node_namespace)
 
 
@@ -55,7 +55,7 @@ def get_action_server_names_and_types_by_node(
       action types.
     """
     with node.handle as node_capsule:
-        return _rclpy_action.rclpy_action_get_server_names_and_types_by_node(
+        return get_rclpy_action_implementation().rclpy_action_get_server_names_and_types_by_node(
             node_capsule, remote_node_name, remote_node_namespace)
 
 
@@ -69,4 +69,4 @@ def get_action_names_and_types(node: Node) -> List[Tuple[str, List[str]]]:
       action types.
     """
     with node.handle as node_capsule:
-        return _rclpy_action.rclpy_action_get_names_and_types(node_capsule)
+        return get_rclpy_action_implementation().rclpy_action_get_names_and_types(node_capsule)

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -20,8 +20,7 @@ from action_msgs.msg import GoalInfo, GoalStatus
 
 from rclpy.executors import await_or_execute
 from rclpy.impl.implementation_singleton import get_rclpy_action_implementation
-from rclpy.qos import qos_profile_action_status_default
-from rclpy.qos import qos_profile_services_default
+from rclpy.qos import qos_profiles
 from rclpy.qos import QoSProfile
 from rclpy.task import Future
 from rclpy.type_support import check_for_type_support
@@ -212,11 +211,11 @@ class ActionServer(Waitable):
         goal_callback=default_goal_callback,
         handle_accepted_callback=default_handle_accepted_callback,
         cancel_callback=default_cancel_callback,
-        goal_service_qos_profile=qos_profile_services_default,
-        result_service_qos_profile=qos_profile_services_default,
-        cancel_service_qos_profile=qos_profile_services_default,
-        feedback_pub_qos_profile=QoSProfile(depth=10),
-        status_pub_qos_profile=qos_profile_action_status_default,
+        goal_service_qos_profile=None,
+        result_service_qos_profile=None,
+        cancel_service_qos_profile=None,
+        feedback_pub_qos_profile=None,
+        status_pub_qos_profile=None,
         result_timeout=900
     ):
         """
@@ -243,6 +242,17 @@ class ActionServer(Waitable):
         :param result_timeout: How long in seconds a result is kept by the server after a goal
             reaches a terminal state.
         """
+        if goal_service_qos_profile is None:
+            goal_service_qos_profile = qos_profiles.services_default
+        if result_service_qos_profile is None:
+            result_service_qos_profile = qos_profiles.services_default
+        if cancel_service_qos_profile is None:
+            cancel_service_qos_profile = qos_profiles.services_default
+        if feedback_pub_qos_profile is None:
+            feedback_pub_qos_profile = QoSProfile(depth=10)
+        if status_pub_qos_profile is None:
+            status_pub_qos_profile = qos_profiles.action_status_default
+
         if callback_group is None:
             callback_group = node.default_callback_group
 

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -19,7 +19,7 @@ from typing import TypeVar
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.context import Context
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.qos import QoSProfile
 from rclpy.task import Future
 
@@ -123,7 +123,7 @@ class Client:
             raise TypeError()
 
         with self.handle as capsule:
-            sequence_number = _rclpy.rclpy_send_request(capsule, request)
+            sequence_number = get_rclpy_implementation().rclpy_send_request(capsule, request)
         if sequence_number in self._pending_requests:
             raise RuntimeError('Sequence (%r) conflicts with pending request' % sequence_number)
 
@@ -141,7 +141,7 @@ class Client:
         :return: ``True`` if a server is ready, ``False`` otherwise.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_service_server_is_available(capsule)
+            return get_rclpy_implementation().rclpy_service_server_is_available(capsule)
 
     def wait_for_service(self, timeout_sec: float = None) -> bool:
         """

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -15,7 +15,7 @@
 from enum import IntEnum
 
 from rclpy.handle import Handle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 from .duration import Duration
 
@@ -107,14 +107,14 @@ class JumpHandle:
             min_backward = threshold.min_backward.nanoseconds
 
         with self._clock.handle as clock_capsule:
-            _rclpy.rclpy_add_clock_callback(
+            get_rclpy_implementation().rclpy_add_clock_callback(
                 clock_capsule, self, threshold.on_clock_change, min_forward, min_backward)
 
     def unregister(self):
         """Remove a jump callback from the clock."""
         if self._clock is not None:
             with self._clock.handle as clock_capsule:
-                _rclpy.rclpy_remove_clock_callback(clock_capsule, self)
+                get_rclpy_implementation().rclpy_remove_clock_callback(clock_capsule, self)
             self._clock = None
 
 
@@ -127,7 +127,7 @@ class Clock:
             self = super().__new__(ROSClock)
         else:
             self = super().__new__(cls)
-        self.__handle = Handle(_rclpy.rclpy_create_clock(clock_type))
+        self.__handle = Handle(get_rclpy_implementation().rclpy_create_clock(clock_type))
         self._clock_type = clock_type
         return self
 
@@ -145,10 +145,10 @@ class Clock:
     def now(self):
         from rclpy.time import Time
         with self.handle as clock_capsule:
-            time_handle = _rclpy.rclpy_clock_get_now(clock_capsule)
+            time_handle = get_rclpy_implementation().rclpy_clock_get_now(clock_capsule)
         # TODO(dhood): Return a python object from the C extension
         return Time(
-            nanoseconds=_rclpy.rclpy_time_point_get_nanoseconds(time_handle),
+            nanoseconds=get_rclpy_implementation().rclpy_time_point_get_nanoseconds(time_handle),
             clock_type=self.clock_type)
 
     def create_jump_callback(self, threshold, *, pre_callback=None, post_callback=None):
@@ -198,12 +198,17 @@ class ROSClock(Clock):
     @property
     def ros_time_is_active(self):
         with self.handle as clock_capsule:
-            return _rclpy.rclpy_clock_get_ros_time_override_is_enabled(clock_capsule)
+            return get_rclpy_implementation().rclpy_clock_get_ros_time_override_is_enabled(
+                clock_capsule
+            )
 
     def _set_ros_time_is_active(self, enabled):
         # This is not public because it is only to be called by a TimeSource managing the Clock
         with self.handle as clock_capsule:
-            _rclpy.rclpy_clock_set_ros_time_override_is_enabled(clock_capsule, enabled)
+            get_rclpy_implementation().rclpy_clock_set_ros_time_override_is_enabled(
+                clock_capsule,
+                enabled
+            )
 
     def set_ros_time_override(self, time):
         from rclpy.time import Time
@@ -211,4 +216,7 @@ class ROSClock(Clock):
             raise TypeError(
                 'Time must be specified as rclpy.time.Time. Received type: {0}'.format(type(time)))
         with self.handle as clock_capsule:
-            _rclpy.rclpy_clock_set_ros_time_override(clock_capsule, time._time_handle)
+            get_rclpy_implementation().rclpy_clock_set_ros_time_override(
+                clock_capsule,
+                time._time_handle
+            )

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -15,6 +15,8 @@
 import threading
 from typing import Callable
 
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
+
 
 class Context:
     """
@@ -26,8 +28,7 @@ class Context:
     """
 
     def __init__(self):
-        from rclpy.impl.implementation_singleton import rclpy_implementation
-        self._handle = rclpy_implementation.rclpy_create_context()
+        self._handle = get_rclpy_implementation().rclpy_create_context()
         self._lock = threading.Lock()
         self._callbacks = []
         self._callbacks_lock = threading.Lock()
@@ -38,10 +39,8 @@ class Context:
 
     def ok(self):
         """Check if context hasn't been shut down."""
-        # imported locally to avoid loading extensions on module import
-        from rclpy.impl.implementation_singleton import rclpy_implementation
         with self._lock:
-            return rclpy_implementation.rclpy_ok(self._handle)
+            return get_rclpy_implementation().rclpy_ok(self._handle)
 
     def _call_on_shutdown_callbacks(self):
         with self._callbacks_lock:
@@ -51,19 +50,15 @@ class Context:
 
     def shutdown(self):
         """Shutdown this context."""
-        # imported locally to avoid loading extensions on module import
-        from rclpy.impl.implementation_singleton import rclpy_implementation
         with self._lock:
-            rclpy_implementation.rclpy_shutdown(self._handle)
+            get_rclpy_implementation().rclpy_shutdown(self._handle)
         self._call_on_shutdown_callbacks()
 
     def try_shutdown(self):
         """Shutdown this context, if not already shutdown."""
-        # imported locally to avoid loading extensions on module import
-        from rclpy.impl.implementation_singleton import rclpy_implementation
         with self._lock:
-            if rclpy_implementation.rclpy_ok(self._handle):
-                rclpy_implementation.rclpy_shutdown(self._handle)
+            if get_rclpy_implementation().rclpy_ok(self._handle):
+                get_rclpy_implementation().rclpy_shutdown(self._handle)
                 self._call_on_shutdown_callbacks()
 
     def on_shutdown(self, callback: Callable[[], None]):

--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import builtin_interfaces
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 
 class Duration:
@@ -22,14 +22,18 @@ class Duration:
         total_nanoseconds = int(seconds * 1e9)
         total_nanoseconds += int(nanoseconds)
         try:
-            self._duration_handle = _rclpy.rclpy_create_duration(total_nanoseconds)
+            self._duration_handle = get_rclpy_implementation().rclpy_create_duration(
+                total_nanoseconds
+            )
         except OverflowError as e:
             raise OverflowError(
                 'Total nanoseconds value is too large to store in C time point.') from e
 
     @property
     def nanoseconds(self):
-        return _rclpy.rclpy_duration_get_nanoseconds(self._duration_handle)
+        return get_rclpy_implementation().rclpy_duration_get_nanoseconds(
+            self._duration_handle
+        )
 
     def __repr__(self):
         return 'Duration(nanoseconds={0})'.format(self.nanoseconds)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -37,7 +37,7 @@ from rclpy.client import Client
 from rclpy.context import Context
 from rclpy.guard_condition import GuardCondition
 from rclpy.handle import InvalidHandle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.service import Service
 from rclpy.signals import SignalHandlerGuardCondition
 from rclpy.subscription import Subscription
@@ -62,11 +62,11 @@ class _WaitSet:
     """Make sure the wait set gets destroyed when a generator exits."""
 
     def __enter__(self):
-        self.wait_set = _rclpy.rclpy_get_zero_initialized_wait_set()
+        self.wait_set = get_rclpy_implementation().rclpy_get_zero_initialized_wait_set()
         return self.wait_set
 
     def __exit__(self, t, v, tb):
-        _rclpy.rclpy_destroy_wait_set(self.wait_set)
+        get_rclpy_implementation().rclpy_destroy_wait_set(self.wait_set)
 
 
 class _WorkTracker:
@@ -311,14 +311,14 @@ class Executor:
 
     def _take_timer(self, tmr):
         with tmr.handle as capsule:
-            _rclpy.rclpy_call_timer(capsule)
+            get_rclpy_implementation().rclpy_call_timer(capsule)
 
     async def _execute_timer(self, tmr, _):
         await await_or_execute(tmr.callback)
 
     def _take_subscription(self, sub):
         with sub.handle as capsule:
-            msg = _rclpy.rclpy_take(capsule, sub.msg_type, sub.raw)
+            msg = get_rclpy_implementation().rclpy_take(capsule, sub.msg_type, sub.raw)
         return msg
 
     async def _execute_subscription(self, sub, msg):
@@ -327,7 +327,7 @@ class Executor:
 
     def _take_client(self, client):
         with client.handle as capsule:
-            return _rclpy.rclpy_take_response(capsule, client.srv_type.Response)
+            return get_rclpy_implementation().rclpy_take_response(capsule, client.srv_type.Response)
 
     async def _execute_client(self, client, seq_and_response):
         sequence, response = seq_and_response
@@ -343,7 +343,7 @@ class Executor:
 
     def _take_service(self, srv):
         with srv.handle as capsule:
-            request_and_header = _rclpy.rclpy_take_request(capsule, srv.srv_type.Request)
+            request_and_header = get_rclpy_implementation().rclpy_take_request(capsule, srv.srv_type.Request)
         return request_and_header
 
     async def _execute_service(self, srv, request_and_header):
@@ -528,7 +528,7 @@ class Executor:
                     except InvalidHandle:
                         entity_count.num_guard_conditions -= 1
 
-                _rclpy.rclpy_wait_set_init(
+                get_rclpy_implementation().rclpy_wait_set_init(
                     wait_set,
                     entity_count.num_subscriptions,
                     entity_count.num_guard_conditions,
@@ -538,33 +538,68 @@ class Executor:
                     entity_count.num_events,
                     self._context.handle)
 
-                _rclpy.rclpy_wait_set_clear_entities(wait_set)
+                get_rclpy_implementation().rclpy_wait_set_clear_entities(wait_set)
                 for sub_capsule in sub_capsules:
-                    _rclpy.rclpy_wait_set_add_entity('subscription', wait_set, sub_capsule)
+                    get_rclpy_implementation().rclpy_wait_set_add_entity(
+                        'subscription',
+                        wait_set,
+                        sub_capsule
+                    )
                 for cli_capsule in client_capsules:
-                    _rclpy.rclpy_wait_set_add_entity('client', wait_set, cli_capsule)
+                    get_rclpy_implementation().rclpy_wait_set_add_entity(
+                        'client',
+                        wait_set,
+                        cli_capsule
+                    )
                 for srv_capsule in service_capsules:
-                    _rclpy.rclpy_wait_set_add_entity('service', wait_set, srv_capsule)
+                    get_rclpy_implementation().rclpy_wait_set_add_entity(
+                        'service',
+                        wait_set,
+                        srv_capsule
+                    )
                 for tmr_capsule in timer_capsules:
-                    _rclpy.rclpy_wait_set_add_entity('timer', wait_set, tmr_capsule)
+                    get_rclpy_implementation().rclpy_wait_set_add_entity(
+                        'timer',
+                        wait_set,
+                        tmr_capsule
+                    )
                 for gc_capsule in guard_capsules:
-                    _rclpy.rclpy_wait_set_add_entity('guard_condition', wait_set, gc_capsule)
+                    get_rclpy_implementation().rclpy_wait_set_add_entity(
+                        'guard_condition',
+                        wait_set,
+                        gc_capsule
+                    )
                 for waitable in waitables:
                     waitable.add_to_wait_set(wait_set)
 
                 # Wait for something to become ready
-                _rclpy.rclpy_wait(wait_set, timeout_nsec)
+                get_rclpy_implementation().rclpy_wait(wait_set, timeout_nsec)
                 if self._is_shutdown:
                     raise ShutdownException()
                 if not self._context.ok():
                     raise ExternalShutdownException()
 
                 # get ready entities
-                subs_ready = _rclpy.rclpy_get_ready_entities('subscription', wait_set)
-                guards_ready = _rclpy.rclpy_get_ready_entities('guard_condition', wait_set)
-                timers_ready = _rclpy.rclpy_get_ready_entities('timer', wait_set)
-                clients_ready = _rclpy.rclpy_get_ready_entities('client', wait_set)
-                services_ready = _rclpy.rclpy_get_ready_entities('service', wait_set)
+                subs_ready = get_rclpy_implementation().rclpy_get_ready_entities(
+                    'subscription',
+                    wait_set
+                )
+                guards_ready = get_rclpy_implementation().rclpy_get_ready_entities(
+                    'guard_condition',
+                    wait_set
+                )
+                timers_ready = get_rclpy_implementation().rclpy_get_ready_entities(
+                    'timer',
+                    wait_set
+                )
+                clients_ready = get_rclpy_implementation().rclpy_get_ready_entities(
+                    'client',
+                    wait_set
+                )
+                services_ready = get_rclpy_implementation().rclpy_get_ready_entities(
+                    'service',
+                    wait_set
+                )
 
                 # Mark all guards as triggered before yielding since they're auto-taken
                 for gc in guards:
@@ -587,7 +622,7 @@ class Executor:
                     if tmr.handle.pointer in timers_ready:
                         with tmr.handle as capsule:
                             # Check timer is ready to workaround rcl issue with cancelled timers
-                            if _rclpy.rclpy_is_timer_ready(capsule):
+                            if get_rclpy_implementation().rclpy_is_timer_ready(capsule):
                                 if tmr.callback_group.can_execute(tmr):
                                     handler = self._make_handler(
                                         tmr, node, self._take_timer, self._execute_timer)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -327,7 +327,10 @@ class Executor:
 
     def _take_client(self, client):
         with client.handle as capsule:
-            return get_rclpy_implementation().rclpy_take_response(capsule, client.srv_type.Response)
+            return get_rclpy_implementation().rclpy_take_response(
+                capsule,
+                client.srv_type.Response
+            )
 
     async def _execute_client(self, client, seq_and_response):
         sequence, response = seq_and_response
@@ -343,7 +346,10 @@ class Executor:
 
     def _take_service(self, srv):
         with srv.handle as capsule:
-            request_and_header = get_rclpy_implementation().rclpy_take_request(capsule, srv.srv_type.Request)
+            request_and_header = get_rclpy_implementation().rclpy_take_request(
+                capsule,
+                srv.srv_type.Request
+            )
         return request_and_header
 
     async def _execute_service(self, srv, request_and_header):

--- a/rclpy/rclpy/expand_topic_name.py
+++ b/rclpy/rclpy/expand_topic_name.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 
 def expand_topic_name(topic_name, node_name, node_namespace):
@@ -30,4 +30,8 @@ def expand_topic_name(topic_name, node_name, node_namespace):
     :returns: expanded topic name which is fully qualified
     :raises: ValueError if the topic name, node name or namespace are invalid
     """
-    return _rclpy.rclpy_expand_topic_name(topic_name, node_name, node_namespace)
+    return get_rclpy_implementation().rclpy_expand_topic_name(
+        topic_name,
+        node_name,
+        node_namespace
+    )

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rclpy.handle import Handle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.utilities import get_default_context
 
 
@@ -21,7 +21,9 @@ class GuardCondition:
 
     def __init__(self, callback, callback_group, context=None):
         self._context = get_default_context() if context is None else context
-        self.__handle = Handle(_rclpy.rclpy_create_guard_condition(self._context.handle))
+        self.__handle = Handle(get_rclpy_implementation().rclpy_create_guard_condition(
+            self._context.handle
+        ))
         self.callback = callback
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor
@@ -31,7 +33,7 @@ class GuardCondition:
 
     def trigger(self):
         with self.handle as capsule:
-            _rclpy.rclpy_trigger_guard_condition(capsule)
+            get_rclpy_implementation().rclpy_trigger_guard_condition(capsule)
 
     @property
     def handle(self):

--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -15,7 +15,7 @@
 from threading import RLock
 import weakref
 
-from rclpy.impl.implementation_singleton import rclpy_pycapsule_implementation as _rclpy_capsule
+from rclpy.impl.implementation_singleton import get_rclpy_pycapsule_implementation
 
 
 class InvalidHandle(Exception):
@@ -52,8 +52,10 @@ class Handle:
         self.__dependent_handles = weakref.WeakSet()
         self.__destroy_callbacks = []
         # Called to give an opportunity to raise an exception if the object is not a pycapsule.
-        self.__capsule_name = _rclpy_capsule.rclpy_pycapsule_name(pycapsule)
-        self.__capsule_pointer = _rclpy_capsule.rclpy_pycapsule_pointer(pycapsule)
+        self.__capsule_name = get_rclpy_pycapsule_implementation().rclpy_pycapsule_name(pycapsule)
+        self.__capsule_pointer = get_rclpy_pycapsule_implementation().rclpy_pycapsule_pointer(
+            pycapsule
+        )
 
     def __eq__(self, other):
         return self.__capsule_pointer == other.__capsule_pointer
@@ -188,7 +190,7 @@ class Handle:
     def __destroy_self(self):
         with self.__rlock:
             # Calls pycapsule destructor
-            _rclpy_capsule.rclpy_pycapsule_destroy(self.__capsule)
+            get_rclpy_pycapsule_implementation().rclpy_pycapsule_destroy(self.__capsule)
             # Call post-destroy callbacks
             while self.__destroy_callbacks:
                 self.__destroy_callbacks.pop()(self)

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Open Source Robotics Foundation, Inc.
+# Copyright 2016-2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,17 +19,56 @@ For example, you might use it like this:
 
 .. code::
 
-    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+    from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
-    _rclpy.rclpy_init()
-    while _rclpy.rclpy_ok():
+    get_rclpy_implementation().rclpy_init()
+    while get_rclpy_implementation().rclpy_ok():
         # ...
 """
 
 from rclpy.impl import _import
 
-rclpy_implementation = _import('._rclpy')
-rclpy_action_implementation = _import('._rclpy_action')
-rclpy_logging_implementation = _import('._rclpy_logging')
-rclpy_signal_handler_implementation = _import('._rclpy_signal_handler')
-rclpy_pycapsule_implementation = _import('._rclpy_pycapsule')
+
+def get_rclpy_implementation():
+    """
+    Get the rclpy C extension.
+
+    This function shouldn't be called from module level.
+    """
+    return _import('._rclpy')
+
+
+def get_rclpy_action_implementation():
+    """
+    Get the rclpy action C extension.
+
+    This function shouldn't be called from module level.
+    """
+    return _import('._rclpy_action')
+
+
+def get_rclpy_logging_implementation():
+    """
+    Get the rclpy logging C extension.
+
+    This function shouldn't be called from module level.
+    """
+    return _import('._rclpy_logging')
+
+
+def get_rclpy_signal_handler_implementation():
+    """
+    Get the rclpy C extension.
+
+    This function shouldn't be called from module level.
+    """
+    return _import('._rclpy_signal_handler')
+
+
+def get_rclpy_pycapsule_implementation():
+    """
+    Get the rclpy pycapsule C extension.
+
+    This function shouldn't be called from module level.
+    """
+    return _import('._rclpy_pycapsule')

--- a/rclpy/rclpy/impl/implementation_singleton.py
+++ b/rclpy/rclpy/impl/implementation_singleton.py
@@ -26,8 +26,6 @@ For example, you might use it like this:
         # ...
 """
 
-from rclpy.impl import _import
-
 
 def get_rclpy_implementation():
     """
@@ -35,6 +33,7 @@ def get_rclpy_implementation():
 
     This function shouldn't be called from module level.
     """
+    from rclpy.impl import _import
     return _import('._rclpy')
 
 
@@ -44,6 +43,7 @@ def get_rclpy_action_implementation():
 
     This function shouldn't be called from module level.
     """
+    from rclpy.impl import _import
     return _import('._rclpy_action')
 
 
@@ -53,6 +53,7 @@ def get_rclpy_logging_implementation():
 
     This function shouldn't be called from module level.
     """
+    from rclpy.impl import _import
     return _import('._rclpy_logging')
 
 
@@ -62,6 +63,7 @@ def get_rclpy_signal_handler_implementation():
 
     This function shouldn't be called from module level.
     """
+    from rclpy.impl import _import
     return _import('._rclpy_signal_handler')
 
 
@@ -71,4 +73,5 @@ def get_rclpy_pycapsule_implementation():
 
     This function shouldn't be called from module level.
     """
+    from rclpy.impl import _import
     return _import('._rclpy_pycapsule')

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2017-2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import inspect
 import os
 import time
 
-from rclpy.impl.implementation_singleton import rclpy_logging_implementation as _rclpy_logging
+from rclpy.impl.implementation_singleton import get_rclpy_logging_implementation
 
 # Known filenames from which logging methods can be called (will be ignored in `_find_caller`).
 _internal_callers = []
@@ -231,18 +231,24 @@ class RcutilsLogger:
     def set_level(self, level):
         from rclpy.logging import LoggingSeverity
         level = LoggingSeverity(level)
-        return _rclpy_logging.rclpy_logging_set_logger_level(self.name, level)
+        return get_rclpy_logging_implementation().rclpy_logging_set_logger_level(self.name, level)
 
     def get_effective_level(self):
         from rclpy.logging import LoggingSeverity
         level = LoggingSeverity(
-            _rclpy_logging.rclpy_logging_get_logger_effective_level(self.name))
+            get_rclpy_logging_implementation().rclpy_logging_get_logger_effective_level(
+                self.name
+            )
+        )
         return level
 
     def is_enabled_for(self, severity):
         from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)
-        return _rclpy_logging.rclpy_logging_logger_is_enabled_for(self.name, severity)
+        return get_rclpy_logging_implementation().rclpy_logging_logger_is_enabled_for(
+            self.name,
+            severity
+        )
 
     def log(self, message, severity, **kwargs):
         r"""
@@ -322,7 +328,7 @@ class RcutilsLogger:
                 return False
 
         # Call the relevant function from the C extension.
-        _rclpy_logging.rclpy_logging_rcutils_log(
+        get_rclpy_logging_implementation().rclpy_logging_rcutils_log(
             severity, name, message,
             caller_id.function_name, caller_id.file_path, caller_id.line_number)
         return True

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -15,7 +15,7 @@
 
 from enum import IntEnum
 
-from rclpy.impl.implementation_singleton import rclpy_logging_implementation as _rclpy_logging
+from rclpy.impl.implementation_singleton import get_rclpy_logging_implementation
 import rclpy.impl.rcutils_logger
 
 
@@ -44,11 +44,11 @@ def get_logger(name):
 
 
 def initialize():
-    return _rclpy_logging.rclpy_logging_initialize()
+    return get_rclpy_logging_implementation().rclpy_logging_initialize()
 
 
 def shutdown():
-    return _rclpy_logging.rclpy_logging_shutdown()
+    return get_rclpy_logging_implementation().rclpy_logging_shutdown()
 
 
 def clear_config():
@@ -59,9 +59,11 @@ def clear_config():
 
 def set_logger_level(name, level):
     level = LoggingSeverity(level)
-    return _rclpy_logging.rclpy_logging_set_logger_level(name, level)
+    return get_rclpy_logging_implementation().rclpy_logging_set_logger_level(name, level)
 
 
 def get_logger_effective_level(name):
-    logger_level = _rclpy_logging.rclpy_logging_get_logger_effective_level(name)
+    logger_level = get_rclpy_logging_implementation().rclpy_logging_get_logger_effective_level(
+        name
+    )
     return LoggingSeverity(logger_level)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -57,8 +57,7 @@ from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
 from rclpy.parameter_service import ParameterService
 from rclpy.publisher import Publisher
 from rclpy.qos import DeprecatedQoSProfile
-from rclpy.qos import qos_profile_parameter_events
-from rclpy.qos import qos_profile_services_default
+from rclpy.qos import qos_profiles
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
 from rclpy.qos_event import SubscriptionEventCallbacks
@@ -172,7 +171,7 @@ class Node:
         self.__executor_weakref = None
 
         self._parameter_event_publisher = self.create_publisher(
-            ParameterEvent, 'parameter_events', qos_profile_parameter_events)
+            ParameterEvent, 'parameter_events', qos_profiles.parameter_events)
 
         with self.handle as capsule:
             self._parameter_overrides = get_rclpy_implementation().rclpy_get_node_parameters(
@@ -1195,7 +1194,7 @@ class Node:
         srv_type,
         srv_name: str,
         *,
-        qos_profile: QoSProfile = qos_profile_services_default,
+        qos_profile: Optional[QoSProfile] = None,
         callback_group: CallbackGroup = None
     ) -> Client:
         """
@@ -1211,6 +1210,8 @@ class Node:
             callback_group = self.default_callback_group
         check_for_type_support(srv_type)
         failed = False
+        if qos_profile is None:
+            qos_profile = qos_profiles.services_default
         try:
             with self.handle as node_capsule:
                 client_capsule = get_rclpy_implementation().rclpy_create_client(
@@ -1241,7 +1242,7 @@ class Node:
         srv_name: str,
         callback: Callable[[SrvTypeRequest, SrvTypeResponse], SrvTypeResponse],
         *,
-        qos_profile: QoSProfile = qos_profile_services_default,
+        qos_profile: Optional[QoSProfile] = None,
         callback_group: CallbackGroup = None
     ) -> Service:
         """
@@ -1259,6 +1260,8 @@ class Node:
             callback_group = self.default_callback_group
         check_for_type_support(srv_type)
         failed = False
+        if qos_profile is None:
+            qos_profile = qos_profiles.services_default
         try:
             with self.handle as node_capsule:
                 service_capsule = get_rclpy_implementation().rclpy_create_service(

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -51,7 +51,7 @@ from rclpy.expand_topic_name import expand_topic_name
 from rclpy.guard_condition import GuardCondition
 from rclpy.handle import Handle
 from rclpy.handle import InvalidHandle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.logging import get_logger
 from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
 from rclpy.parameter_service import ParameterService
@@ -150,7 +150,7 @@ class Node:
         if not self._context.ok():
             raise NotInitializedException('cannot create node')
         try:
-            self.__handle = Handle(_rclpy.rclpy_create_node(
+            self.__handle = Handle(get_rclpy_implementation().rclpy_create_node(
                 node_name, namespace, self._context.handle, cli_args, use_global_arguments
             ))
         except ValueError:
@@ -165,7 +165,9 @@ class Node:
             # Should not get to this point
             raise RuntimeError('rclpy_create_node failed for unknown reason')
         with self.handle as capsule:
-            self._logger = get_logger(_rclpy.rclpy_get_node_logger_name(capsule))
+            self._logger = get_logger(get_rclpy_implementation().rclpy_get_node_logger_name(
+                capsule
+            ))
 
         self.__executor_weakref = None
 
@@ -173,7 +175,10 @@ class Node:
             ParameterEvent, 'parameter_events', qos_profile_parameter_events)
 
         with self.handle as capsule:
-            self._parameter_overrides = _rclpy.rclpy_get_node_parameters(Parameter, capsule)
+            self._parameter_overrides = get_rclpy_implementation().rclpy_get_node_parameters(
+                Parameter,
+                capsule
+            )
         # Combine parameters from params files with those from the node constructor and
         # use the set_parameters_atomically API so a parameter event is published.
         if parameter_overrides is not None:
@@ -287,12 +292,12 @@ class Node:
     def get_name(self) -> str:
         """Get the name of the node."""
         with self.handle as capsule:
-            return _rclpy.rclpy_get_node_name(capsule)
+            return get_rclpy_implementation().rclpy_get_node_name(capsule)
 
     def get_namespace(self) -> str:
         """Get the namespace of the node."""
         with self.handle as capsule:
-            return _rclpy.rclpy_get_node_namespace(capsule)
+            return get_rclpy_implementation().rclpy_get_node_namespace(capsule)
 
     def get_clock(self) -> Clock:
         """Get the clock used by the node."""
@@ -1098,7 +1103,7 @@ class Node:
         failed = False
         try:
             with self.handle as node_capsule:
-                publisher_capsule = _rclpy.rclpy_create_publisher(
+                publisher_capsule = get_rclpy_implementation().rclpy_create_publisher(
                     node_capsule, msg_type, topic, qos_profile.get_c_qos_profile())
         except ValueError:
             failed = True
@@ -1163,7 +1168,7 @@ class Node:
         failed = False
         try:
             with self.handle as capsule:
-                subscription_capsule = _rclpy.rclpy_create_subscription(
+                subscription_capsule = get_rclpy_implementation().rclpy_create_subscription(
                     capsule, msg_type, topic, qos_profile.get_c_qos_profile())
         except ValueError:
             failed = True
@@ -1208,7 +1213,7 @@ class Node:
         failed = False
         try:
             with self.handle as node_capsule:
-                client_capsule = _rclpy.rclpy_create_client(
+                client_capsule = get_rclpy_implementation().rclpy_create_client(
                     node_capsule,
                     srv_type,
                     srv_name,
@@ -1256,7 +1261,7 @@ class Node:
         failed = False
         try:
             with self.handle as node_capsule:
-                service_capsule = _rclpy.rclpy_create_service(
+                service_capsule = get_rclpy_implementation().rclpy_create_service(
                     node_capsule,
                     srv_type,
                     srv_name,
@@ -1461,7 +1466,7 @@ class Node:
           topic types.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_publisher_names_and_types_by_node(
+            return get_rclpy_implementation().rclpy_get_publisher_names_and_types_by_node(
                 capsule, no_demangle, node_name, node_namespace)
 
     def get_subscriber_names_and_types_by_node(
@@ -1481,7 +1486,7 @@ class Node:
           topic types.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_subscriber_names_and_types_by_node(
+            return get_rclpy_implementation().rclpy_get_subscriber_names_and_types_by_node(
                 capsule, no_demangle, node_name, node_namespace)
 
     def get_service_names_and_types_by_node(
@@ -1499,7 +1504,7 @@ class Node:
           and the second element is a list of service types.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_service_names_and_types_by_node(
+            return get_rclpy_implementation().rclpy_get_service_names_and_types_by_node(
                 capsule, node_name, node_namespace)
 
     def get_client_names_and_types_by_node(
@@ -1517,7 +1522,7 @@ class Node:
           and the second element is a list of service client types.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_client_names_and_types_by_node(
+            return get_rclpy_implementation().rclpy_get_client_names_and_types_by_node(
                 capsule, node_name, node_namespace)
 
     def get_topic_names_and_types(self, no_demangle: bool = False) -> List[Tuple[str, List[str]]]:
@@ -1530,7 +1535,10 @@ class Node:
           topic types.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_topic_names_and_types(capsule, no_demangle)
+            return get_rclpy_implementation().rclpy_get_topic_names_and_types(
+                capsule,
+                no_demangle
+            )
 
     def get_service_names_and_types(self) -> List[Tuple[str, List[str]]]:
         """
@@ -1541,7 +1549,7 @@ class Node:
           service types.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_service_names_and_types(capsule)
+            return get_rclpy_implementation().rclpy_get_service_names_and_types(capsule)
 
     def get_node_names(self) -> List[str]:
         """
@@ -1550,7 +1558,7 @@ class Node:
         :return: List of node names.
         """
         with self.handle as capsule:
-            names_ns = _rclpy.rclpy_get_node_names_and_namespaces(capsule)
+            names_ns = get_rclpy_implementation().rclpy_get_node_names_and_namespaces(capsule)
         return [n[0] for n in names_ns]
 
     def get_node_names_and_namespaces(self) -> List[Tuple[str, str]]:
@@ -1560,7 +1568,7 @@ class Node:
         :return: List of tuples containing two strings: the node name and node namespace.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_node_names_and_namespaces(capsule)
+            return get_rclpy_implementation().rclpy_get_node_names_and_namespaces(capsule)
 
     def _count_publishers_or_subscribers(self, topic_name, func):
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
@@ -1579,7 +1587,10 @@ class Node:
         :param topic_name: the topic_name on which to count the number of publishers.
         :return: the number of publishers on the topic.
         """
-        return self._count_publishers_or_subscribers(topic_name, _rclpy.rclpy_count_publishers)
+        return self._count_publishers_or_subscribers(
+            topic_name,
+            get_rclpy_implementation().rclpy_count_publishers
+        )
 
     def count_subscribers(self, topic_name: str) -> int:
         """
@@ -1592,7 +1603,10 @@ class Node:
         :param topic_name: the topic_name on which to count the number of subscribers.
         :return: the number of subscribers on the topic.
         """
-        return self._count_publishers_or_subscribers(topic_name, _rclpy.rclpy_count_subscribers)
+        return self._count_publishers_or_subscribers(
+            topic_name,
+            get_rclpy_implementation().rclpy_count_subscribers
+        )
 
     def assert_liveliness(self) -> None:
         """
@@ -1602,4 +1616,4 @@ class Node:
         application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
         """
         with self.handle as capsule:
-            _rclpy.rclpy_assert_liveliness(capsule)
+            get_rclpy_implementation().rclpy_assert_liveliness(capsule)

--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -18,7 +18,7 @@ from rcl_interfaces.srv import DescribeParameters, GetParameters, GetParameterTy
 from rcl_interfaces.srv import ListParameters, SetParameters, SetParametersAtomically
 from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
-from rclpy.qos import qos_profile_parameters
+from rclpy.qos import qos_profiles
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 
@@ -32,35 +32,35 @@ class ParameterService:
             TOPIC_SEPARATOR_STRING.join((nodename, 'describe_parameters'))
         node.create_service(
             DescribeParameters, describe_parameters_service_name,
-            self._describe_parameters_callback, qos_profile=qos_profile_parameters
+            self._describe_parameters_callback, qos_profile=qos_profiles.parameters
         )
         get_parameters_service_name = TOPIC_SEPARATOR_STRING.join((nodename, 'get_parameters'))
         node.create_service(
             GetParameters, get_parameters_service_name, self._get_parameters_callback,
-            qos_profile=qos_profile_parameters
+            qos_profile=qos_profiles.parameters
         )
         get_parameter_types_service_name = \
             TOPIC_SEPARATOR_STRING.join((nodename, 'get_parameter_types'))
         node.create_service(
             GetParameterTypes, get_parameter_types_service_name,
-            self._get_parameter_types_callback, qos_profile=qos_profile_parameters
+            self._get_parameter_types_callback, qos_profile=qos_profiles.parameters
         )
         list_parameters_service_name = TOPIC_SEPARATOR_STRING.join((nodename, 'list_parameters'))
         node.create_service(
             ListParameters, list_parameters_service_name, self._list_parameters_callback,
-            qos_profile=qos_profile_parameters
+            qos_profile=qos_profiles.parameters
         )
         set_parameters_service_name = TOPIC_SEPARATOR_STRING.join((nodename, 'set_parameters'))
         node.create_service(
             SetParameters, set_parameters_service_name, self._set_parameters_callback,
-            qos_profile=qos_profile_parameters
+            qos_profile=qos_profiles.parameters
         )
         set_parameters_atomically_service_name = \
             TOPIC_SEPARATOR_STRING.join((nodename, 'set_parameters_atomically'))
         node.create_service(
             SetParametersAtomically, set_parameters_atomically_service_name,
             self._set_parameters_atomically_callback,
-            qos_profile=qos_profile_parameters
+            qos_profile=qos_profiles.parameters
         )
 
     def _describe_parameters_callback(self, request, response):

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -16,7 +16,7 @@ from typing import TypeVar
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.handle import Handle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
 
@@ -67,7 +67,7 @@ class Publisher:
         if not isinstance(msg, self.msg_type):
             raise TypeError()
         with self.handle as capsule:
-            _rclpy.rclpy_publish(capsule, msg)
+            get_rclpy_implementation().rclpy_publish(capsule, msg)
 
     @property
     def handle(self):
@@ -84,4 +84,4 @@ class Publisher:
         application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
         """
         with self.handle as capsule:
-            _rclpy.rclpy_assert_liveliness(capsule)
+            get_rclpy_implementation().rclpy_assert_liveliness(capsule)

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -18,8 +18,8 @@ from enum import IntEnum
 import warnings
 
 from rclpy.duration import Duration
-from rclpy.impl.implementation_singleton import rclpy_action_implementation as _rclpy_action
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_action_implementation
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 # "Forward-declare" this value so that it can be used in the QoSProfile initializer.
 # It will have a value by the end of definitions, before user code runs.
@@ -218,7 +218,7 @@ class QoSProfile:
         self._avoid_ros_namespace_conventions = value
 
     def get_c_qos_profile(self):
-        return _rclpy.rclpy_convert_from_py_qos_policy(
+        return get_rclpy_implementation().rclpy_convert_from_py_qos_policy(
             self.history,
             self.depth,
             self.reliability,
@@ -350,20 +350,25 @@ class DeprecatedQoSProfile(QoSProfile):
         self.name = profile_name
 
 
-_qos_profile_default = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile('qos_profile_default'))
+_qos_profile_default = QoSProfile(**get_rclpy_implementation().rclpy_get_rmw_qos_profile(
+    'qos_profile_default'
+))
 qos_profile_default = DeprecatedQoSProfile(_qos_profile_default, 'qos_profile_default')
-qos_profile_system_default = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+qos_profile_system_default = QoSProfile(**get_rclpy_implementation().rclpy_get_rmw_qos_profile(
     'qos_profile_system_default'))
-qos_profile_sensor_data = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+qos_profile_sensor_data = QoSProfile(**get_rclpy_implementation().rclpy_get_rmw_qos_profile(
     'qos_profile_sensor_data'))
-qos_profile_services_default = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+qos_profile_services_default = QoSProfile(**get_rclpy_implementation().rclpy_get_rmw_qos_profile(
     'qos_profile_services_default'))
-qos_profile_parameters = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+qos_profile_parameters = QoSProfile(**get_rclpy_implementation().rclpy_get_rmw_qos_profile(
     'qos_profile_parameters'))
-qos_profile_parameter_events = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+qos_profile_parameter_events = QoSProfile(**get_rclpy_implementation().rclpy_get_rmw_qos_profile(
     'qos_profile_parameter_events'))
 qos_profile_action_status_default = QoSProfile(
-    **_rclpy_action.rclpy_action_get_rmw_qos_profile('rcl_action_qos_profile_status_default'))
+    **get_rclpy_action_implementation().rclpy_action_get_rmw_qos_profile(
+        'rcl_action_qos_profile_status_default'
+    )
+)
 
 
 class QoSPresetProfiles(Enum):

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -21,7 +21,7 @@ from typing import Optional
 import rclpy
 from rclpy.callback_groups import CallbackGroup
 from rclpy.handle import Handle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.waitable import NumberOfEntities
 from rclpy.waitable import Waitable
 
@@ -113,7 +113,10 @@ class QoSEventHandler(Waitable):
 
         self._parent_handle = parent_handle
         with parent_handle as parent_capsule:
-            event_capsule = _rclpy.rclpy_create_event(event_type, parent_capsule)
+            event_capsule = get_rclpy_implementation().rclpy_create_event(
+                event_type,
+                parent_capsule
+            )
         self._event_handle = Handle(event_capsule)
         self._event_handle.requires(self._parent_handle)
         self._ready_to_take_data = False
@@ -124,7 +127,11 @@ class QoSEventHandler(Waitable):
         """Return True if entities are ready in the wait set."""
         if self._event_index is None:
             return False
-        if _rclpy.rclpy_wait_set_is_ready('event', wait_set, self._event_index):
+        if get_rclpy_implementation().rclpy_wait_set_is_ready(
+            'event',
+            wait_set,
+            self._event_index
+        ):
             self._ready_to_take_data = True
         return self._ready_to_take_data
 
@@ -133,7 +140,11 @@ class QoSEventHandler(Waitable):
         if self._ready_to_take_data:
             self._ready_to_take_data = False
             with self._parent_handle as parent_capsule, self._event_handle as event_capsule:
-                return _rclpy.rclpy_take_event(event_capsule, parent_capsule, self.event_type)
+                return get_rclpy_implementation().rclpy_take_event(
+                    event_capsule,
+                    parent_capsule,
+                    self.event_type
+                )
         return None
 
     async def execute(self, taken_data):
@@ -149,7 +160,11 @@ class QoSEventHandler(Waitable):
     def add_to_wait_set(self, wait_set):
         """Add entites to wait set."""
         with self._event_handle as event_capsule:
-            self._event_index = _rclpy.rclpy_wait_set_add_entity('event', wait_set, event_capsule)
+            self._event_index = get_rclpy_implementation().rclpy_wait_set_add_entity(
+                'event',
+                wait_set,
+                event_capsule
+            )
     # End Waitable API
 
 

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Open Source Robotics Foundation, Inc.
+# Copyright 2016-2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ from typing import Callable
 from typing import TypeVar
 
 from rclpy.callback_groups import CallbackGroup
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.qos import QoSProfile
 
 # Used for documentation purposes only
@@ -71,7 +71,7 @@ class Service:
         if not isinstance(response, self.srv_type.Response):
             raise TypeError()
         with self.handle as capsule:
-            _rclpy.rclpy_send_response(capsule, response, header)
+            get_rclpy_implementation().rclpy_send_response(capsule, response, header)
 
     @property
     def handle(self):

--- a/rclpy/rclpy/signals.py
+++ b/rclpy/rclpy/signals.py
@@ -14,7 +14,7 @@
 
 from rclpy.guard_condition import GuardCondition
 from rclpy.handle import InvalidHandle
-from rclpy.impl.implementation_singleton import rclpy_signal_handler_implementation as _signals
+from rclpy.impl.implementation_singleton import get_rclpy_signal_handler_implementation
 
 
 class SignalHandlerGuardCondition(GuardCondition):
@@ -22,7 +22,9 @@ class SignalHandlerGuardCondition(GuardCondition):
     def __init__(self, context=None):
         super().__init__(callback=None, callback_group=None, context=context)
         with self.handle as capsule:
-            _signals.rclpy_register_sigint_guard_condition(capsule)
+            get_rclpy_signal_handler_implementation().rclpy_register_sigint_guard_condition(
+                capsule
+            )
 
     def __del__(self):
         try:
@@ -36,5 +38,7 @@ class SignalHandlerGuardCondition(GuardCondition):
 
     def destroy(self):
         with self.handle as capsule:
-            _signals.rclpy_unregister_sigint_guard_condition(capsule)
+            get_rclpy_signal_handler_implementation().rclpy_unregister_sigint_guard_condition(
+                capsule
+            )
         super().destroy()

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2018-2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 import builtin_interfaces
 from rclpy.clock import ClockType
 from rclpy.duration import Duration
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 
 CONVERSION_CONSTANT = 10 ** 9
@@ -33,7 +33,10 @@ class Time:
         total_nanoseconds = int(seconds * CONVERSION_CONSTANT)
         total_nanoseconds += int(nanoseconds)
         try:
-            self._time_handle = _rclpy.rclpy_create_time_point(total_nanoseconds, clock_type)
+            self._time_handle = get_rclpy_implementation().rclpy_create_time_point(
+                total_nanoseconds,
+                clock_type
+            )
         except OverflowError as e:
             raise OverflowError(
                 'Total nanoseconds value is too large to store in C time point.') from e
@@ -41,7 +44,7 @@ class Time:
 
     @property
     def nanoseconds(self):
-        return _rclpy.rclpy_time_point_get_nanoseconds(self._time_handle)
+        return get_rclpy_implementation().rclpy_time_point_get_nanoseconds(self._time_handle)
 
     def seconds_nanoseconds(self):
         """

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -15,7 +15,7 @@
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 from rclpy.handle import Handle
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.utilities import get_default_context
 
 
@@ -27,7 +27,7 @@ class WallTimer:
         # TODO(sloretz) Allow passing clocks in via timer constructor
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         with self._clock.handle as clock_capsule:
-            self.__handle = Handle(_rclpy.rclpy_create_timer(
+            self.__handle = Handle(get_rclpy_implementation().rclpy_create_timer(
                 clock_capsule, self._context.handle, timer_period_ns))
         self.__handle.requires(self._clock.handle)
         self.timer_period_ns = timer_period_ns
@@ -50,7 +50,7 @@ class WallTimer:
     @property
     def timer_period_ns(self):
         with self.handle as capsule:
-            val = _rclpy.rclpy_get_timer_period(capsule)
+            val = get_rclpy_implementation().rclpy_get_timer_period(capsule)
         self._timer_period_ns = val
         return val
 
@@ -58,29 +58,29 @@ class WallTimer:
     def timer_period_ns(self, value):
         val = int(value)
         with self.handle as capsule:
-            _rclpy.rclpy_change_timer_period(capsule, val)
+            get_rclpy_implementation().rclpy_change_timer_period(capsule, val)
         self._timer_period_ns = val
 
     def is_ready(self):
         with self.handle as capsule:
-            return _rclpy.rclpy_is_timer_ready(capsule)
+            return get_rclpy_implementation().rclpy_is_timer_ready(capsule)
 
     def is_canceled(self):
         with self.handle as capsule:
-            return _rclpy.rclpy_is_timer_canceled(capsule)
+            return get_rclpy_implementation().rclpy_is_timer_canceled(capsule)
 
     def cancel(self):
         with self.handle as capsule:
-            _rclpy.rclpy_cancel_timer(capsule)
+            get_rclpy_implementation().rclpy_cancel_timer(capsule)
 
     def reset(self):
         with self.handle as capsule:
-            _rclpy.rclpy_reset_timer(capsule)
+            get_rclpy_implementation().rclpy_reset_timer(capsule)
 
     def time_since_last_call(self):
         with self.handle as capsule:
-            return _rclpy.rclpy_time_since_last_call(capsule)
+            return get_rclpy_implementation().rclpy_time_since_last_call(capsule)
 
     def time_until_next_call(self):
         with self.handle as capsule:
-            return _rclpy.rclpy_time_until_next_call(capsule)
+            return get_rclpy_implementation().rclpy_time_until_next_call(capsule)

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -17,6 +17,7 @@ import threading
 
 from rclpy.constants import S_TO_NS
 from rclpy.context import Context
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 g_default_context = None
 g_context_lock = threading.Lock()
@@ -37,9 +38,7 @@ def get_default_context(*, shutting_down=False):
 
 
 def remove_ros_args(args=None):
-    # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    return rclpy_implementation.rclpy_remove_ros_args(
+    return get_rclpy_implementation().rclpy_remove_ros_args(
         args if args is not None else sys.argv)
 
 
@@ -63,9 +62,7 @@ def try_shutdown(*, context=None):
 
 
 def get_rmw_implementation_identifier():
-    # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    return rclpy_implementation.rclpy_get_rmw_implementation_identifier()
+    return get_rclpy_implementation().rclpy_get_rmw_implementation_identifier()
 
 
 def timeout_sec_to_nsec(timeout_sec):

--- a/rclpy/rclpy/validate_full_topic_name.py
+++ b/rclpy/rclpy/validate_full_topic_name.py
@@ -14,7 +14,7 @@
 
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 
 def validate_full_topic_name(name, *, is_service=False):
@@ -31,7 +31,7 @@ def validate_full_topic_name(name, *, is_service=False):
     :returns: True when it is valid
     :raises: InvalidTopicNameException: when the name is invalid
     """
-    result = _rclpy.rclpy_get_validation_error_for_full_topic_name(name)
+    result = get_rclpy_implementation().rclpy_get_validation_error_for_full_topic_name(name)
     if result is None:
         return True
     error_msg, invalid_index = result

--- a/rclpy/rclpy/validate_namespace.py
+++ b/rclpy/rclpy/validate_namespace.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rclpy.exceptions import InvalidNamespaceException
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 
 def validate_namespace(namespace):
@@ -31,7 +31,9 @@ def validate_namespace(namespace):
     :returns: True when it is valid
     :raises: InvalidNamespaceException: when the namespace is invalid
     """
-    result = _rclpy.rclpy_get_validation_error_for_namespace(namespace)
+    result = get_rclpy_implementation().rclpy_get_validation_error_for_namespace(
+        namespace
+    )
     if result is None:
         return True
     error_msg, invalid_index = result

--- a/rclpy/rclpy/validate_node_name.py
+++ b/rclpy/rclpy/validate_node_name.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from rclpy.exceptions import InvalidNodeNameException
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 
 def validate_node_name(node_name):
@@ -27,7 +27,7 @@ def validate_node_name(node_name):
     :returns: True when it is valid
     :raises: InvalidNodeNameException: when the node_name is invalid
     """
-    result = _rclpy.rclpy_get_validation_error_for_node_name(node_name)
+    result = get_rclpy_implementation().rclpy_get_validation_error_for_node_name(node_name)
     if result is None:
         return True
     error_msg, invalid_index = result

--- a/rclpy/rclpy/validate_topic_name.py
+++ b/rclpy/rclpy/validate_topic_name.py
@@ -14,7 +14,7 @@
 
 from rclpy.exceptions import InvalidServiceNameException
 from rclpy.exceptions import InvalidTopicNameException
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 
 TOPIC_SEPARATOR_STRING = '/'
 
@@ -33,7 +33,7 @@ def validate_topic_name(name, *, is_service=False):
     :returns: True when it is valid
     :raises: InvalidTopicNameException: when the name is invalid
     """
-    result = _rclpy.rclpy_get_validation_error_for_topic_name(name)
+    result = get_rclpy_implementation().rclpy_get_validation_error_for_topic_name(name)
     if result is None:
         return True
     error_msg, invalid_index = result

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -33,6 +33,7 @@ from rclpy.exceptions import ParameterAlreadyDeclaredException
 from rclpy.exceptions import ParameterImmutableException
 from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.executors import SingleThreadedExecutor
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
@@ -1564,10 +1565,11 @@ class TestCreateNode(unittest.TestCase):
         context = rclpy.context.Context()
         rclpy.init(context=context)
 
-        from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-
         invalid_ros_args_error_pattern = r'Failed to parse ROS arguments:.*not-a-remap.*'
-        with self.assertRaisesRegex(_rclpy.RCLInvalidROSArgsError, invalid_ros_args_error_pattern):
+        with self.assertRaisesRegex(
+            get_rclpy_implementation().RCLInvalidROSArgsError,
+            invalid_ros_args_error_pattern
+        ):
             rclpy.create_node(
                 'my_node',
                 namespace='/my_ns',
@@ -1575,7 +1577,10 @@ class TestCreateNode(unittest.TestCase):
                 context=context)
 
         unknown_ros_args_error_pattern = r'Found unknown ROS arguments:.*\[\'--my-custom-flag\'\]'
-        with self.assertRaisesRegex(_rclpy.UnknownROSArgsError, unknown_ros_args_error_pattern):
+        with self.assertRaisesRegex(
+            get_rclpy_implementation().UnknownROSArgsError,
+            unknown_ros_args_error_pattern
+        ):
             rclpy.create_node(
                 'my_node',
                 namespace='/my_ns',

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -35,8 +35,7 @@ from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.parameter import Parameter
-from rclpy.qos import qos_profile_default
-from rclpy.qos import qos_profile_sensor_data
+from rclpy.qos import qos_profiles
 from rclpy.time_source import USE_SIM_TIME_NAME
 from test_msgs.msg import BasicTypes
 
@@ -70,7 +69,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     def test_create_publisher(self):
         self.node.create_publisher(BasicTypes, 'chatter', 0)
         self.node.create_publisher(BasicTypes, 'chatter', 1)
-        self.node.create_publisher(BasicTypes, 'chatter', qos_profile_sensor_data)
+        self.node.create_publisher(BasicTypes, 'chatter', qos_profiles.sensor_data)
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
             self.node.create_publisher(BasicTypes, 'chatter?', 1)
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
@@ -86,7 +85,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 0)
         self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 1)
         self.node.create_subscription(
-            BasicTypes, 'chatter', lambda msg: print(msg), qos_profile_sensor_data)
+            BasicTypes, 'chatter', lambda msg: print(msg), qos_profiles.sensor_data)
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
             self.node.create_subscription(BasicTypes, 'chatter?', lambda msg: print(msg), 1)
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not start with a number'):
@@ -154,7 +153,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            self.node.create_publisher(BasicTypes, 'chatter', qos_profile_default)
+            self.node.create_publisher(BasicTypes, 'chatter', qos_profiles.default)
             assert len(w) == 1
             assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:
@@ -165,7 +164,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             self.node.create_subscription(
-                BasicTypes, 'chatter', lambda msg: print(msg), qos_profile_default)
+                BasicTypes, 'chatter', lambda msg: print(msg), qos_profiles.default)
             assert len(w) == 1
             assert issubclass(w[0].category, UserWarning)
         with warnings.catch_warnings(record=True) as w:

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -17,12 +17,10 @@ import warnings
 
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import get_rclpy_implementation
-from rclpy.qos import _qos_profile_default
-from rclpy.qos import qos_profile_system_default
+from rclpy.qos import qos_profiles
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSHistoryPolicy
 from rclpy.qos import QoSLivelinessPolicy
-from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 
@@ -141,15 +139,14 @@ class TestQosProfile(unittest.TestCase):
 
     def test_preset_profiles(self):
         # Make sure the Enum does what we expect
-        assert QoSPresetProfiles.SYSTEM_DEFAULT.value == qos_profile_system_default
         assert (
-            QoSPresetProfiles.SYSTEM_DEFAULT.value ==
-            QoSPresetProfiles.get_from_short_key('system_default'))
+            qos_profiles.system_default ==
+            qos_profiles.get_from_short_key('system_default'))
 
     def test_default_profile(self):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter('always')
             profile = QoSProfile()
         assert all(
-            profile.__getattribute__(k) == _qos_profile_default.__getattribute__(k)
+            profile.__getattribute__(k) == qos_profiles._default.__getattribute__(k)
             for k in profile.__slots__)

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -16,7 +16,7 @@ import unittest
 import warnings
 
 from rclpy.duration import Duration
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.implementation_singleton import get_rclpy_implementation
 from rclpy.qos import _qos_profile_default
 from rclpy.qos import qos_profile_system_default
 from rclpy.qos import QoSDurabilityPolicy
@@ -31,7 +31,9 @@ class TestQosProfile(unittest.TestCase):
 
     def convert_and_assert_equality(self, qos_profile):
         c_profile = qos_profile.get_c_qos_profile()
-        converted_profile = QoSProfile(**_rclpy.rclpy_convert_to_py_qos_policy(c_profile))
+        converted_profile = QoSProfile(**get_rclpy_implementation().rclpy_convert_to_py_qos_policy(
+            c_profile
+        ))
         self.assertEqual(qos_profile, converted_profile)
 
     def test_depth_only_constructor(self):

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -209,7 +209,8 @@ class TestQoSEvent(unittest.TestCase):
         # Make no assumptions about being able to actually receive the events
         subscription = self.node.create_subscription(EmptyMsg, 'test_topic', Mock(), 10)
         wait_set = get_rclpy_implementation().rclpy_get_zero_initialized_wait_set()
-        get_rclpy_implementation().rclpy_wait_set_init(wait_set, 0, 0, 0, 0, 0, 2, self.context.handle)
+        get_rclpy_implementation().rclpy_wait_set_init(
+            wait_set, 0, 0, 0, 0, 0, 2, self.context.handle)
 
         deadline_event_handle = self._create_event_handle(
             subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_DEADLINE_MISSED)


### PR DESCRIPTION
Yet another alternative to #417 #420.
See https://github.com/ros2/rclpy/pull/420#issuecomment-529681952.

I ended up having a lot of problems with the `qos` module after applying lazy import, as all the default profiles are constructed at module level.
For working around the problem, I did a lot of changes that I don't like at all.

I would rather solve https://github.com/ros2/build_cop/issues/235 directly in `launch_testing_ros`, and figure out later how to avoid having to "hack" the imports while testing in `rclpy` (which is the root cause of https://github.com/ros2/build_cop/issues/235).

I would rather not merge this PR nor apply lazy import in general, as I believe is creating more problems than solving.