### PR TITLE
Expressly destroy a node's objects before the node.

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1461,18 +1461,18 @@ class Node:
         # It will be destroyed with other publishers below.
         self._parameter_event_publisher = None
 
-        for p in self.__publishers:
-            self.destroy_publisher(p) 
-        for s in self.__subscriptions:
-            self.destroy_subscriber(s) 
-        for c in self.__clients:
-            self.destroy_client(c) 
-        for s in self.__services:
-            self.destroy_service(s) 
-        for t in self.__timers:
-            self.destroy_timer(t) 
-        for g in self.__guards:
-            self.destroy_guard(g) 
+        while self.__publishers:
+            self.destroy_publisher(self.__publishers.pop()) 
+        while self.__subscriptions:
+            self.destroy_subscriber(self.__subscriptions.pop()) 
+        while self.__clients:
+            self.destroy_client(self.__clients.pop()) 
+        while self.__services:
+            self.destroy_service(self.__services.pop()) 
+        while self.__timers:
+            self.destroy_timer(self.__timers.pop()) 
+        while self.__guards:
+            self.destroy_guard(self.__guards.pop()) 
         self.handle.destroy()
         self._wake_executor()
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1462,17 +1462,17 @@ class Node:
         self._parameter_event_publisher = None
 
         while self.__publishers:
-            self.destroy_publisher(self.__publishers.pop()) 
+            self.destroy_publisher(self.__publishers.pop())
         while self.__subscriptions:
-            self.destroy_subscriber(self.__subscriptions.pop()) 
+            self.destroy_subscription(self.__subscriptions.pop())
         while self.__clients:
-            self.destroy_client(self.__clients.pop()) 
+            self.destroy_client(self.__clients.pop())
         while self.__services:
-            self.destroy_service(self.__services.pop()) 
+            self.destroy_service(self.__services.pop())
         while self.__timers:
-            self.destroy_timer(self.__timers.pop()) 
+            self.destroy_timer(self.__timers.pop())
         while self.__guards:
-            self.destroy_guard(self.__guards.pop()) 
+            self.destroy_guard(self.__guards.pop())
         self.handle.destroy()
         self._wake_executor()
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1461,18 +1461,20 @@ class Node:
         # It will be destroyed with other publishers below.
         self._parameter_event_publisher = None
 
+        # Destroy dependent items eagerly to work around a possible hang
+        # https://github.com/ros2/build_cop/issues/248
         while self.__publishers:
-            self.destroy_publisher(self.__publishers.pop())
+            self.destroy_publisher(self.__publishers[0])
         while self.__subscriptions:
-            self.destroy_subscription(self.__subscriptions.pop())
+            self.destroy_subscription(self.__subscriptions[0])
         while self.__clients:
-            self.destroy_client(self.__clients.pop())
+            self.destroy_client(self.__clients[0])
         while self.__services:
-            self.destroy_service(self.__services.pop())
+            self.destroy_service(self.__services[0])
         while self.__timers:
-            self.destroy_timer(self.__timers.pop())
+            self.destroy_timer(self.__timers[0])
         while self.__guards:
-            self.destroy_guard_condition(self.__guards.pop())
+            self.destroy_guard_condition(self.__guards[0])
         self.handle.destroy()
         self._wake_executor()
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1461,12 +1461,18 @@ class Node:
         # It will be destroyed with other publishers below.
         self._parameter_event_publisher = None
 
-        self.__publishers.clear()
-        self.__subscriptions.clear()
-        self.__clients.clear()
-        self.__services.clear()
-        self.__timers.clear()
-        self.__guards.clear()
+        for p in self.__publishers:
+            self.destroy_publisher(p) 
+        for s in self.__subscriptions:
+            self.destroy_subscriber(s) 
+        for c in self.__clients:
+            self.destroy_client(c) 
+        for s in self.__services:
+            self.destroy_service(s) 
+        for t in self.__timers:
+            self.destroy_timer(t) 
+        for g in self.__guards:
+            self.destroy_guard(g) 
         self.handle.destroy()
         self._wake_executor()
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1472,7 +1472,7 @@ class Node:
         while self.__timers:
             self.destroy_timer(self.__timers.pop())
         while self.__guards:
-            self.destroy_guard(self.__guards.pop())
+            self.destroy_guard_condition(self.__guards.pop())
         self.handle.destroy()
         self._wake_executor()
 


### PR DESCRIPTION
This seems to reduce hangs during test runs described in
https://github.com/ros2/build_cop/issues/248.
Another few hours of testing will convince me to strengthen that statement.

The handles corresponding to the destroyed objects *should* be getting
destroyed explicitly when self.handle.destroy() is called below. It
seems however that when running with Fast-RTPS it's possible to get into
a state where multiple threads are waiting on futexes and none can move
forward. The rclpy context of this apparent deadlock is while clearing
a node's list of publishers or services (possibly others, although
publishers and services were the only ones observed).

I consider this patch to be a workaround rather than a fix as I'm not particularly proud of how little I understand why the existing destruction handling is insufficient.
I think there may either be a race condition between the rcl/rmw layer
and the rmw implementation layer which is being tripped by the
haphazardness of Python's garbage collector or there is a logical
problem with the handle destruction ordering in rclpy that only
Fast-RTPS is sensitive to. A further possibility is to play around with pausing the garbage collector and triggering it at explicit points to see if that changes results at all.