### PR TITLE
Remove deprecated QoS functionality

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -24,7 +24,6 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
-import warnings
 import weakref
 
 from rcl_interfaces.msg import FloatingPointRange
@@ -57,7 +56,6 @@ from rclpy.logging import get_logger
 from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
 from rclpy.parameter_service import ParameterService
 from rclpy.publisher import Publisher
-from rclpy.qos import DeprecatedQoSProfile
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
@@ -1035,9 +1033,6 @@ class Node:
 
     def _validate_qos_or_depth_parameter(self, qos_or_depth) -> QoSProfile:
         if isinstance(qos_or_depth, QoSProfile):
-            if isinstance(qos_or_depth, DeprecatedQoSProfile):
-                warnings.warn(
-                    "Using deprecated QoSProfile '{qos_or_depth.name}'".format_map(locals()))
             return qos_or_depth
         elif isinstance(qos_or_depth, int):
             if qos_or_depth < 0:
@@ -1069,7 +1064,7 @@ class Node:
         self,
         msg_type,
         topic: str,
-        qos_profile: Union[QoSProfile, int] = None,
+        qos_profile: Union[QoSProfile, int],
         *,
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[PublisherEventCallbacks] = None,
@@ -1080,7 +1075,6 @@ class Node:
         :param msg_type: The type of ROS messages the publisher will publish.
         :param topic: The name of the topic the publisher will publish to.
         :param qos_profile: A QoSProfile or a history depth to apply to the publisher.
-          This is a required parameter, and only defaults to None for backwards compatibility.
           In the case that a history depth is provided, the QoS history is set to
           RMW_QOS_POLICY_HISTORY_KEEP_LAST, the QoS history depth is set to the value
           of the parameter, and all other QoS settings are set to their default values.
@@ -1089,12 +1083,7 @@ class Node:
         :param event_callbacks: User-defined callbacks for middleware events.
         :return: The new publisher.
         """
-        # if the new API is not used, issue a deprecation warning and continue with the old API
-        if qos_profile is None:
-            warnings.warn("Pass an explicit 'qos_profile' argument")
-            qos_profile = QoSProfile(depth=10)
-        else:
-            qos_profile = self._validate_qos_or_depth_parameter(qos_profile)
+        qos_profile = self._validate_qos_or_depth_parameter(qos_profile)
 
         callback_group = callback_group or self.default_callback_group
 
@@ -1130,7 +1119,7 @@ class Node:
         msg_type,
         topic: str,
         callback: Callable[[MsgType], None],
-        qos_profile: Union[QoSProfile, int] = None,
+        qos_profile: Union[QoSProfile, int],
         *,
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[SubscriptionEventCallbacks] = None,
@@ -1144,7 +1133,6 @@ class Node:
         :param callback: A user-defined callback function that is called when a message is
             received by the subscription.
         :param qos_profile: A QoSProfile or a history depth to apply to the subscription.
-          This is a required parameter, and only defaults to None for backwards compatibility.
           In the case that a history depth is provided, the QoS history is set to
           RMW_QOS_POLICY_HISTORY_KEEP_LAST, the QoS history depth is set to the value
           of the parameter, and all other QoS settings are set to their default values.
@@ -1154,12 +1142,7 @@ class Node:
         :param raw: If ``True``, then received messages will be stored in raw binary
             representation.
         """
-        # if the new API is not used, issue a deprecation warning and continue with the old API
-        if qos_profile is None:
-            warnings.warn("Pass an explicit 'qos_profile' argument")
-            qos_profile = QoSProfile(depth=10)
-        else:
-            qos_profile = self._validate_qos_or_depth_parameter(qos_profile)
+        qos_profile = self._validate_qos_or_depth_parameter(qos_profile)
 
         callback_group = callback_group or self.default_callback_group
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -14,7 +14,6 @@
 
 import unittest
 from unittest.mock import Mock
-import warnings
 
 from rcl_interfaces.msg import FloatingPointRange
 from rcl_interfaces.msg import IntegerRange
@@ -34,7 +33,6 @@ from rclpy.exceptions import ParameterImmutableException
 from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.parameter import Parameter
-from rclpy.qos import qos_profile_default
 from rclpy.qos import qos_profile_sensor_data
 from rclpy.time_source import USE_SIM_TIME_NAME
 from test_msgs.msg import BasicTypes
@@ -144,34 +142,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             self.node.create_service(GetParameters, '/get/42parameters', lambda req: None)
         with self.assertRaisesRegex(ValueError, 'unknown substitution'):
             self.node.create_service(GetParameters, 'foo/{bad_sub}', lambda req: None)
-
-    def test_deprecation_warnings(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.node.create_publisher(BasicTypes, 'chatter')
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.node.create_publisher(BasicTypes, 'chatter', qos_profile_default)
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg))
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.node.create_subscription(
-                BasicTypes, 'chatter', lambda msg: print(msg), qos_profile_default)
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), raw=True)
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
 
     def test_service_names_and_types(self):
         # test that it doesn't raise

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import unittest
-import warnings
 
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-from rclpy.qos import _qos_profile_default
+from rclpy.qos import InvalidQoSProfileException
 from rclpy.qos import qos_profile_system_default
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSHistoryPolicy
@@ -96,33 +95,13 @@ class TestQosProfile(unittest.TestCase):
         )
         self.convert_and_assert_equality(source_profile)
 
-    def test_deprecation_warnings(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+    def test_invalid_qos(self):
+        with self.assertRaises(InvalidQoSProfileException):
+            # No history or depth settings provided
             QoSProfile()
-            assert len(w) == 2  # must supply depth or history, _and_ KEEP_LAST needs depth
-            assert issubclass(w[0].category, UserWarning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # No deprecation if history is supplied
-            QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL)
-            assert len(w) == 0, str(w[-1].message)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # Deprecation warning if KEEP_LAST, but no depth
+        with self.assertRaises(InvalidQoSProfileException):
+            # History is KEEP_LAST, but no depth is provided
             QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST)
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # No deprecation if 'depth' is present
-            QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=1)
-            assert len(w) == 0, str(w[-1].message)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # No deprecation if only depth
-            QoSProfile(depth=1)
-            assert len(w) == 0, str(w[-1].message)
 
     def test_policy_short_names(self):
         # Full test on History to show the mechanism works
@@ -143,11 +122,3 @@ class TestQosProfile(unittest.TestCase):
         assert (
             QoSPresetProfiles.SYSTEM_DEFAULT.value ==
             QoSPresetProfiles.get_from_short_key('system_default'))
-
-    def test_default_profile(self):
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always')
-            profile = QoSProfile()
-        assert all(
-            profile.__getattribute__(k) == _qos_profile_default.__getattribute__(k)
-            for k in profile.__slots__)


### PR DESCRIPTION
Existing warnings are replaced with a new exception, InvalidQoSProfileException.

Resolves #430