### PR TITLE
Implement functions to get publisher and subcription informations like QoS policies from topic name

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -209,6 +209,7 @@ if(BUILD_TESTING)
     test/test_time.py
     test/test_timer.py
     test/test_topic_or_service_is_hidden.py
+    test/test_topic_endpoint_info.py
     test/test_utilities.py
     test/test_validate_full_topic_name.py
     test/test_validate_namespace.py

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1689,9 +1689,15 @@ class Node:
         no_mangle: bool,
         func: Callable[[object, str, bool], List[Dict]]
     ) -> List[TopicEndpointInfo]:
-        fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
-        validate_full_topic_name(fq_topic_name)
         with self.handle as node_capsule:
+            if no_mangle:
+                fq_topic_name = topic_name
+            else:
+                fq_topic_name = expand_topic_name(
+                    topic_name, self.get_name(), self.get_namespace())
+                validate_full_topic_name(fq_topic_name)
+                fq_topic_name = _rclpy.rclpy_remap_topic_name(node_capsule, fq_topic_name)
+
             info_dicts = func(node_capsule, fq_topic_name, no_mangle)
             infos = [TopicEndpointInfo(**x) for x in info_dicts]
             return infos

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -67,6 +67,7 @@ from rclpy.subscription import Subscription
 from rclpy.time_source import TimeSource
 from rclpy.timer import Rate
 from rclpy.timer import Timer
+from rclpy.topic_endpoint_info import TopicEndpointInfo
 from rclpy.type_support import check_for_type_support
 from rclpy.utilities import get_default_context
 from rclpy.validate_full_topic_name import validate_full_topic_name
@@ -1687,14 +1688,16 @@ class Node:
         topic_name: str,
         no_mangle: bool,
         func: Callable[[object, str, bool], List[Dict]]
-    ) -> List[Dict]:
+    ) -> List[TopicEndpointInfo]:
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
         validate_full_topic_name(fq_topic_name)
         with self.handle as node_capsule:
-            return func(node_capsule, fq_topic_name, no_mangle)
+            info_dicts = func(node_capsule, fq_topic_name, no_mangle)
+            infos = [TopicEndpointInfo(**x) for x in info_dicts]
+            return infos
 
     def get_publishers_info_by_topic(
-            self, topic_name: str, no_mangle: bool = False) -> List[Dict]:
+            self, topic_name: str, no_mangle: bool = False) -> List[TopicEndpointInfo]:
         """
         Return a list of publishers publishing to a given topic.
 
@@ -1713,7 +1716,7 @@ class Node:
         :param topic_name: the topic_name on which to find the publishers.
         :param no_mangle: no_mangle if `true`, `topic_name` needs to be a valid middleware topic
             name, otherwise it should be a valid ROS topic name. Defaults to `false`.
-        :return: a list of dictionaries representing all the publishers on this topic.
+        :return: a list of TopicEndpointInfo for all the publishers on this topic.
         """
         return self._get_info_by_topic(
             topic_name,
@@ -1721,7 +1724,7 @@ class Node:
             _rclpy.rclpy_get_publishers_info_by_topic)
 
     def get_subscriptions_info_by_topic(
-            self, topic_name: str, no_mangle: bool = False) -> List[Dict]:
+            self, topic_name: str, no_mangle: bool = False) -> List[TopicEndpointInfo]:
         """
         Return a list of subscriptions to a given topic.
 
@@ -1740,7 +1743,7 @@ class Node:
         :param topic_name: the topic_name on which to find the subscriptions.
         :param no_mangle: no_mangle if `true`, `topic_name` needs to be a valid middleware topic
             name, otherwise it should be a valid ROS topic name. Defaults to `false`.
-        :return: a list of dictionaries representing all the subscriptions on this topic.
+        :return: a list of TopicEndpointInfo for all the subscriptions on this topic.
         """
         return self._get_info_by_topic(
             topic_name,

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1701,7 +1701,7 @@ class Node:
         """
         Return a list of publishers publishing to a given topic.
 
-        The returned parameter is a list of dictionaries, where each dictionary will contain
+        The returned parameter is a list of TopicEndpointInfo objects, where each will contain
         the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
 
         When the `no_mangle` parameter is `true`, the provided `topic_name` should be a valid topic
@@ -1728,7 +1728,7 @@ class Node:
         """
         Return a list of subscriptions to a given topic.
 
-        The returned parameter is a list of dictionaries, where each dictionary will contain
+        The returned parameter is a list of TopicEndpointInfo objects, where each will contain
         the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
 
         When the `no_mangle` parameter is `true`, the provided `topic_name` should be a valid topic

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1701,17 +1701,18 @@ class Node:
         The returned parameter is a list of dictionaries, where each dictionary will
         contain the node name, node namespace, topic type, participant's GID and its QoS profile.
 
-        'topic_name' may be a relative, private or fully qualified topic name.
-        A relative or private topic will be expanded using this node's namespace and name, if
-        the 'no_mangle' param is set to false.
+        When the `no_mangle` parameter is `true`, the provided `topic_name` should be a valid topic
+        name for the middleware (useful when combining ROS with native middleware (e.g. DDS) apps).
+        When the `no_mangle` parameter is `false`, the provided `topic_name` should follow
+        ROS topic name conventions.
 
-        The queried topic name is not remapped.
-
-        'no_mangle' defaults to false.
+        `topic_name` may be a relative, private, or fully qualified topic name.
+        A relative or private topic will be expanded using this node's namespace and name.
+        The queried `topic_name` is not remapped.
 
         :param topic_name: the topic_name on which to find the publishers.
-        :param no_mangle: if false, the given topic name will be expanded
-                          to its fully qualified name.
+        :param no_mangle: no_mangle if `true`, `topic_name` needs to be a valid middleware topic
+                          name, otherwise it should be a valid ROS topic name. Defaults to `false`.
         :return: a list of dictionaries representing all the publishers on this topic.
         """
         return self._get_info_by_topic(
@@ -1727,17 +1728,18 @@ class Node:
         The returned parameter is a list of dictionaries, where each dictionary will contain
         the node name, node namespace, topic type, participant's GID and its QoS profile.
 
-        'topic_name' may be a relative, private or fully qualified topic name.
-        A relative or private topic will be expanded using this node's namespace and name, if
-        the 'no_mangle' param is set to false.
+        When the `no_mangle` parameter is `true`, the provided `topic_name` should be a valid topic
+        name for the middleware (useful when combining ROS with native middleware (e.g. DDS) apps).
+        When the `no_mangle` parameter is `false`, the provided `topic_name` should follow
+        ROS topic name conventions.
 
-        The queried topic name is not remapped.
-
-        'no_mangle' defaults to false.
+        `topic_name` may be a relative, private, or fully qualified topic name.
+        A relative or private topic will be expanded using this node's namespace and name.
+        The queried `topic_name` is not remapped.
 
         :param topic_name: the topic_name on which to find the subscriptions.
-        :param no_mangle: if false, the given topic name will be expanded
-                          to its fully qualified name.
+        :param no_mangle: no_mangle if `true`, `topic_name` needs to be a valid middleware topic
+                          name, otherwise it should be a valid ROS topic name. Defaults to `false`.
         :return: a list of dictionaries representing all the subscriptions on this topic.
         """
         return self._get_info_by_topic(

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1642,7 +1642,7 @@ class Node:
 
     def _count_publishers_or_subscribers(self, topic_name, func):
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
-        validate_topic_name(fq_topic_name)
+        validate_full_topic_name(fq_topic_name)
         with self.handle as node_capsule:
             return func(node_capsule, fq_topic_name)
 
@@ -1689,7 +1689,7 @@ class Node:
         func: Callable[[object, str, bool], List[Dict]]
     ) -> List[Dict]:
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
-        validate_topic_name(fq_topic_name)
+        validate_full_topic_name(fq_topic_name)
         with self.handle as node_capsule:
             return func(node_capsule, fq_topic_name, no_mangle)
 
@@ -1698,8 +1698,8 @@ class Node:
         """
         Return a list of publishers publishing to a given topic.
 
-        The returned parameter is a list of dictionaries, where each dictionary will
-        contain the node name, node namespace, topic type, participant's GID and its QoS profile.
+        The returned parameter is a list of dictionaries, where each dictionary will contain
+        the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
 
         When the `no_mangle` parameter is `true`, the provided `topic_name` should be a valid topic
         name for the middleware (useful when combining ROS with native middleware (e.g. DDS) apps).
@@ -1712,7 +1712,7 @@ class Node:
 
         :param topic_name: the topic_name on which to find the publishers.
         :param no_mangle: no_mangle if `true`, `topic_name` needs to be a valid middleware topic
-                          name, otherwise it should be a valid ROS topic name. Defaults to `false`.
+            name, otherwise it should be a valid ROS topic name. Defaults to `false`.
         :return: a list of dictionaries representing all the publishers on this topic.
         """
         return self._get_info_by_topic(
@@ -1726,7 +1726,7 @@ class Node:
         Return a list of subscriptions to a given topic.
 
         The returned parameter is a list of dictionaries, where each dictionary will contain
-        the node name, node namespace, topic type, participant's GID and its QoS profile.
+        the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
 
         When the `no_mangle` parameter is `true`, the provided `topic_name` should be a valid topic
         name for the middleware (useful when combining ROS with native middleware (e.g. DDS) apps).
@@ -1739,7 +1739,7 @@ class Node:
 
         :param topic_name: the topic_name on which to find the subscriptions.
         :param no_mangle: no_mangle if `true`, `topic_name` needs to be a valid middleware topic
-                          name, otherwise it should be a valid ROS topic name. Defaults to `false`.
+            name, otherwise it should be a valid ROS topic name. Defaults to `false`.
         :return: a list of dictionaries representing all the subscriptions on this topic.
         """
         return self._get_info_by_topic(

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1683,10 +1683,11 @@ class Node:
             _rclpy.rclpy_assert_liveliness(capsule)
 
     def _get_info_by_topic(
-            self,
-            topic_name: str,
-            no_mangle: bool,
-            func: Callable[[object, str, bool], List[Dict]]) -> List[Dict]:
+        self,
+        topic_name: str,
+        no_mangle: bool,
+        func: Callable[[object, str, bool], List[Dict]]
+    ) -> List[Dict]:
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
         validate_topic_name(fq_topic_name)
         with self.handle as node_capsule:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1703,9 +1703,12 @@ class Node:
             return infos
 
     def get_publishers_info_by_topic(
-            self, topic_name: str, no_mangle: bool = False) -> List[TopicEndpointInfo]:
+        self,
+        topic_name: str,
+        no_mangle: bool = False
+    ) -> List[TopicEndpointInfo]:
         """
-        Return a list of publishers publishing to a given topic.
+        Return a list of publishers on a given topic.
 
         The returned parameter is a list of TopicEndpointInfo objects, where each will contain
         the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.
@@ -1730,9 +1733,12 @@ class Node:
             _rclpy.rclpy_get_publishers_info_by_topic)
 
     def get_subscriptions_info_by_topic(
-            self, topic_name: str, no_mangle: bool = False) -> List[TopicEndpointInfo]:
+        self,
+        topic_name: str,
+        no_mangle: bool = False
+    ) -> List[TopicEndpointInfo]:
         """
-        Return a list of subscriptions to a given topic.
+        Return a list of subscriptions on a given topic.
 
         The returned parameter is a list of TopicEndpointInfo objects, where each will contain
         the node name, node namespace, topic type, topic endpoint's GID, and its QoS profile.

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1681,3 +1681,65 @@ class Node:
         """
         with self.handle as capsule:
             _rclpy.rclpy_assert_liveliness(capsule)
