### PR TITLE
Provide subscription count from Publisher #418

### DIFF
--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -69,6 +69,11 @@ class Publisher:
         with self.handle as capsule:
             _rclpy.rclpy_publish(capsule, msg)
 
+    def get_subscription_count(self) -> int:
+        """Get the amount of subscribers that this publisher has."""
+        with self.handle as capsule:
+            return _rclpy.rclpy_publisher_get_subscription_count(capsule)
+
     @property
     def handle(self):
         return self.__handle

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4835,7 +4835,7 @@ static PyMethodDef rclpy_methods[] = {
   },
   {
     "rclpy_publisher_get_subscription_count", rclpy_publisher_get_subscription_count, METH_VARARGS,
-    "Count subscribers from publisher."
+    "Count subscribers from a publisher."
   },
   {
     "rclpy_send_request", rclpy_send_request, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -18,6 +18,7 @@
 #include <rcl/expand_topic_name.h>
 #include <rcl/graph.h>
 #include <rcl/node.h>
+#include <rcl/publisher.h>
 #include <rcl/rcl.h>
 #include <rcl/time.h>
 #include <rcl/validate_topic_name.h>
@@ -1405,6 +1406,37 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   Py_RETURN_NONE;
+}
+
+/// Count subscribers from a publisher.
+/**
+ *
+ * \param[in] pynode Capsule pointing to the publisher
+ * \return count of subscribers
+ */
+static PyObject *
+rclpy_publisher_get_subscription_count(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pypublisher;
+
+  if (!PyArg_ParseTuple(args, "O", &pypublisher)) {
+    return NULL;
+  }
+
+  const rclpy_publisher_t * pub = (rclpy_publisher_t *)PyCapsule_GetPointer(
+    pypublisher, "rclpy_publisher_t");
+  if (!pub) {
+    return NULL;
+  }
+
+  size_t count = 0;
+  rmw_ret_t ret = rcl_publisher_get_subscription_count(&pub->publisher, &count);
+  if (RMW_RET_OK != ret) {
+    PyErr_Format(PyExc_RuntimeError, "%s", rmw_get_error_string().str);
+    rmw_reset_error();
+    return NULL;
+  }
+  return PyLong_FromSize_t(count);
 }
 
 /// PyCapsule destructor for timer
@@ -4800,6 +4832,10 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_publish", rclpy_publish, METH_VARARGS,
     "Publish a message."
+  },
+  {
+    "rclpy_publisher_get_subscription_count", rclpy_publisher_get_subscription_count, METH_VARARGS,
+    "Count subscribers from publisher."
   },
   {
     "rclpy_send_request", rclpy_send_request, METH_VARARGS,

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -205,17 +205,20 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertEqual(0, self.node.count_publishers(fq_topic_name))
         self.assertEqual(0, self.node.count_subscribers(fq_topic_name))
 
-        self.node.create_publisher(BasicTypes, short_topic_name, 1)
+        short_topic_publisher = self.node.create_publisher(BasicTypes, short_topic_name, 1)
         self.assertEqual(1, self.node.count_publishers(short_topic_name))
         self.assertEqual(1, self.node.count_publishers(fq_topic_name))
+        self.assertEqual(0, short_topic_publisher.get_subscription_count())
 
         self.node.create_subscription(BasicTypes, short_topic_name, lambda msg: print(msg), 1)
         self.assertEqual(1, self.node.count_subscribers(short_topic_name))
         self.assertEqual(1, self.node.count_subscribers(fq_topic_name))
+        self.assertEqual(1, short_topic_publisher.get_subscription_count())
 
         self.node.create_subscription(BasicTypes, short_topic_name, lambda msg: print(msg), 1)
         self.assertEqual(2, self.node.count_subscribers(short_topic_name))
         self.assertEqual(2, self.node.count_subscribers(fq_topic_name))
+        self.assertEqual(2, short_topic_publisher.get_subscription_count())
 
         # error cases
         with self.assertRaisesRegex(TypeError, 'bad argument type for built-in operation'):


### PR DESCRIPTION
fixes #418 . Publisher python's class can get the amount of subscribers that it has.

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8159)](https://ci.ros2.org/job/ci_linux/8159/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4141)](https://ci.ros2.org/job/ci_linux-aarch64/4141/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6644)](https://ci.ros2.org/job/ci_osx/6644/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8038)](https://ci.ros2.org/job/ci_windows/8038/)

There are some **test failures** which I think they are unrelated with this change. You can see for example: 

- Linux job [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8161)](https://ci.ros2.org/job/ci_linux/8161/)
- Arch job [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4143)](https://ci.ros2.org/job/ci_linux-aarch64/4143/)
- OSX job [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6646)](https://ci.ros2.org/job/ci_osx/6646/)
- Windows job [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8040)](https://ci.ros2.org/job/ci_windows/8040/)

All of them related with **rmw** (**connext** and **fastrtps**) in master