### PR TITLE
[dashing backport] Action server: catch exception from user execute callback (#437)

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -15,6 +15,7 @@
 from enum import Enum
 import functools
 import threading
+import traceback
 
 from action_msgs.msg import GoalInfo, GoalStatus
 
@@ -328,8 +329,14 @@ class ActionServer(Waitable):
         goal_uuid = goal_handle.goal_id.uuid
         self._node.get_logger().debug('Executing goal with ID {0}'.format(goal_uuid))
 
-        # Execute user callback
-        execute_result = await await_or_execute(execute_callback, goal_handle)
+        try:
+            # Execute user callback
+            execute_result = await await_or_execute(execute_callback, goal_handle)
+        except Exception as ex:
+            # Create an empty result so that we can still send a response to the client
+            execute_result = self._action_type.Result()
+            self._node.get_logger().error('Error raised in execute callback: {0}'.format(ex))
+            traceback.print_exc()
 
         # If user did not trigger a terminal state, assume aborted
         if goal_handle.is_active:

--- a/rclpy/test/test_action_server.py
+++ b/rclpy/test/test_action_server.py
@@ -520,6 +520,35 @@ class TestActionServer(unittest.TestCase):
         self.assertEqual(result_response.result.sequence.tolist(), [1, 1, 2, 3, 5])
         action_server.destroy()
 
+    def test_execute_raises_exception(self):
+
+        def execute_callback(goal_handle):
+            # User callback raises
+            raise RuntimeError('test user callback raises')
+
+        action_server = ActionServer(
+            self.node,
+            Fibonacci,
+            'fibonacci',
+            execute_callback=execute_callback,
+        )
+
+        goal_uuid = UUID(uuid=list(uuid.uuid4().bytes))
+        goal_msg = Fibonacci.Impl.SendGoalService.Request()
+        goal_msg.goal_id = goal_uuid
+        goal_future = self.mock_action_client.send_goal(goal_msg)
+        rclpy.spin_until_future_complete(self.node, goal_future, self.executor)
+        goal_handle = goal_future.result()
+        self.assertTrue(goal_handle.accepted)
+
+        get_result_future = self.mock_action_client.get_result(goal_uuid)
+        rclpy.spin_until_future_complete(self.node, get_result_future, self.executor)
+        result_response = get_result_future.result()
+        # Goal status should default to STATUS_ABORTED
+        self.assertEqual(result_response.status, GoalStatus.STATUS_ABORTED)
+        self.assertEqual(result_response.result.sequence.tolist(), [])
+        action_server.destroy()
+
     def test_expire_goals_none(self):
 
         # 1 second timeout


### PR DESCRIPTION
Backport #437 to Dashing.

Fixes #296.

Catch and print exception traceback from user-defined execute callback.
Added unit test to cover this case.