+
+    def _get_info_by_topic(
+            self,
+            topic_name: str,
+            no_mangle: bool,
+            func: Callable[[object, str, bool], List[Dict]]) -> List[Dict]:
+        fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
+        validate_topic_name(fq_topic_name)
+        with self.handle as node_capsule:
+            return func(node_capsule, fq_topic_name, no_mangle)
+
+    def get_publishers_info_by_topic(
+            self, topic_name: str, no_mangle: bool = False) -> List[Dict]:
+        """
+        Return a list of publishers publishing to a given topic.
+
+        The returned parameter is a list of dictionaries, where each dictionary will
+        contain the node name, node namespace, topic type, participant's GID and its QoS profile.
+
+        'topic_name' may be a relative, private or fully qualified topic name.
+        A relative or private topic will be expanded using this node's namespace and name, if
+        the 'no_mangle' param is set to false.
+
+        The queried topic name is not remapped.
+
+        'no_mangle' defaults to false.
+
+        :param topic_name: the topic_name on which to find the publishers.
+        :param no_mangle: if false, the given topic name will be expanded
+                          to its fully qualified name.
+        :return: a list of dictionaries representing all the publishers on this topic.
+        """
+        return self._get_info_by_topic(
+            topic_name,
+            no_mangle,
+            _rclpy.rclpy_get_publishers_info_by_topic)
+
+    def get_subscriptions_info_by_topic(
+            self, topic_name: str, no_mangle: bool = False) -> List[Dict]:
+        """
+        Return a list of subscriptions to a given topic.
+
+        The returned parameter is a list of dictionaries, where each dictionary will contain
+        the node name, node namespace, topic type, participant's GID and its QoS profile.
+
+        'topic_name' may be a relative, private or fully qualified topic name.
+        A relative or private topic will be expanded using this node's namespace and name, if
+        the 'no_mangle' param is set to false.
+
+        The queried topic name is not remapped.
+
+        'no_mangle' defaults to false.
+
+        :param topic_name: the topic_name on which to find the subscriptions.
+        :param no_mangle: if false, the given topic name will be expanded
+                          to its fully qualified name.
+        :return: a list of dictionaries representing all the subscriptions on this topic.
+        """
+        return self._get_info_by_topic(
+            topic_name,
+            no_mangle,
+            _rclpy.rclpy_get_subscriptions_info_by_topic)

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -276,6 +276,8 @@ class HistoryPolicy(QoSPolicyEnum):
     KEEP_LAST = RMW_QOS_POLICY_HISTORY_KEEP_LAST
     RMW_QOS_POLICY_HISTORY_KEEP_ALL = 2
     KEEP_ALL = RMW_QOS_POLICY_HISTORY_KEEP_ALL
+    RMW_QOS_POLICY_HISTORY_UNKNOWN = 3
+    UNKNOWN = RMW_QOS_POLICY_HISTORY_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
@@ -295,6 +297,8 @@ class ReliabilityPolicy(QoSPolicyEnum):
     RELIABLE = RMW_QOS_POLICY_RELIABILITY_RELIABLE
     RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT = 2
     BEST_EFFORT = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT
+    RMW_QOS_POLICY_RELIABILITY_UNKNOWN = 3
+    UNKNOWN = RMW_QOS_POLICY_RELIABILITY_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
@@ -314,6 +318,8 @@ class DurabilityPolicy(QoSPolicyEnum):
     TRANSIENT_LOCAL = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL
     RMW_QOS_POLICY_DURABILITY_VOLATILE = 2
     VOLATILE = RMW_QOS_POLICY_DURABILITY_VOLATILE
+    RMW_QOS_POLICY_DURABILITY_UNKNOWN = 3
+    UNKNOWN = RMW_QOS_POLICY_DURABILITY_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
@@ -335,11 +341,15 @@ class LivelinessPolicy(QoSPolicyEnum):
     MANUAL_BY_NODE = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE
     RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC = 3
     MANUAL_BY_TOPIC = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC
+    RMW_QOS_POLICY_LIVELINESS_UNKNOWN = 4
+    UNKNOWN = RMW_QOS_POLICY_LIVELINESS_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
 QoSLivelinessPolicy = LivelinessPolicy
 
+qos_profile_unknown = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+    'qos_profile_unknown'))
 qos_profile_system_default = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_system_default'))
 qos_profile_sensor_data = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
@@ -350,11 +360,12 @@ qos_profile_parameters = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_parameters'))
 qos_profile_parameter_events = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_parameter_events'))
-qos_profile_action_status_default = QoSProfile(
-    **_rclpy_action.rclpy_action_get_rmw_qos_profile('rcl_action_qos_profile_status_default'))
+qos_profile_action_status_default = QoSProfile(**_rclpy_action.rclpy_action_get_rmw_qos_profile(
+    'rcl_action_qos_profile_status_default'))
 
 
 class QoSPresetProfiles(Enum):
+    UNKNOWN = qos_profile_unknown
     SYSTEM_DEFAULT = qos_profile_system_default
     SENSOR_DATA = qos_profile_sensor_data
     SERVICES_DEFAULT = qos_profile_services_default

--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -14,7 +14,7 @@
 
 from enum import IntEnum
 
-from rclpy.qos import QoSProfile, QoSPresetProfiles
+from rclpy.qos import QoSPresetProfiles, QoSProfile
 
 
 class TopicEndpointTypeEnum(IntEnum):
@@ -49,7 +49,7 @@ class TopicEndpointInfo:
         self.node_namespace = kwargs.get('node_namespace', '')
         self.topic_type = kwargs.get('topic_type', '')
         self.endpoint_type = kwargs.get('endpoint_type', TopicEndpointTypeEnum.INVALID)
-        self.endpoint_gid = kwargs.get('endpoint_gid', list())
+        self.endpoint_gid = kwargs.get('endpoint_gid', [])
         self.qos_profile = kwargs.get('qos_profile', QoSPresetProfiles.UNKNOWN.value)
 
     @property

