### PR TITLE
Add Rate

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -200,6 +200,7 @@ if(BUILD_TESTING)
     test/test_parameters_callback.py
     test/test_qos.py
     test/test_qos_event.py
+    test/test_rate.py
     test/test_task.py
     test/test_time_source.py
     test/test_time.py

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -110,3 +110,10 @@ class ParameterImmutableException(ParameterException):
 
     def __init__(self, parameter, *args):
         Exception.__init__(self, 'Attempted to modify read-only parameter', parameter, *args)
+
+
+class ROSInterruptException(Exception):
+    """Raised when an operation is canceled by rclpy shutting down."""
+
+    def __init__(self, *args):
+        Exception.__init__(self, 'rclpy.shutdown() has been called', *args)

--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -55,6 +55,10 @@ class Handle:
         self.__capsule_name = _rclpy_capsule.rclpy_pycapsule_name(pycapsule)
         self.__capsule_pointer = _rclpy_capsule.rclpy_pycapsule_pointer(pycapsule)
 
+    def __bool__(self):
+        """Return True if the handle is valid."""
+        return self.__valid
+
     def __eq__(self, other):
         return self.__capsule_pointer == other.__capsule_pointer
 

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -89,7 +89,7 @@ class Timer:
 class Rate:
     """A utility for sleeping at a fixed rate."""
 
-    def __init__(self, timer: Timer, *, context=None):
+    def __init__(self, timer: Timer, *, context):
         # Rate is a wrapper around a timer
         self._timer = timer
         self._is_shutdown = False

--- a/rclpy/test/test_rate.py
+++ b/rclpy/test/test_rate.py
@@ -1,0 +1,122 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+
+import pytest
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+
+# Hz
+FREQ = 10.0
+PERIOD = 1.0 / FREQ
+PASS_MAX_JITTER = PERIOD * 0.1
+
+
+class RateRunner:
+
+    def __init__(self, rate):
+        self.avg_period = None
+        self.max_jitter = None
+        self.done = False
+
+        self._num_measurements = 10
+        self._thread = threading.Thread(target=self._run, args=(rate,), daemon=True)
+        self._thread.start()
+
+    def __str__(self):
+        return 'avg period: {} max jitter: {}'.format(self.avg_period, self.max_jitter)
+
+    def _run(self, rate):
+        try:
+            measurements = []
+            # First sleep time depends on how long thread took to start, so ignore it
+            rate.sleep()
+            last_wake_time = time.monotonic()
+
+            for i in range(self._num_measurements):
+                rate.sleep()
+                now = time.monotonic()
+                measurements.append(now - last_wake_time)
+                last_wake_time = now
+
+            self.avg_period = sum(measurements) / len(measurements)
+            self.max_jitter = max([abs(m) - self.avg_period for m in measurements])  # noqa: C407
+        finally:
+            self.done = True
+
+
+class TestRate:
+
+    def setup_method(self):
+        self.context = rclpy.context.Context()
+        rclpy.init(context=self.context)
+        self.node = rclpy.create_node('test_rate', context=self.context)
+        self.executor = SingleThreadedExecutor(context=self.context)
+        self.executor.add_node(self.node)
+
+    def teardown_method(self):
+        self.executor.shutdown()
+        self.node.destroy_node()
+        rclpy.shutdown(context=self.context)
+
+    def test_rate_valid_period(self):
+        rate = self.node.create_rate(FREQ)
+
+        runner = RateRunner(rate)
+        while not runner.done:
+            self.executor.spin_once()
+
+        assert runner.max_jitter <= PASS_MAX_JITTER, str(runner)
+        assert abs(runner.avg_period - PERIOD) <= PASS_MAX_JITTER, str(runner)
+
+    def test_rate_invalid_period(self):
+        with pytest.raises(TypeError):
+            self.node.create_rate(None)
+
+        with pytest.raises(ValueError):
+            self.node.create_rate(0.0)
+
+        with pytest.raises(ValueError):
+            self.node.create_rate(-1.0)
+
+    def test_destroy(self):
+        rate = self.node.create_rate(FREQ)
+        self.node.destroy_rate(rate)
+
+    def test_destroy_wakes_rate(self):
+        rate = self.node.create_rate(0.0000001)
+
+        self._thread = threading.Thread(target=rate.sleep, daemon=True)
+        self._thread.start()
+        self.node.destroy_rate(rate)
+        self._thread.join()
+
+
+def test_shutdown_wakes_rate():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node('test_rate_shutdown', context=context)
+    executor = SingleThreadedExecutor(context=context)
+    executor.add_node(node)
+
+    rate = node.create_rate(0.0000001)
+
+    _thread = threading.Thread(target=rate.sleep, daemon=True)
+    _thread.start()
+    executor.shutdown()
+    node.destroy_node()
+    rclpy.shutdown(context=context)
+    _thread.join()


### PR DESCRIPTION
Resolves #186

This adds a `Rate` class. It's a tool for running a loop at a constant rate.

Plus:
* Made context shutdown callbacks use `weakref.WeakMethod()`.
  * Should prevent the callback list from growing infinitely.
* Added `Handle.__bool__()`.
  * Used to avoid sleeping if the timer was destroyed.

Comparison with ROS 1:
* ROS 1: `rate = rospy.Rate(10)`; ROS 2 `rate = node.create_rate(10)`.
* Both raise `ROSInterruptException` if the client library has been shutdown
* ROS 1: may raise `ROSTimeMovedBackwardsException`; ROS 2: uses [timer time jump logic](https://github.com/ros2/rcl/blob/e6739884151c302838cfbe908fc9963ef4836f8f/rcl/src/rcl/timer.c#L60).
  * If it went back more than 1 period, `Rate` sleeps for 1 full period. If it went backwards less than a period, `Rate` sleeps for the time remaining. If the time source changed, sleeps for the time remaining.
* ROS 1: Almost always ok to call in a callback; ROS 2: An executor must be serving the timer, so may block if called in a callback in a `SingleThreadedExecutor`
* ROS 1: Had `Rate.remaining()`; ROS 2: not implemented. It should be easy to add if someone needs it.