### PR TITLE
Support array parameter types

### DIFF
--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import array
 from enum import Enum
 
 from rcl_interfaces.msg import Parameter as ParameterMsg
@@ -52,7 +53,7 @@ class Parameter:
                 return Parameter.Type.DOUBLE
             elif isinstance(parameter_value, str):
                 return Parameter.Type.STRING
-            elif isinstance(parameter_value, (list, tuple)):
+            elif isinstance(parameter_value, (list, tuple, array.array)):
                 if all(isinstance(v, bytes) for v in parameter_value):
                     return Parameter.Type.BYTE_ARRAY
                 elif all(isinstance(v, bool) for v in parameter_value):
@@ -86,10 +87,10 @@ class Parameter:
                 return isinstance(parameter_value, (list, tuple)) and \
                     all(isinstance(v, bool) for v in parameter_value)
             if Parameter.Type.INTEGER_ARRAY == self:
-                return isinstance(parameter_value, (list, tuple)) and \
+                return isinstance(parameter_value, (list, tuple, array.array)) and \
                     all(isinstance(v, int) for v in parameter_value)
             if Parameter.Type.DOUBLE_ARRAY == self:
-                return isinstance(parameter_value, (list, tuple)) and \
+                return isinstance(parameter_value, (list, tuple, array.array)) and \
                     all(isinstance(v, float) for v in parameter_value)
             if Parameter.Type.STRING_ARRAY == self:
                 return isinstance(parameter_value, (list, tuple)) and \

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -15,6 +15,8 @@
 from array import array
 import unittest
 
+from rcl_interfaces.msg import Parameter as ParameterMsg
+from rcl_interfaces.msg import ParameterValue
 from rclpy.parameter import Parameter
 
 
@@ -143,11 +145,21 @@ class TestParameter(unittest.TestCase):
         int_array = array('i', [1, 2, 3])
         self.assertEqual(
             Parameter.Type.INTEGER_ARRAY, Parameter.Type.from_parameter_value(int_array))
+        # test that it doesn't raise
+        Parameter.from_parameter_msg(ParameterMsg(
+            name='int_array',
+            value=ParameterValue(type=7, integer_array_value=[1, 2, 3])
+        ))
 
     def test_double_array(self):
         double_array = array('d', [1.0, 2.0, 3.0])
         self.assertEqual(
             Parameter.Type.DOUBLE_ARRAY, Parameter.Type.from_parameter_value(double_array))
+        # test that it doesn't raise
+        Parameter.from_parameter_msg(ParameterMsg(
+            name='double_array',
+            value=ParameterValue(type=8, double_array_value=[1.0, 2.0, 3.0])
+        ))
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from array import array
 import unittest
 
 from rclpy.parameter import Parameter
@@ -137,6 +138,16 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(
             Parameter.Type.INTEGER_ARRAY, Parameter.Type.from_parameter_value(int_tuple))
         self.assertTrue(Parameter.Type.check(Parameter.Type.INTEGER_ARRAY, int_tuple))
+
+    def test_integer_array(self):
+        int_array = array('i', [1, 2, 3])
+        self.assertEqual(
+            Parameter.Type.INTEGER_ARRAY, Parameter.Type.from_parameter_value(int_array))
+
+    def test_double_array(self):
+        double_array = array('d', [1.0, 2.0, 3.0])
+        self.assertEqual(
+            Parameter.Type.DOUBLE_ARRAY, Parameter.Type.from_parameter_value(double_array))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #424. Adds support for double and int python arrays

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8489)](https://ci.ros2.org/job/ci_linux/8489/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4377)](https://ci.ros2.org/job/ci_linux-aarch64/4377/)
- macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6904)](http://ci.ros2.org/job/ci_osx/6904/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8392)](http://ci.ros2.org/job/ci_windows/8392/)

Edit: Rerunning jobs