--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -1,0 +1,176 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import IntEnum
+
+from rclpy.qos import QoSProfile, QoSPresetProfiles
+
+
+class TopicEndpointTypeEnum(IntEnum):
+    """
+    Enum for possible types of topic endpoints.
+
+    This enum matches the one defined in rmw/types.h
+    """
+
+    INVALID = 0
+    PUBLISHER = 1
+    SUBSCRIPTION = 2
+
+
+class TopicEndpointInfo:
+    """
+    Information on a topic endpoint.
+    """
+
+    __slots__ = [
+        '_node_name',
+        '_node_namespace',
+        '_topic_type',
+        '_endpoint_type',
+        '_endpoint_gid',
+        '_qos_profile'
+    ]
+
+    def __init__(self, **kwargs):
+        assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
+            'Invalid arguments passed to constructor: %r' % kwargs.keys()
+
+        self.node_name = kwargs.get('node_name', '')
+        self.node_namespace = kwargs.get('node_namespace', '')
+        self.topic_type = kwargs.get('topic_type', '')
+        self.endpoint_type = kwargs.get('endpoint_type', TopicEndpointTypeEnum.INVALID)
+        self.endpoint_gid = kwargs.get('endpoint_gid', list())
+        self.qos_profile = kwargs.get('qos_profile', QoSPresetProfiles.UNKNOWN.value)
+
+    @property
+    def node_name(self):
+        """
+        Get field 'node_name'.
+
+        :returns: node_name attribute
+        :rtype: str
+        """
+        return self._node_name
+
+    @node_name.setter
+    def node_name(self, value):
+        assert isinstance(value, str)
+        self._node_name = value
+
+    @property
+    def node_namespace(self):
+        """
+        Get field 'node_namespace'.
+
+        :returns: node_namespace attribute
+        :rtype: str
+        """
+        return self._node_namespace
+
+    @node_namespace.setter
+    def node_namespace(self, value):
+        assert isinstance(value, str)
+        self._node_namespace = value
+
+    @property
+    def topic_type(self):
+        """
+        Get field 'topic_type'.
+
+        :returns: topic_type attribute
+        :rtype: str
+        """
+        return self._topic_type
+
+    @topic_type.setter
+    def topic_type(self, value):
+        assert isinstance(value, str)
+        self._topic_type = value
+
+    @property
+    def endpoint_type(self):
+        """
+        Get field 'endpoint_type'.
+
+        :returns: endpoint_type attribute
+        :rtype: TopicEndpointTypeEnum
+        """
+        return self._endpoint_type
+
+    @endpoint_type.setter
+    def endpoint_type(self, value):
+        if isinstance(value, TopicEndpointTypeEnum):
+            self._endpoint_type = value
+        elif isinstance(value, int):
+            self._endpoint_type = TopicEndpointTypeEnum(value)
+        else:
+            assert False
+
+    @property
+    def endpoint_gid(self):
+        """
+        Get field 'endpoint_gid'.
+
+        :returns: endpoint_gid attribute
+        :rtype: list
+        """
+        return self._endpoint_gid
+
+    @endpoint_gid.setter
+    def endpoint_gid(self, value):
+        assert all(isinstance(x, int) for x in value)
+        self._endpoint_gid = value
+
+    @property
+    def qos_profile(self):
+        """
+        Get field 'qos_profile'.
+
+        :returns: qos_profile attribute
+        :rtype: QoSProfile
+        """
+        return self._qos_profile
+
+    @qos_profile.setter
+    def qos_profile(self, value):
+        if isinstance(value, QoSProfile):
+            self._qos_profile = value
+        elif isinstance(value, dict):
+            self._qos_profile = QoSProfile(**value)
+        else:
+            assert False
+
+    def __eq__(self, other):
+        if not isinstance(other, TopicEndpointInfo):
+            return False
+        return all(
+            self.__getattribute__(slot) == other.__getattribute__(slot)
+            for slot in self.__slots__)
+
+    def __str__(self):
+        result = 'Node name: %s\n' % self.node_name
+        result += 'Node namespace: %s\n' % self.node_namespace
+        result += 'Topic type: %s\n' % self.topic_type
+        result += 'Endpoint type: %s\n' % self.endpoint_type.name
+        result += 'GID: %s\n' % '.'.join(format(x, '02x') for x in self.endpoint_gid)
+        result += 'QoS profile:\n'
+        result += '  Reliability: %s\n' % self.qos_profile.reliability.name
+        result += '  Durability: %s\n' % self.qos_profile.durability.name
+        result += '  Lifespan: %d nanoseconds\n' % self.qos_profile.lifespan.nanoseconds
+        result += '  Deadline: %d nanoseconds\n' % self.qos_profile.deadline.nanoseconds
+        result += '  Liveliness: %s\n' % self.qos_profile.liveliness.name
+        result += '  Liveliness lease duration: %d nanoseconds' % \
+            self.qos_profile.liveliness_lease_duration.nanoseconds
+        return result

--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -30,9 +30,7 @@ class TopicEndpointTypeEnum(IntEnum):
 
 
 class TopicEndpointInfo:
