### PR TITLE
Expand test timeout to deflake rmw_connext

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -220,7 +220,7 @@ if(BUILD_TESTING)
       PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
       APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}
         PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
-      TIMEOUT 60
+      TIMEOUT 120
       WERROR ON
     )
   endforeach()


### PR DESCRIPTION
I didn't see any duplication as in other tests, the following are just very substantial test files.

Based on a test local to my laptop, two test exceed the current 60 second timeout:

```
test_executor .....................   Passed   61.35 sec
test_node .........................   Passed  103.98 sec
```

And one is marginal:

```
test_time_source ..................   Passed   54.96 sec
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>