### PR TITLE
Drop rclpy test_remove_ros_args_empty test case.

### DIFF
--- a/rclpy/test/test_utilities.py
+++ b/rclpy/test/test_utilities.py
@@ -38,11 +38,6 @@ class TestValidateRemoveRosArgs(unittest.TestCase):
         self.assertEqual('--foo=bar', stripped_args[2])
         self.assertEqual('--baz', stripped_args[3])
 
-    def test_remove_ros_args_empty(self):
-        args = []
-        with self.assertRaises(RuntimeError):
-            rclpy.utilities.remove_ros_args(args=args)
-
 
 class TestUtilities(unittest.TestCase):
 


### PR DESCRIPTION
Follow-up PR after https://github.com/ros2/rcl/pull/518.