-    """
-    Information on a topic endpoint.
-    """
+    """Information on a topic endpoint."""
 
     __slots__ = [
         '_node_name',

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -915,11 +915,11 @@ _get_info_by_topic(
   rcl_topic_endpoint_info_array_t info_array = rcl_get_zero_initialized_topic_endpoint_info_array();
   rcl_ret_t ret = rcl_get_info_by_topic(node, &allocator, topic_name, no_mangle, &info_array);
   rcl_ret_t fini_ret;
-  if (ret != RCL_RET_OK) {
-    if (ret == RCL_RET_BAD_ALLOC) {
+  if (RCL_RET_OK != ret) {
+    if (RCL_RET_BAD_ALLOC == ret) {
       PyErr_Format(PyExc_MemoryError, "Failed to get information by topic for %s: %s",
         type, rcl_get_error_string().str);
-    } else if (ret == RCL_RET_UNSUPPORTED) {
+    } else if (RCL_RET_UNSUPPORTED == ret) {
       PyErr_Format(PyExc_NotImplementedError, "Failed to get information by topic for %s: "
         "function not supported by RMW_IMPLEMENTATION", type);
     } else {
@@ -937,7 +937,7 @@ _get_info_by_topic(
   }
   PyObject * py_info_array = rclpy_convert_to_py_topic_endpoint_info_list(&info_array);
   fini_ret = rcl_topic_endpoint_info_array_fini(&info_array, &allocator);
-  if (fini_ret != RCL_RET_OK) {
+  if (RCL_RET_OK != fini_ret) {
     PyErr_Format(RCLError, "rcl_topic_endpoint_info_array_fini failed.");
     rcl_reset_error();
     return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -31,7 +31,7 @@
 #include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 #include <rmw/serialized_message.h>
-#include <rmw/topic_info_array.h>
+#include <rmw/topic_endpoint_info_array.h>
 #include <rmw/types.h>
 #include <rmw/validate_full_topic_name.h>
 #include <rmw/validate_namespace.h>
@@ -891,7 +891,7 @@ typedef rcl_ret_t (* rcl_get_info_by_topic_func_t)(
   rcutils_allocator_t * allocator,
   const char * topic_name,
   bool no_mangle,
-  rmw_topic_info_array_t * info_array);
+  rmw_topic_endpoint_info_array_t * info_array);
 
 static PyObject *
 _get_info_by_topic(
@@ -911,7 +911,7 @@ _get_info_by_topic(
     return NULL;
   }
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  rmw_topic_info_array_t info_array = rmw_get_zero_initialized_topic_info_array();
+  rmw_topic_endpoint_info_array_t info_array = rmw_get_zero_initialized_topic_endpoint_info_array();
   rcl_ret_t ret = rcl_get_info_by_topic(node, &allocator, topic_name, no_mangle, &info_array);
   rmw_ret_t fini_ret;
   if (ret != RCL_RET_OK) {
@@ -926,18 +926,18 @@ _get_info_by_topic(
         type, rcl_get_error_string().str);
     }
     rcl_reset_error();
-    fini_ret = rmw_topic_info_array_fini(&info_array, &allocator);
+    fini_ret = rmw_topic_endpoint_info_array_fini(&info_array, &allocator);
     if (fini_ret != RMW_RET_OK) {
-      PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed: %s",
+      PyErr_Format(PyExc_RuntimeError, "rmw_topic_endpoint_info_array_fini failed: %s",
         rmw_get_error_string().str);
       rmw_reset_error();
     }
     return NULL;
   }
-  PyObject * py_info_array = rclpy_convert_to_py_topic_info_list(&info_array);
-  fini_ret = rmw_topic_info_array_fini(&info_array, &allocator);
+  PyObject * py_info_array = rclpy_convert_to_py_topic_endpoint_info_list(&info_array);
+  fini_ret = rmw_topic_endpoint_info_array_fini(&info_array, &allocator);
   if (fini_ret != RMW_RET_OK) {
-    PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed.");
+    PyErr_Format(PyExc_RuntimeError, "rmw_topic_endpoint_info_array_fini failed.");
     rmw_reset_error();
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -31,6 +31,7 @@
 #include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 #include <rmw/serialized_message.h>
+#include <rmw/topic_info_array.h>
 #include <rmw/types.h>
 #include <rmw/validate_full_topic_name.h>
 #include <rmw/validate_namespace.h>
@@ -884,6 +885,96 @@ rclpy_count_subscribers(PyObject * Py_UNUSED(self), PyObject * args)
 {
   return _count_subscribers_publishers(args, "subscribers", rcl_count_subscribers);
 }
+
+typedef rcl_ret_t (* rcl_get_info_by_topic_func)(
+  const rcl_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * info_array);
+
+static PyObject *
+_get_info_by_topic(
+  PyObject * args, const char * type,
+  rcl_get_info_by_topic_func rcl_get_info_by_topic)
+{
+  PyObject * pynode;
+  const char * topic_name;
+  PyObject * pyno_mangle;
+
+  if (!PyArg_ParseTuple(args, "OsO", &pynode, &topic_name, &pyno_mangle)) {
+    return NULL;
+  }
+
+  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, "rcl_node_t");
+  if (!node) {
+    return NULL;
+  }
+  bool no_mangle = PyObject_IsTrue(pyno_mangle);
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rmw_topic_info_array_t info_array = rmw_get_zero_initialized_topic_info_array();
+  rcl_ret_t ret = rcl_get_info_by_topic(node, &allocator, topic_name, no_mangle, &info_array);
+  rmw_ret_t fini_ret;
+  if (ret != RCL_RET_OK) {
+    if (ret == RCL_RET_BAD_ALLOC) {
+      PyErr_Format(PyExc_MemoryError, "Failed to get information by topic for %s: %s",
+        type, rcl_get_error_string().str);
+    } else {
+      PyErr_Format(PyExc_RuntimeError, "Failed to get information by topic for %s: %s",
+        type, rcl_get_error_string().str);
+    }
+    rcl_reset_error();
+    fini_ret = rmw_topic_info_array_fini(&allocator, &info_array);
+    if (fini_ret != RMW_RET_OK) {
+      PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed.");
+      rmw_reset_error();
+    }
+    return NULL;
+  }
+  PyObject * py_info_array = rclpy_convert_to_py_topic_info_list(&info_array);
+  fini_ret = rmw_topic_info_array_fini(&allocator, &info_array);
+  if (fini_ret != RMW_RET_OK) {
+    PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed.");
+    rmw_reset_error();
+    return NULL;
+  }
+  return py_info_array;
+}
+
+/// Returns a list of publishers, publishing to a topic
+/// The returned publisher information includes node name, node namespace,
+/// topic type, gid and qos profile
+/**
+ *
+ * \param[in] pynode Capsule pointing to the node to get the namespace from.
+ * \param[in] topic_name the topic name to get the publishers for.
+ * \param[in] no_mangle if true the given topic name will be
+ *            expanded to its fully qualified name.
+ * \return list of publishers
+ */
+static PyObject *
+rclpy_get_publishers_info_by_topic(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  return _get_info_by_topic(args, "publishers", rcl_get_publishers_info_by_topic);
+}
+
+/// Returns a list of subscriptions to a topic
+/// The returned subscription information includes node name, node namespace,
+/// topic type, gid and qos profile
+/**
+ *
+ * \param[in] pynode Capsule pointing to the node to get the namespace from.
+ * \param[in] topic_name the topic name to get the subscriptions for.
+ * \param[in] no_mangle if true the given topic name will be
+ *            expanded to its fully qualified name.
+ * \return list of subscriptions.
+ */
+static PyObject *
+rclpy_get_subscriptions_info_by_topic(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  return _get_info_by_topic(args, "subscriptions", rcl_get_subscriptions_info_by_topic);
+}
+
 
 /// Validate a topic name and return error message and index of invalidation.
 /**
@@ -4876,6 +4967,14 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_count_subscribers", rclpy_count_subscribers, METH_VARARGS,
     "Count subscribers for a topic."
+  },
+  {
+    "rclpy_get_publishers_info_by_topic", rclpy_get_publishers_info_by_topic, METH_VARARGS,
+    "Get a list of publishers for a topic."
+  },
+  {
+    "rclpy_get_subscriptions_info_by_topic", rclpy_get_subscriptions_info_by_topic, METH_VARARGS,
+    "Get a list of subscriptions for a topic."
   },
   {
     "rclpy_expand_topic_name", rclpy_expand_topic_name, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -951,8 +951,8 @@ _get_info_by_topic(
  *
  * \param[in] pynode Capsule pointing to the node to get the namespace from.
  * \param[in] topic_name the topic name to get the publishers for.
- * \param[in] no_mangle if true the given topic name will be
- *            expanded to its fully qualified name.
+ * \param[in] no_mangle if `true`, `topic_name` needs to be a valid middleware topic name,
+ *            otherwise it should be a valid ROS topic name.
  * \return list of publishers
  */
 static PyObject *
@@ -968,8 +968,8 @@ rclpy_get_publishers_info_by_topic(PyObject * Py_UNUSED(self), PyObject * args)
  *
  * \param[in] pynode Capsule pointing to the node to get the namespace from.
  * \param[in] topic_name the topic name to get the subscriptions for.
- * \param[in] no_mangle if true the given topic name will be
- *            expanded to its fully qualified name.
+ * \param[in] no_mangle if `true`, `topic_name` needs to be a valid middleware topic name,
+ *            otherwise it should be a valid ROS topic name.
  * \return list of subscriptions.
  */
 static PyObject *

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -927,7 +927,7 @@ _get_info_by_topic(
         type, rcl_get_error_string().str);
     }
     rcl_reset_error();
-    fini_ret = rmw_topic_info_array_fini(&allocator, &info_array);
+    fini_ret = rmw_topic_info_array_fini(&info_array, &allocator);
     if (fini_ret != RMW_RET_OK) {
       PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed: %s",
         rmw_get_error_string().str);
@@ -936,7 +936,7 @@ _get_info_by_topic(
     return NULL;
   }
   PyObject * py_info_array = rclpy_convert_to_py_topic_info_list(&info_array);
-  fini_ret = rmw_topic_info_array_fini(&allocator, &info_array);
+  fini_ret = rmw_topic_info_array_fini(&info_array, &allocator);
   if (fini_ret != RMW_RET_OK) {
     PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed.");
     rmw_reset_error();

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1074,7 +1074,7 @@ rclpy_get_validation_error_for_full_topic_name(PyObject * Py_UNUSED(self), PyObj
   int validation_result;
   size_t invalid_index;
   rmw_ret_t ret = rmw_validate_full_topic_name(topic_name, &validation_result, &invalid_index);
-  if (ret != RCL_RET_OK) {
+  if (ret != RMW_RET_OK) {
     if (ret == RMW_RET_BAD_ALLOC) {
       PyErr_Format(PyExc_MemoryError, "%s", rmw_get_error_string().str);
     } else {
@@ -1137,7 +1137,7 @@ rclpy_get_validation_error_for_namespace(PyObject * Py_UNUSED(self), PyObject * 
   int validation_result;
   size_t invalid_index;
   rmw_ret_t ret = rmw_validate_namespace(namespace_, &validation_result, &invalid_index);
-  if (ret != RCL_RET_OK) {
+  if (ret != RMW_RET_OK) {
     if (ret == RMW_RET_BAD_ALLOC) {
       PyErr_Format(PyExc_MemoryError, "%s", rmw_get_error_string().str);
     } else {
@@ -1200,7 +1200,7 @@ rclpy_get_validation_error_for_node_name(PyObject * Py_UNUSED(self), PyObject * 
   int validation_result;
   size_t invalid_index;
   rmw_ret_t ret = rmw_validate_node_name(node_name, &validation_result, &invalid_index);
-  if (ret != RCL_RET_OK) {
+  if (ret != RMW_RET_OK) {
     if (ret == RMW_RET_BAD_ALLOC) {
       PyErr_Format(PyExc_MemoryError, "%s", rmw_get_error_string().str);
     } else {
@@ -1554,7 +1554,7 @@ rclpy_publisher_get_subscription_count(PyObject * Py_UNUSED(self), PyObject * ar
 
   size_t count = 0;
   rmw_ret_t ret = rcl_publisher_get_subscription_count(&pub->publisher, &count);
-  if (RCL_RET_OK != ret) {
+  if (RMW_RET_OK != ret) {
     PyErr_Format(RCLError, "%s", rmw_get_error_string().str);
     rmw_reset_error();
     return NULL;
@@ -2921,7 +2921,7 @@ rclpy_take_raw(rcl_subscription_t * subscription)
       "Failed to initialize message: %s", rcl_get_error_string().str);
     rcl_reset_error();
     rmw_ret_t r_fini = rmw_serialized_message_fini(&msg);
-    if (r_fini != RCL_RET_OK) {
+    if (r_fini != RMW_RET_OK) {
       PyErr_Format(RCLError, "Failed to deallocate message buffer: %d", r_fini);
     }
     return NULL;
@@ -2934,14 +2934,14 @@ rclpy_take_raw(rcl_subscription_t * subscription)
       "Failed to take_serialized from a subscription: %s", rcl_get_error_string().str);
     rcl_reset_error();
     rmw_ret_t r_fini = rmw_serialized_message_fini(&msg);
-    if (r_fini != RCL_RET_OK) {
+    if (r_fini != RMW_RET_OK) {
       PyErr_Format(RCLError, "Failed to deallocate message buffer: %d", r_fini);
     }
     return NULL;
   }
   PyObject * python_bytes = PyBytes_FromStringAndSize((char *)(msg.buffer), msg.buffer_length);
   rmw_ret_t r_fini = rmw_serialized_message_fini(&msg);
-  if (r_fini != RCL_RET_OK) {
+  if (r_fini != RMW_RET_OK) {
     PyErr_Format(RCLError, "Failed to deallocate message buffer: %d", r_fini);
     if (python_bytes) {
       Py_DECREF(python_bytes);
@@ -4875,7 +4875,7 @@ rclpy_serialize(PyObject * Py_UNUSED(self), PyObject * args)
   // Serialize
   rmw_ret_t rmw_ret = rmw_serialize(ros_msg, ts, &serialized_msg);
   destroy_ros_message(ros_msg);
-  if (RCL_RET_OK != rmw_ret) {
+  if (RMW_RET_OK != rmw_ret) {
     PyErr_Format(RCLError, "Failed to serialize ROS message");
     rcutils_ret = rmw_serialized_message_fini(&serialized_msg);
     if (RCUTILS_RET_OK != rcutils_ret) {
@@ -4923,7 +4923,7 @@ rclpy_deserialize(PyObject * Py_UNUSED(self), PyObject * args)
   // Deserialize
   rmw_ret_t rmw_ret = rmw_deserialize(&serialized_msg, ts, deserialized_ros_msg);
 
-  if (RCL_RET_OK != rmw_ret) {
+  if (RMW_RET_OK != rmw_ret) {
     destroy_ros_message(deserialized_ros_msg);
     PyErr_Format(RCLError, "Failed to deserialize ROS message");
     return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -921,7 +921,7 @@ _get_info_by_topic(
         type, rcl_get_error_string().str);
     } else if (ret == RCL_RET_UNSUPPORTED) {
       PyErr_Format(PyExc_NotImplementedError, "Failed to get information by topic for %s: "
-                                       "function not supported by RMW_IMPLEMENTATION", type);
+        "function not supported by RMW_IMPLEMENTATION", type);
     } else {
       PyErr_Format(PyExc_RuntimeError, "Failed to get information by topic for %s: %s",
         type, rcl_get_error_string().str);
@@ -929,7 +929,8 @@ _get_info_by_topic(
     rcl_reset_error();
     fini_ret = rmw_topic_info_array_fini(&allocator, &info_array);
     if (fini_ret != RMW_RET_OK) {
-      PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed: %s", rmw_get_error_string().str);
+      PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed: %s",
+        rmw_get_error_string().str);
       rmw_reset_error();
     }
     return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1553,8 +1553,8 @@ rclpy_publisher_get_subscription_count(PyObject * Py_UNUSED(self), PyObject * ar
   }
 
   size_t count = 0;
-  rmw_ret_t ret = rcl_publisher_get_subscription_count(&pub->publisher, &count);
-  if (RMW_RET_OK != ret) {
+  rcl_ret_t ret = rcl_publisher_get_subscription_count(&pub->publisher, &count);
+  if (RCL_RET_OK != ret) {
     PyErr_Format(RCLError, "%s", rmw_get_error_string().str);
     rmw_reset_error();
     return NULL;
@@ -3852,6 +3852,8 @@ rclpy_get_rmw_qos_profile(PyObject * Py_UNUSED(self), PyObject * args)
     pyqos_profile = rclpy_common_convert_to_qos_dict(&rmw_qos_profile_system_default);
   } else if (0 == strcmp(pyrmw_profile, "qos_profile_services_default")) {
     pyqos_profile = rclpy_common_convert_to_qos_dict(&rmw_qos_profile_services_default);
+  } else if (0 == strcmp(pyrmw_profile, "qos_profile_unknown")) {
+    pyqos_profile = rclpy_common_convert_to_qos_dict(&rmw_qos_profile_unknown);
   } else if (0 == strcmp(pyrmw_profile, "qos_profile_parameters")) {
     pyqos_profile = rclpy_common_convert_to_qos_dict(&rmw_qos_profile_parameters);
   } else if (0 == strcmp(pyrmw_profile, "qos_profile_parameter_events")) {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -922,13 +922,13 @@ _get_info_by_topic(
       PyErr_Format(PyExc_NotImplementedError, "Failed to get information by topic for %s: "
         "function not supported by RMW_IMPLEMENTATION", type);
     } else {
-      PyErr_Format(PyExc_RuntimeError, "Failed to get information by topic for %s: %s",
+      PyErr_Format(RCLError, "Failed to get information by topic for %s: %s",
         type, rcl_get_error_string().str);
     }
     rcl_reset_error();
     fini_ret = rmw_topic_endpoint_info_array_fini(&info_array, &allocator);
     if (fini_ret != RMW_RET_OK) {
-      PyErr_Format(PyExc_RuntimeError, "rmw_topic_endpoint_info_array_fini failed: %s",
+      PyErr_Format(RCLError, "rmw_topic_endpoint_info_array_fini failed: %s",
         rmw_get_error_string().str);
       rmw_reset_error();
     }
@@ -937,7 +937,7 @@ _get_info_by_topic(
   PyObject * py_info_array = rclpy_convert_to_py_topic_endpoint_info_list(&info_array);
   fini_ret = rmw_topic_endpoint_info_array_fini(&info_array, &allocator);
   if (fini_ret != RMW_RET_OK) {
-    PyErr_Format(PyExc_RuntimeError, "rmw_topic_endpoint_info_array_fini failed.");
+    PyErr_Format(RCLError, "rmw_topic_endpoint_info_array_fini failed.");
     rmw_reset_error();
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -919,6 +919,9 @@ _get_info_by_topic(
     if (ret == RCL_RET_BAD_ALLOC) {
       PyErr_Format(PyExc_MemoryError, "Failed to get information by topic for %s: %s",
         type, rcl_get_error_string().str);
+    } else if (ret == RCL_RET_UNSUPPORTED) {
+      PyErr_Format(PyExc_NotImplementedError, "Failed to get information by topic for %s: "
+                                       "function not supported by RMW_IMPLEMENTATION", type);
     } else {
       PyErr_Format(PyExc_RuntimeError, "Failed to get information by topic for %s: %s",
         type, rcl_get_error_string().str);
@@ -926,7 +929,7 @@ _get_info_by_topic(
     rcl_reset_error();
     fini_ret = rmw_topic_info_array_fini(&allocator, &info_array);
     if (fini_ret != RMW_RET_OK) {
-      PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed.");
+      PyErr_Format(PyExc_RuntimeError, "rmw_topic_info_array_fini failed: %s", rmw_get_error_string().str);
       rmw_reset_error();
     }
     return NULL;

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -886,7 +886,7 @@ rclpy_count_subscribers(PyObject * Py_UNUSED(self), PyObject * args)
   return _count_subscribers_publishers(args, "subscribers", rcl_count_subscribers);
 }
 
-typedef rcl_ret_t (* rcl_get_info_by_topic_func)(
+typedef rcl_ret_t (* rcl_get_info_by_topic_func_t)(
   const rcl_node_t * node,
   rcutils_allocator_t * allocator,
   const char * topic_name,
@@ -896,13 +896,13 @@ typedef rcl_ret_t (* rcl_get_info_by_topic_func)(
 static PyObject *
 _get_info_by_topic(
   PyObject * args, const char * type,
-  rcl_get_info_by_topic_func rcl_get_info_by_topic)
+  rcl_get_info_by_topic_func_t rcl_get_info_by_topic)
 {
   PyObject * pynode;
   const char * topic_name;
-  PyObject * pyno_mangle;
+  int no_mangle;
 
-  if (!PyArg_ParseTuple(args, "OsO", &pynode, &topic_name, &pyno_mangle)) {
+  if (!PyArg_ParseTuple(args, "Osp", &pynode, &topic_name, &no_mangle)) {
     return NULL;
   }
 
@@ -910,7 +910,6 @@ _get_info_by_topic(
   if (!node) {
     return NULL;
   }
-  bool no_mangle = PyObject_IsTrue(pyno_mangle);
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rmw_topic_info_array_t info_array = rmw_get_zero_initialized_topic_info_array();
   rcl_ret_t ret = rcl_get_info_by_topic(node, &allocator, topic_name, no_mangle, &info_array);
@@ -4974,11 +4973,11 @@ static PyMethodDef rclpy_methods[] = {
   },
   {
     "rclpy_get_publishers_info_by_topic", rclpy_get_publishers_info_by_topic, METH_VARARGS,
-    "Get a list of publishers for a topic."
+    "Get publishers info for a topic."
   },
   {
     "rclpy_get_subscriptions_info_by_topic", rclpy_get_subscriptions_info_by_topic, METH_VARARGS,
-    "Get a list of subscriptions for a topic."
+    "Get subscriptions info for a topic."
   },
   {
     "rclpy_expand_topic_name", rclpy_expand_topic_name, METH_VARARGS,

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -132,13 +132,13 @@ RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_convert_to_py(void * message, PyObject * pyclass);
 
-/// Convert a C rmw_topic_info_array_t into a Python list.
+/// Convert a C rmw_topic_endpoint_info_array_t into a Python list.
 /**
- * \param[in] info_array a pointer to a rmw_topic_info_array_t
+ * \param[in] info_array a pointer to a rmw_topic_endpoint_info_array_t
  * \return Python list
  */
 RCLPY_COMMON_PUBLIC
 PyObject *
-rclpy_convert_to_py_topic_info_list(const rmw_topic_info_array_t * info_array);
+rclpy_convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array_t * info_array);
 
 #endif  // RCLPY_COMMON__COMMON_H_

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -132,4 +132,13 @@ RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_convert_to_py(void * message, PyObject * pyclass);
 
+/// Convert a C rmw_topic_info_array_t into a Python list.
+/**
+ * \param[in] info_array a pointer to a rmw_topic_info_array_t
+ * \return Python list
+ */
+RCLPY_COMMON_PUBLIC
+PyObject *
+rclpy_convert_to_py_topic_info_list(const rmw_topic_info_array_t * info_array);
+
 #endif  // RCLPY_COMMON__COMMON_H_

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -391,7 +391,7 @@ _rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic
   if (!py_endpoint_gid) {
     goto fail;
   }
-  for (uint i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
+  for (int i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
     PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_gid[i]);
     if (!py_val_at_index) {
       goto fail;

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -367,7 +367,7 @@ _rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic
   PyObject * py_node_namespace = NULL;
   PyObject * py_topic_type = NULL;
   PyObject * py_gid = NULL;
-  PyObject * py_topic_endpoint_info_dict = NULL;
+  PyObject * py_endpoint_info_dict = NULL;
 
   py_qos_profile = rclpy_common_convert_to_qos_dict(&topic_endpoint_info->qos_profile);
   if (!py_qos_profile) {
@@ -398,29 +398,29 @@ _rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic
   }
 
   // Create dictionary that represents rmw_topic_endpoint_info_t
-  py_topic_endpoint_info_dict = PyDict_New();
-  if (!py_topic_endpoint_info_dict) {
+  py_endpoint_info_dict = PyDict_New();
+  if (!py_endpoint_info_dict) {
     goto fail;
   }
   // Populate keyword arguments
   // A success returns 0, and a failure returns -1
   int set_result = 0;
-  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "qos_profile", py_qos_profile);
-  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "node_name", py_node_name);
-  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "node_namespace", py_node_namespace);
-  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "topic_type", py_topic_type);
-  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "gid", py_gid);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "qos_profile", py_qos_profile);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "node_name", py_node_name);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "node_namespace", py_node_namespace);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "topic_type", py_topic_type);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "gid", py_gid);
   if (set_result != 0) {
     goto fail;
   }
-  return py_topic_endpoint_info_dict;
+  return py_endpoint_info_dict;
 fail:
   Py_XDECREF(py_qos_profile);
   Py_XDECREF(py_node_name);
   Py_XDECREF(py_node_namespace);
   Py_XDECREF(py_topic_type);
   Py_XDECREF(py_gid);
-  Py_XDECREF(py_topic_endpoint_info_dict);
+  Py_XDECREF(py_endpoint_info_dict);
   return NULL;
 }
 
@@ -438,13 +438,14 @@ rclpy_convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array
 
   for (size_t i = 0; i < info_array->count; ++i) {
     rmw_topic_endpoint_info_t topic_endpoint_info = info_array->info_array[i];
-    PyObject * py_topic_endpoint_info_dict = _rclpy_convert_to_py_topic_endpoint_info(&topic_endpoint_info);
-    if (!py_topic_endpoint_info_dict) {
+    PyObject * py_endpoint_info_dict = _rclpy_convert_to_py_topic_endpoint_info(
+      &topic_endpoint_info);
+    if (!py_endpoint_info_dict) {
       Py_DECREF(py_info_array);
       return NULL;
     }
     // add this dict to the list
-    PyList_SET_ITEM(py_info_array, i, py_topic_endpoint_info_dict);
+    PyList_SET_ITEM(py_info_array, i, py_endpoint_info_dict);
   }
   return py_info_array;
 }

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -390,7 +390,7 @@ _rclpy_convert_to_py_topic_info(const rmw_topic_info_t * topic_info)
     goto fail;
   }
   for (uint i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
-    PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_info->gid[i]);
+    PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_info->endpoint_gid[i]);
     if (!py_val_at_index) {
       goto fail;
     }

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -360,28 +360,28 @@ rclpy_convert_to_py(void * message, PyObject * pyclass)
 }
 
 PyObject *
-_rclpy_convert_to_py_topic_info(const rmw_topic_info_t * topic_info)
+_rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic_endpoint_info)
 {
   PyObject * py_qos_profile = NULL;
   PyObject * py_node_name = NULL;
   PyObject * py_node_namespace = NULL;
   PyObject * py_topic_type = NULL;
   PyObject * py_gid = NULL;
-  PyObject * py_topic_info_dict = NULL;
+  PyObject * py_topic_endpoint_info_dict = NULL;
 
-  py_qos_profile = rclpy_common_convert_to_qos_dict(&topic_info->qos_profile);
+  py_qos_profile = rclpy_common_convert_to_qos_dict(&topic_endpoint_info->qos_profile);
   if (!py_qos_profile) {
     goto fail;
   }
-  py_node_name = PyUnicode_FromString(topic_info->node_name);
+  py_node_name = PyUnicode_FromString(topic_endpoint_info->node_name);
   if (!py_node_name) {
     goto fail;
   }
-  py_node_namespace = PyUnicode_FromString(topic_info->node_namespace);
+  py_node_namespace = PyUnicode_FromString(topic_endpoint_info->node_namespace);
   if (!py_node_namespace) {
     goto fail;
   }
-  py_topic_type = PyUnicode_FromString(topic_info->topic_type);
+  py_topic_type = PyUnicode_FromString(topic_endpoint_info->topic_type);
   if (!py_topic_type) {
     goto fail;
   }
@@ -390,42 +390,42 @@ _rclpy_convert_to_py_topic_info(const rmw_topic_info_t * topic_info)
     goto fail;
   }
   for (uint i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
-    PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_info->endpoint_gid[i]);
+    PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_gid[i]);
     if (!py_val_at_index) {
       goto fail;
     }
     PyList_SET_ITEM(py_gid, i, py_val_at_index);
   }
 
-  // Create dictionary that represents rmw_topic_info_t
-  py_topic_info_dict = PyDict_New();
-  if (!py_topic_info_dict) {
+  // Create dictionary that represents rmw_topic_endpoint_info_t
+  py_topic_endpoint_info_dict = PyDict_New();
+  if (!py_topic_endpoint_info_dict) {
     goto fail;
   }
   // Populate keyword arguments
   // A success returns 0, and a failure returns -1
   int set_result = 0;
-  set_result += PyDict_SetItemString(py_topic_info_dict, "qos_profile", py_qos_profile);
-  set_result += PyDict_SetItemString(py_topic_info_dict, "node_name", py_node_name);
-  set_result += PyDict_SetItemString(py_topic_info_dict, "node_namespace", py_node_namespace);
-  set_result += PyDict_SetItemString(py_topic_info_dict, "topic_type", py_topic_type);
-  set_result += PyDict_SetItemString(py_topic_info_dict, "gid", py_gid);
+  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "qos_profile", py_qos_profile);
+  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "node_name", py_node_name);
+  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "node_namespace", py_node_namespace);
+  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "topic_type", py_topic_type);
+  set_result += PyDict_SetItemString(py_topic_endpoint_info_dict, "gid", py_gid);
   if (set_result != 0) {
     goto fail;
   }
-  return py_topic_info_dict;
+  return py_topic_endpoint_info_dict;
 fail:
   Py_XDECREF(py_qos_profile);
   Py_XDECREF(py_node_name);
   Py_XDECREF(py_node_namespace);
   Py_XDECREF(py_topic_type);
   Py_XDECREF(py_gid);
-  Py_XDECREF(py_topic_info_dict);
+  Py_XDECREF(py_topic_endpoint_info_dict);
   return NULL;
 }
 
 PyObject *
-rclpy_convert_to_py_topic_info_list(const rmw_topic_info_array_t * info_array)
+rclpy_convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array_t * info_array)
 {
   if (!info_array) {
     return NULL;
@@ -437,14 +437,14 @@ rclpy_convert_to_py_topic_info_list(const rmw_topic_info_array_t * info_array)
   }
 
   for (size_t i = 0; i < info_array->count; ++i) {
-    rmw_topic_info_t topic_info = info_array->info_array[i];
-    PyObject * py_topic_info_dict = _rclpy_convert_to_py_topic_info(&topic_info);
-    if (!py_topic_info_dict) {
+    rmw_topic_endpoint_info_t topic_endpoint_info = info_array->info_array[i];
+    PyObject * py_topic_endpoint_info_dict = _rclpy_convert_to_py_topic_endpoint_info(&topic_endpoint_info);
+    if (!py_topic_endpoint_info_dict) {
       Py_DECREF(py_info_array);
       return NULL;
     }
     // add this dict to the list
-    PyList_SET_ITEM(py_info_array, i, py_topic_info_dict);
+    PyList_SET_ITEM(py_info_array, i, py_topic_endpoint_info_dict);
   }
   return py_info_array;
 }

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -369,29 +369,22 @@ _rclpy_convert_to_py_topic_info(const rmw_topic_info_t * topic_info)
   PyObject * py_gid = NULL;
   PyObject * py_topic_info_dict = NULL;
 
-  const rmw_qos_profile_t qos_profile = topic_info->qos_profile;
-  py_qos_profile = rclpy_common_convert_to_qos_dict(&qos_profile);
+  py_qos_profile = rclpy_common_convert_to_qos_dict(&topic_info->qos_profile);
   if (!py_qos_profile) {
     goto fail;
   }
-  const char * node_name = topic_info->node_name;
-  py_node_name = PyUnicode_FromString(node_name);
+  py_node_name = PyUnicode_FromString(topic_info->node_name);
   if (!py_node_name) {
     goto fail;
   }
-
-  const char * node_namespace = topic_info->node_namespace;
-  py_node_namespace = PyUnicode_FromString(node_namespace);
+  py_node_namespace = PyUnicode_FromString(topic_info->node_namespace);
   if (!py_node_namespace) {
     goto fail;
   }
-
-  const char * topic_type = topic_info->topic_type;
-  py_topic_type = PyUnicode_FromString(topic_type);
+  py_topic_type = PyUnicode_FromString(topic_info->topic_type);
   if (!py_topic_type) {
     goto fail;
   }
-
   py_gid = PyList_New(RMW_GID_STORAGE_SIZE);
   if (!py_gid) {
     goto fail;
@@ -422,12 +415,12 @@ _rclpy_convert_to_py_topic_info(const rmw_topic_info_t * topic_info)
   }
   return py_topic_info_dict;
 fail:
-  Py_DECREF(py_qos_profile);
-  Py_DECREF(py_node_name);
-  Py_DECREF(py_node_namespace);
-  Py_DECREF(py_topic_type);
-  Py_DECREF(py_gid);
-  Py_DECREF(py_topic_info_dict);
+  Py_XDECREF(py_qos_profile);
+  Py_XDECREF(py_node_name);
+  Py_XDECREF(py_node_namespace);
+  Py_XDECREF(py_topic_type);
+  Py_XDECREF(py_gid);
+  Py_XDECREF(py_topic_info_dict);
   return NULL;
 }
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -181,18 +181,18 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     def assert_qos_equal(self, qos_profile, qos_dict):
         # Depth and history are skipped because they are not retrieved.
         self.assertEqual(qos_profile.durability, qos_dict['durability'],
-                         'Durability is unequal')
+            'Durability is unequal')
         self.assertEqual(qos_profile.reliability, qos_dict['reliability'],
-                         'Reliability is unequal')
+            'Reliability is unequal')
         self.assertEqual(qos_profile.lifespan, qos_dict['lifespan'],
-                         'lifespan is unequal')
+            'lifespan is unequal')
         self.assertEqual(qos_profile.deadline, qos_dict['deadline'],
-                         'Deadline is unequal')
+            'Deadline is unequal')
         self.assertEqual(qos_profile.liveliness, qos_dict['liveliness'],
-                         'liveliness is unequal')
+            'liveliness is unequal')
         self.assertEqual(qos_profile.liveliness_lease_duration,
-                         qos_dict['liveliness_lease_duration'],
-                         'liveliness_lease_duration is unequal')
+            qos_dict['liveliness_lease_duration'],
+            'liveliness_lease_duration is unequal')
 
     @unittest.skipIf(get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp',
                      'Implementation is not supported')

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -197,7 +197,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     @unittest.skipIf(get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp',
                      'Implementation is not supported')
     def test_get_publishers_subscriptions_info_by_topic(self):
-        topic_name = 'test_topic_info'
+        topic_name = 'test_topic_endpoint_info'
         fq_topic_name = '{namespace}/{name}'.format(namespace=TEST_NAMESPACE, name=topic_name)
         # Lists should be empty
         self.assertFalse(self.node.get_publishers_info_by_topic(fq_topic_name))

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -220,8 +220,8 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # Subscription list should be empty
         self.assertFalse(self.node.get_subscriptions_info_by_topic(fq_topic_name))
         # Verify publisher list has the right data
-        # self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
-        # self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
+        self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
+        self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
         self.assertEqual('test_msgs::msg::dds_::BasicTypes_', publisher_list[0].get('topic_type'))
         actual_qos_profile = publisher_list[0].get('qos_profile')
         self.assert_qos_equal(qos_profile, actual_qos_profile)
@@ -243,8 +243,8 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertEqual(1, len(publisher_list))
         self.assertEqual(1, len(subscription_list))
         # Verify subscription list has the right data
-        # self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
-        # self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
+        self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
+        self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
         self.assertEqual('test_msgs::msg::dds_::BasicTypes_',
                          publisher_list[0].get('topic_type'))
         self.assertEqual('test_msgs::msg::dds_::BasicTypes_',

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -50,17 +50,6 @@ TEST_NAMESPACE = '/my_ns'
 TEST_RESOURCES_DIR = pathlib.Path(__file__).resolve().parent / 'resources' / 'test_node'
 
 
-def are_qos_equal(qos_profile, qos_dict):
-    # Depth and history are skipped because they are not retrieved.
-    return qos_profile.durability == qos_dict['durability'] and \
-           qos_profile.reliability == qos_dict['reliability'] and \
-           qos_profile.deadline == qos_dict['deadline'] and \
-           qos_profile.lifespan == qos_dict['lifespan'] and \
-           qos_profile.liveliness == qos_dict['liveliness'] and \
-           qos_profile.liveliness_lease_duration == \
-           qos_dict['liveliness_lease_duration']
-
-
 class TestNodeAllowUndeclaredParameters(unittest.TestCase):
 
     @classmethod
@@ -188,6 +177,22 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # test that it doesn't raise
         self.node.get_node_names_and_namespaces()
 
+    def assert_qos_equal(self, qos_profile, qos_dict):
+        # Depth and history are skipped because they are not retrieved.
+        self.assertEqual(qos_profile.durability, qos_dict['durability'],
+                         'Durability is unequal')
+        self.assertEqual(qos_profile.reliability, qos_dict['reliability'],
+                         'Reliability is unequal')
+        self.assertEqual(qos_profile.deadline, qos_dict['deadline'],
+                         'Deadline is unequal')
+        self.assertEqual(qos_profile.lifespan, qos_dict['lifespan'],
+                         'lifespan is unequal')
+        self.assertEqual(qos_profile.liveliness, qos_dict['liveliness'],
+                         'liveliness is unequal')
+        self.assertEqual(qos_profile.liveliness_lease_duration,
+                         qos_dict['liveliness_lease_duration'],
+                         'liveliness_lease_duration is unequal')
+
     def test_get_publishers_subscriptions_info_by_topic(self):
         topic_name = 'test_topic_info'
         fq_topic_name = '{namespace}/{name}'.format(namespace=TEST_NAMESPACE, name=topic_name)
@@ -216,7 +221,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
         self.assertEqual('test_msgs::msg::dds_::BasicTypes_', publisher_list[0].get('topic_type'))
         actual_qos_profile = publisher_list[0].get('qos_profile')
-        self.assertTrue(are_qos_equal(qos_profile, actual_qos_profile))
+        self.assert_qos_equal(qos_profile, actual_qos_profile)
 
         # Add a subscription
         qos_profile2 = QoSProfile(
@@ -243,8 +248,8 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
                          subscription_list[0].get('topic_type'))
         publisher_qos_profile = publisher_list[0].get('qos_profile')
         subscription_qos_profile = subscription_list[0].get('qos_profile')
-        self.assertTrue(are_qos_equal(qos_profile, publisher_qos_profile))
-        self.assertTrue(are_qos_equal(qos_profile2, subscription_qos_profile))
+        self.assert_qos_equal(qos_profile, publisher_qos_profile)
+        self.assert_qos_equal(qos_profile2, subscription_qos_profile)
 
         # Error cases
         with self.assertRaisesRegex(TypeError, 'bad argument type for built-in operation'):

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -222,7 +222,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # Verify publisher list has the right data
         self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
         self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
-        self.assertEqual('test_msgs::msg::dds_::BasicTypes_', publisher_list[0].get('topic_type'))
+        self.assertEqual('test_msgs/msg/BasicTypes', publisher_list[0].get('topic_type'))
         actual_qos_profile = publisher_list[0].get('qos_profile')
         self.assert_qos_equal(qos_profile, actual_qos_profile)
 
@@ -245,10 +245,8 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # Verify subscription list has the right data
         self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
         self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
-        self.assertEqual('test_msgs::msg::dds_::BasicTypes_',
-                         publisher_list[0].get('topic_type'))
-        self.assertEqual('test_msgs::msg::dds_::BasicTypes_',
-                         subscription_list[0].get('topic_type'))
+        self.assertEqual('test_msgs/msg/BasicTypes', publisher_list[0].get('topic_type'))
+        self.assertEqual('test_msgs/msg/BasicTypes', subscription_list[0].get('topic_type'))
         publisher_qos_profile = publisher_list[0].get('qos_profile')
         subscription_qos_profile = subscription_list[0].get('qos_profile')
         self.assert_qos_equal(qos_profile, publisher_qos_profile)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -178,20 +178,31 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # test that it doesn't raise
         self.node.get_node_names_and_namespaces()
 
-    def assert_qos_equal(self, qos_profile, qos_dict):
+    def assert_qos_equal(self, expected_qos_profile, actual_qos_profile):
         # Depth and history are skipped because they are not retrieved.
-        self.assertEqual(qos_profile.durability, qos_dict['durability'],
+        self.assertEqual(
+            expected_qos_profile.durability,
+            actual_qos_profile.durability,
             'Durability is unequal')
-        self.assertEqual(qos_profile.reliability, qos_dict['reliability'],
+        self.assertEqual(
+            expected_qos_profile.reliability,
+            actual_qos_profile.reliability,
             'Reliability is unequal')
-        self.assertEqual(qos_profile.lifespan, qos_dict['lifespan'],
+        self.assertEqual(
+            expected_qos_profile.lifespan,
+            actual_qos_profile.lifespan,
             'lifespan is unequal')
-        self.assertEqual(qos_profile.deadline, qos_dict['deadline'],
+        self.assertEqual(
+            expected_qos_profile.deadline,
+            actual_qos_profile.deadline,
             'Deadline is unequal')
-        self.assertEqual(qos_profile.liveliness, qos_dict['liveliness'],
+        self.assertEqual(
+            expected_qos_profile.liveliness,
+            actual_qos_profile.liveliness,
             'liveliness is unequal')
-        self.assertEqual(qos_profile.liveliness_lease_duration,
-            qos_dict['liveliness_lease_duration'],
+        self.assertEqual(
+            expected_qos_profile.liveliness_lease_duration,
+            actual_qos_profile.liveliness_lease_duration,
             'liveliness_lease_duration is unequal')
 
     @unittest.skipIf(get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp',
@@ -220,10 +231,10 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # Subscription list should be empty
         self.assertFalse(self.node.get_subscriptions_info_by_topic(fq_topic_name))
         # Verify publisher list has the right data
-        self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
-        self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
-        self.assertEqual('test_msgs/msg/BasicTypes', publisher_list[0].get('topic_type'))
-        actual_qos_profile = publisher_list[0].get('qos_profile')
+        self.assertEqual(self.node.get_name(), publisher_list[0].node_name)
+        self.assertEqual(self.node.get_namespace(), publisher_list[0].node_namespace)
+        self.assertEqual('test_msgs/msg/BasicTypes', publisher_list[0].topic_type)
+        actual_qos_profile = publisher_list[0].qos_profile
         self.assert_qos_equal(qos_profile, actual_qos_profile)
 
         # Add a subscription
@@ -243,12 +254,12 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertEqual(1, len(publisher_list))
         self.assertEqual(1, len(subscription_list))
         # Verify subscription list has the right data
-        self.assertEqual(self.node.get_name(), publisher_list[0].get('node_name'))
-        self.assertEqual(self.node.get_namespace(), publisher_list[0].get('node_namespace'))
-        self.assertEqual('test_msgs/msg/BasicTypes', publisher_list[0].get('topic_type'))
-        self.assertEqual('test_msgs/msg/BasicTypes', subscription_list[0].get('topic_type'))
-        publisher_qos_profile = publisher_list[0].get('qos_profile')
-        subscription_qos_profile = subscription_list[0].get('qos_profile')
+        self.assertEqual(self.node.get_name(), publisher_list[0].node_name)
+        self.assertEqual(self.node.get_namespace(), publisher_list[0].node_namespace)
+        self.assertEqual('test_msgs/msg/BasicTypes', publisher_list[0].topic_type)
+        self.assertEqual('test_msgs/msg/BasicTypes', subscription_list[0].topic_type)
+        publisher_qos_profile = publisher_list[0].qos_profile
+        subscription_qos_profile = subscription_list[0].qos_profile
         self.assert_qos_equal(qos_profile, publisher_qos_profile)
         self.assert_qos_equal(qos_profile2, subscription_qos_profile)
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -184,10 +184,10 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
                          'Durability is unequal')
         self.assertEqual(qos_profile.reliability, qos_dict['reliability'],
                          'Reliability is unequal')
-        self.assertEqual(qos_profile.deadline, qos_dict['deadline'],
-                         'Deadline is unequal')
         self.assertEqual(qos_profile.lifespan, qos_dict['lifespan'],
                          'lifespan is unequal')
+        self.assertEqual(qos_profile.deadline, qos_dict['deadline'],
+                         'Deadline is unequal')
         self.assertEqual(qos_profile.liveliness, qos_dict['liveliness'],
                          'liveliness is unequal')
         self.assertEqual(qos_profile.liveliness_lease_duration,

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -42,6 +42,7 @@ from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time_source import USE_SIM_TIME_NAME
+from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'
@@ -193,6 +194,8 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
                          qos_dict['liveliness_lease_duration'],
                          'liveliness_lease_duration is unequal')
 
+    @unittest.skipIf(get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp',
+                     'Implementation is not supported')
     def test_get_publishers_subscriptions_info_by_topic(self):
         topic_name = 'test_topic_info'
         fq_topic_name = '{namespace}/{name}'.format(namespace=TEST_NAMESPACE, name=topic_name)

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -105,7 +105,9 @@ class TestQosProfile(unittest.TestCase):
 
     def test_policy_short_names(self):
         # Full test on History to show the mechanism works
-        assert QoSHistoryPolicy.short_keys() == ['system_default', 'keep_last', 'keep_all']
+        assert (
+            QoSHistoryPolicy.short_keys() ==
+            ['system_default', 'keep_last', 'keep_all', 'unknown'])
         assert (
             QoSHistoryPolicy.get_from_short_key('system_default') ==
             QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT.value)

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -1,0 +1,104 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.qos import QoSProfile
+from rclpy.topic_endpoint_info import TopicEndpointInfo, TopicEndpointTypeEnum
+
+
+class TestQosProfile(unittest.TestCase):
+
+    def test_node_name_only_constructor(self):
+        test_node_name = 'test_string'
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.node_name = test_node_name
+
+        info_from_ctor = TopicEndpointInfo(node_name=test_node_name)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_node_name, info_from_ctor.node_name)
+
+    def test_node_namespace_only_constructor(self):
+        test_node_namespace = 'test_string'
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.node_namespace = test_node_namespace
+
+        info_from_ctor = TopicEndpointInfo(node_namespace=test_node_namespace)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_node_namespace, info_from_ctor.node_namespace)
+
+    def test_topic_type_only_constructor(self):
+        test_topic_type = 'test_string'
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.topic_type = test_topic_type
+
+        info_from_ctor = TopicEndpointInfo(topic_type=test_topic_type)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_topic_type, info_from_ctor.topic_type)
+
+    def test_endpoint_type_only_constructor(self):
+        test_endpoint_type = TopicEndpointTypeEnum.SUBSCRIPTION
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.endpoint_type = test_endpoint_type
+
+        info_from_ctor = TopicEndpointInfo(endpoint_type=test_endpoint_type)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_endpoint_type, info_from_ctor.endpoint_type)
+
+    def test_endpoint_gid_only_constructor(self):
+        test_endpoint_gid = [0, 0, 0, 0, 0]
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.endpoint_gid = test_endpoint_gid
+
+        info_from_ctor = TopicEndpointInfo(endpoint_gid=test_endpoint_gid)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_endpoint_gid, info_from_ctor.endpoint_gid)
+
+    def test_qos_profile_only_constructor(self):
+        test_qos_profile = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile('qos_profile_default'))
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.qos_profile = test_qos_profile
+
+        info_from_ctor = TopicEndpointInfo(qos_profile=test_qos_profile)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_qos_profile, info_from_ctor.qos_profile)
+
+    def test_print(self):
+        actual_info_str = str(TopicEndpointInfo())
+        expected_info_str = 'Node name: \n' \
+            'Node namespace: \n' \
+            'Topic type: \n' \
+            'Endpoint type: INVALID\n' \
+            'GID: \n' \
+            'QoS profile:\n' \
+            '  Reliability: RMW_QOS_POLICY_RELIABILITY_UNKNOWN\n' \
+            '  Durability: RMW_QOS_POLICY_DURABILITY_UNKNOWN\n' \
+            '  Lifespan: 0 nanoseconds\n' \
+            '  Deadline: 0 nanoseconds\n' \
+            '  Liveliness: RMW_QOS_POLICY_LIVELINESS_UNKNOWN\n' \
+            '  Liveliness lease duration: 0 nanoseconds'
+        self.assertEqual(expected_info_str, actual_info_str)


### PR DESCRIPTION
**NOTE: DO NOT MERGE until [rmw #186](https://github.com/ros2/rmw/pull/186),  [rmw_implementation #72](https://github.com/ros2/rmw_implementation/pull/72) and [rcl #511](https://github.com/ros2/rcl/pull/511) are merged.**

This PR makes the necessary changes to implement [this](https://github.com/ros2/rmw/issues/151) feature request. The `RCLPY` layer needs to expose functions to the `ros2cli` layer such that `ros2 topic info <topic_name>` can display publisher and subscriptions information for the given `topic_name`.

Summary of changes:
- Added a new helper function in `common.h/c` to convert `rmw_topic_info_array_t` to a Python list of dictionaries.
- Added  `get_publishers_info_by_topic` and `get_subscriptions_info_by_topic` in `node.py`
- Added  `rclpy_get_publishers_info_by_topic` and
`rclpy_get_subscriptions_information_by_topic` in `_rclpy.c`
- Added tests for `node.get_publishers_info_by_topic` and
`node.get_subscriptions_info_by_topic`

Related to issues in aws-roadmap [#85](https://github.com/ros-security/aws-roadmap/issues/85)