### PR TITLE
Get proper parameters with prefixes without dot separator

### DIFF
--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -90,6 +90,9 @@ class ParameterService:
                 names_with_prefixes.append(name)
                 continue
             elif request.prefixes:
+                for prefix in request.prefixes:
+                    if name.startswith(prefix):
+                        response.result.names.append(name)
                 continue
             else:
                 response.result.names.append(name)


### PR DESCRIPTION
For parameters without a "." prefix, the code wasn't working as it should. Connected to https://github.com/ros2/ros2cli/pull/389