### PR TITLE
fix import to use builtin_interfaces.msg

### DIFF
--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import builtin_interfaces
+import builtin_interfaces.msg
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import builtin_interfaces
+import builtin_interfaces.msg
 from rclpy.clock import ClockType
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy


### PR DESCRIPTION
Fix functions using `builtin_interfaces.msg.Duration` / `builtin_interfaces.msg.Time`.