### PR TITLE
add missing exec depend on rcl_interfaces

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -25,13 +25,13 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>rcl_interfaces</test_depend>
   <test_depend>rosidl_generator_py</test_depend>
   <test_depend>test_msgs</test_depend>
 


### PR DESCRIPTION
Fixes ros2/rcl_interfaces#87.