### PR TITLE
Make cppcheck happy

### DIFF
--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <assert.h>
+
 #include "rcl/error_handling.h"
 
 #include "rclpy_common/common.h"
@@ -35,6 +37,7 @@ typedef struct rclpy_qos_profile
 void
 init_rclpy_qos_profile(rclpy_qos_profile_t * rclpy_profile)
 {
+  assert(rclpy_profile);
   memset(rclpy_profile, 0, sizeof(*rclpy_profile));
 }
 


### PR DESCRIPTION
It looks like adding an assert fixes a false-positive from cppcheck.

Previously, cppcheck was complaining that `rclpy_profile` may not be set [![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_win_extra_rmw_rel&build=494)](https://ci.ros2.org/job/nightly_win_extra_rmw_rel/494/)
With this fix: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8136)](https://ci.ros2.org/job/ci_windows/8136/)