### PR TITLE
[crystal backport] Action server: catch exception from user execute callback (#437)

### DIFF
--- a/rclpy/test/action/test_server.py
+++ b/rclpy/test/action/test_server.py
@@ -534,8 +534,8 @@ class TestActionServer(unittest.TestCase):
         )
 
         goal_uuid = UUID(uuid=list(uuid.uuid4().bytes))
-        goal_msg = Fibonacci.Impl.SendGoalService.Request()
-        goal_msg.goal_id = goal_uuid
+        goal_msg = Fibonacci.Goal()
+        goal_msg._action_goal_id = goal_uuid
         goal_future = self.mock_action_client.send_goal(goal_msg)
         rclpy.spin_until_future_complete(self.node, goal_future, self.executor)
         goal_handle = goal_future.result()
@@ -545,8 +545,8 @@ class TestActionServer(unittest.TestCase):
         rclpy.spin_until_future_complete(self.node, get_result_future, self.executor)
         result_response = get_result_future.result()
         # Goal status should default to STATUS_ABORTED
-        self.assertEqual(result_response.status, GoalStatus.STATUS_ABORTED)
-        self.assertEqual(result_response.result.sequence.tolist(), [])
+        self.assertEqual(result_response.action_status, GoalStatus.STATUS_ABORTED)
+        self.assertEqual(result_response.sequence, [])
         action_server.destroy()
 
     def test_expire_goals_none(self):


### PR DESCRIPTION
Backport #437 to Crystal.

Fixes #296.

Catch and print exception traceback from user-defined execute callback.
Added unit test to cover this case.

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8727)](https://ci.ros2.org/job/ci_linux/8727/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4558)](https://ci.ros2.org/job/ci_linux-aarch64/4558/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7129)](https://ci.ros2.org/job/ci_osx/7129/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8642)](https://ci.ros2.org/job/ci_windows/8642/)

Edit: retrigger CI with test refactor (bb76362).

Edit: Unrelated linter errors and one [rosidl_parser test failure](https://ci.ros2.org/job/ci_linux/8727/testReport/junit/(root)/rosidl_parser/test_test_parser/) on all platforms.

CI without this change has the same failures: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8735)](https://ci.ros2.org/job/ci_linux/8735/)