### PR TITLE
Fix the unicode test string for opensplice rmw implementation

### DIFF
--- a/rclpy/test/test_messages.py
+++ b/rclpy/test/test_messages.py
@@ -47,7 +47,14 @@ class TestMessages(unittest.TestCase):
         self.node.destroy_publisher(pub)
 
     def test_different_type_raises(self):
-        pub = self.node.create_publisher(BasicTypes, 'chatter', 1)
+        # TODO(bmarchi): When a publisher is destroyed for opensplice,
+        # the topic from the previous test is kept around and is cached, so
+        # the new publisher can't be created because opensplice checks
+        # if the parameters of the created topic are the same as the one
+        # that has in memory. It's expected that if any participant
+        # is not subscribed/publishing to a topic, this is destroyed.
+        pub = self.node.create_publisher(
+            BasicTypes, 'chatter_different_message_type', 1)
         with self.assertRaises(TypeError):
             pub.publish('different message type')
         self.node.destroy_publisher(pub)

--- a/rclpy/test/test_messages.py
+++ b/rclpy/test/test_messages.py
@@ -53,6 +53,8 @@ class TestMessages(unittest.TestCase):
         # if the parameters of the created topic are the same as the one
         # that has in memory. It's expected that if any participant
         # is not subscribed/publishing to a topic, this is destroyed.
+        # Revert the topic name to 'chatter' once proper topic destruction
+        # for opensplice is possible.
         pub = self.node.create_publisher(
             BasicTypes, 'chatter_different_message_type', 1)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
As the title says, this fixes a particular test for opensplice.
I don't think this is a proper solution for the issue, but it keeps CI happy. What I was able to understand and find, is that opensplice caches the topics that are created. I know we are using a `deb`, but I took a peek to their [community edition](https://github.com/ADLINK-IST/opensplice) and it seems that the errors matched just fine. You can see that error [here](https://ci.ros2.org/job/ci_linux/8480/testReport/junit/rclpy.test.test_messages/TestMessages/test_unicode_string/).
As I was saying, when one creates a publisher/subscriber, it reaches a point where it creates a topic, calling this function

https://github.com/ADLINK-IST/opensplice/blob/c98e118a2e4366d2a5a6af8cbcecdf112bf9e4ab/src/kernel/code/v_topicImpl.c#L477

Specifically, this is part of our interest

https://github.com/ADLINK-IST/opensplice/blob/c98e118a2e4366d2a5a6af8cbcecdf112bf9e4ab/src/kernel/code/v_topicImpl.c#L527

Here, it makes use of a `lookuptable` for topics that lives within the kernel.

https://github.com/ADLINK-IST/opensplice/blob/c98e118a2e4366d2a5a6af8cbcecdf112bf9e4ab/src/kernel/code/v_topicImpl.c#L532

That function is the one that checks the types of the new topic and the one it found (since the names are the same).
Digging a little bit in the rmw implementation for the publisher, I saw that we do call a `delete_topic` function for the participant

https://github.com/ros2/rmw_opensplice/blob/f9997162920857a46a782ad1fbf7b876f6ba05bd/rmw_opensplice_cpp/src/rmw_publisher.cpp#L274

And it seems that there's no issue in "deleting" the topic, otherwise an error/exception should show.
When a node is destroyed, in `rmw_destroy_node`, I found a curious comment.

https://github.com/ros2/rmw_opensplice/blob/f9997162920857a46a782ad1fbf7b876f6ba05bd/rmw_opensplice_cpp/src/rmw_node.cpp#L381-L386

The interesting thing is that it seems that we are somewhat aware that some stuff could be in memory yet even if they shouldn't.
Does anyone have a clue if this is a known issue or we are missing a function call in the `destroy_publisher` function?

- Opensplice jobs:
- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8527)](https://ci.ros2.org/job/ci_linux/8527/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4409)](https://ci.ros2.org/job/ci_linux-aarch64/4409/)
- macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6953)](http://ci.ros2.org/job/ci_osx/6953/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8441)](http://ci.ros2.org/job/ci_windows/8441/)