### PR TITLE
Make use of Clock class for throttling logs

### DIFF
--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -132,8 +132,8 @@ class Throttle(LoggingFilter):
         context['throttle_last_logged'] = 0
         if not isinstance(context['throttle_time_source_type'], Clock):
             raise ValueError(
-                'Received throttle_time_source_type of "{0}"; '
-                'currently Clock object is supported.'
+                'Received throttle_time_source_type of "{0}" '
+                'is not a clock instance'
                 .format(context['throttle_time_source_type']))
 
     @staticmethod

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -17,8 +17,8 @@ from collections import namedtuple
 from collections import OrderedDict
 import inspect
 import os
-import time
 
+from rclpy.clock import Clock
 from rclpy.impl.implementation_singleton import rclpy_logging_implementation as _rclpy_logging
 
 # Known filenames from which logging methods can be called (will be ignored in `_find_caller`).
@@ -123,28 +123,24 @@ class Throttle(LoggingFilter):
 
     params = {
         'throttle_duration_sec': None,
-        'throttle_time_source_type': 'RCUTILS_STEADY_TIME',
+        'throttle_time_source_type': Clock(),
     }
 
     @classmethod
     def initialize_context(cls, context, **kwargs):
         super(Throttle, cls).initialize_context(context, **kwargs)
         context['throttle_last_logged'] = 0
-        # TODO(dhood): clarify the accepted values of the time source type, once it's actually used
-        if context['throttle_time_source_type'] != 'RCUTILS_STEADY_TIME':
+        if not isinstance(context['throttle_time_source_type'], Clock):
             raise ValueError(
                 'Received throttle_time_source_type of "{0}"; '
-                'currently only RCUTILS_STEADY_TIME is supported'
-                # TODO(dhood): remove the following note when the time source is actually rcutils
-                ' (simulated with python time.monotonic)'
+                'currently Clock object is supported.'
                 .format(context['throttle_time_source_type']))
 
     @staticmethod
     def should_log(context):
         logging_condition = True
-        # TODO(dhood): use rcutils time once support is available in rclpy
-        now = time.monotonic()
-        next_log_time = context['throttle_last_logged'] + context['throttle_duration_sec']
+        now = context['throttle_time_source_type'].now().nanoseconds
+        next_log_time = context['throttle_last_logged'] + (context['throttle_duration_sec'] * 1e+9)
         logging_condition = now >= next_log_time
         if logging_condition:
             context['throttle_last_logged'] = now

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -17,7 +17,10 @@ import time
 import unittest
 
 import rclpy
+from rclpy.clock import Clock, ROSClock
 from rclpy.logging import LoggingSeverity
+from rclpy.time import Time
+from rclpy.time_source import TimeSource
 
 
 class TestLogging(unittest.TestCase):
@@ -100,12 +103,13 @@ class TestLogging(unittest.TestCase):
 
     def test_log_throttle(self):
         message_was_logged = []
+        system_clock = Clock()
         for i in range(5):
             message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 throttle_duration_sec=1,
-                throttle_time_source_type='RCUTILS_STEADY_TIME',
+                throttle_time_source_type=system_clock,
             ))
             time.sleep(0.4)
         self.assertEqual(
@@ -115,6 +119,50 @@ class TestLogging(unittest.TestCase):
                 False,  # t=0.8, throttled
                 True,  # t=1.2, not throttled
                 False  # t=1.6, throttled
+            ])
+
+    def test_log_throttle_ros_clock(self):
+        message_was_logged = []
+        ros_clock = ROSClock()
+        time_source = TimeSource()
+        time_source.attach_clock(ros_clock)
+        time_source.ros_time_is_active = True
+        for i in range(5):
+            message_was_logged.append(rclpy.logging._root_logger.log(
+                'message_' + inspect.stack()[0][3] + '_' + str(i),
+                LoggingSeverity.INFO,
+                throttle_duration_sec=1,
+                throttle_time_source_type=ros_clock,
+            ))
+            time.sleep(0.4)
+        self.assertEqual(
+            message_was_logged, [
+                False,  # t=0, throttled
+                False,  # t=0.4, throttled
+                False,  # t=0.8, throttled
+                False,  # t=1.2, throttled
+                False  # t=1.6, throttled
+            ])
+        message_was_logged = []
+        for i in range(5):
+            message_was_logged.append(rclpy.logging._root_logger.log(
+                'message_' + inspect.stack()[0][3] + '_' + str(i),
+                LoggingSeverity.INFO,
+                throttle_duration_sec=2,
+                throttle_time_source_type=ros_clock,
+            ))
+            ros_clock.set_ros_time_override(Time(
+                seconds=i + 1,
+                nanoseconds=0,
+                clock_type=ros_clock.clock_type,
+                ))
+        self.assertEqual(
+            message_was_logged, [
+                False,  # t=0, throttled
+                False,  # t=1.0, throttled
+                True,  # t=2.0, not throttled
+                False,  # t=3.0, throttled
+                True  # t=4.0, not throttled
             ])
 
     def test_log_skip_first(self):
@@ -131,13 +179,14 @@ class TestLogging(unittest.TestCase):
         # Because of the ordering of supported_filters, first the throttle condition will be
         # evaluated/updated, then the skip_first condition
         message_was_logged = []
+        system_clock = Clock()
         for i in range(5):
             message_was_logged.append(rclpy.logging._root_logger.log(
                 'message_' + inspect.stack()[0][3] + '_' + str(i),
                 LoggingSeverity.INFO,
                 skip_first=True,
                 throttle_duration_sec=1,
-                throttle_time_source_type='RCUTILS_STEADY_TIME',
+                throttle_time_source_type=system_clock,
             ))
             time.sleep(0.4)
         self.assertEqual(
@@ -164,12 +213,13 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(message_was_logged, [False, True] + [False] * 3)
 
     def test_log_arguments(self):
+        system_clock = Clock()
         # Check half-specified filter not allowed if a required parameter is missing
         with self.assertRaisesRegex(TypeError, 'required parameter .* not specified'):
             rclpy.logging._root_logger.log(
                 'message',
                 LoggingSeverity.INFO,
-                throttle_time_source_type='RCUTILS_STEADY_TIME',
+                throttle_time_source_type=system_clock,
             )
 
         # Check half-specified filter is allowed if an optional parameter is missing

--- a/rclpy/test/test_logging.py
+++ b/rclpy/test/test_logging.py
@@ -155,7 +155,7 @@ class TestLogging(unittest.TestCase):
                 seconds=i + 1,
                 nanoseconds=0,
                 clock_type=ros_clock.clock_type,
-                ))
+            ))
         self.assertEqual(
             message_was_logged, [
                 False,  # t=0, throttled


### PR DESCRIPTION
As the title says, this make use of the python clock class for throttling logs. Follow up PR for [rclcpp](https://github.com/ros2/rclcpp/pull/879) and [rcutils](https://github.com/ros2/rcutils/pull/183)

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8452)](https://ci.ros2.org/job/ci_linux/8452/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4345)](https://ci.ros2.org/job/ci_linux-aarch64/4345/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8345)](https://ci.ros2.org/job/ci_windows/8345/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6868)](https://ci.ros2.org/job/ci_osx/6868/)

CI failures are unrelated to my changes.