### PR TITLE
Support for ON_REQUESTED_INCOMPATIBLE_QOS and ON_OFFERED_INCOMPATIBLE_QOS events

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -27,6 +27,7 @@ class QoSPolicyKind(IntEnum):
     This enum matches the one defined in rmw/incompatible_qos_events_statuses.h
     """
 
+    # TODO(mm3188): obtain these enum values from the rmw layer, instead of hardcoding
     INVALID = 1 << 0
     DURABILITY = 1 << 1
     DEADLINE = 1 << 2

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -27,29 +27,28 @@ class QoSPolicyKind(IntEnum):
     This enum matches the one defined in rmw/incompatible_qos_events_statuses.h
     """
 
-    RMW_QOS_POLICY_INVALID = 1 << 0
-    RMW_QOS_POLICY_DURABILITY = 1 << 1
-    RMW_QOS_POLICY_DEADLINE = 1 << 2
-    RMW_QOS_POLICY_LIVELINESS = 1 << 3
-    RMW_QOS_POLICY_RELIABILITY = 1 << 4
-    RMW_QOS_POLICY_HISTORY = 1 << 5
-    RMW_QOS_POLICY_LIFESPAN = 1 << 6
+    INVALID = 1 << 0
+    DURABILITY = 1 << 1
+    DEADLINE = 1 << 2
+    LIVELINESS = 1 << 3
+    RELIABILITY = 1 << 4
+    HISTORY = 1 << 5
+    LIFESPAN = 1 << 6
 
 
 def qos_policy_name_from_kind(policy_kind: QoSPolicyKind):
     """Get QoS policy name from QoSPolicyKind enum."""
-
-    if policy_kind == RMW_QOS_POLICY_DURABILITY:
+    if policy_kind == QoSPolicyKind.DURABILITY:
         return 'DURABILITY_QOS_POLICY'
-    elif policy_kind == RMW_QOS_POLICY_DEADLINE:
+    elif policy_kind == QoSPolicyKind.DEADLINE:
         return 'DEADLINE_QOS_POLICY'
-    elif policy_kind == RMW_QOS_POLICY_LIVELINESS:
+    elif policy_kind == QoSPolicyKind.LIVELINESS:
         return 'LIVELINESS_QOS_POLICY'
-    elif policy_kind == RMW_QOS_POLICY_RELIABILITY:
+    elif policy_kind == QoSPolicyKind.RELIABILITY:
         return 'RELIABILITY_QOS_POLICY'
-    elif policy_kind == RMW_QOS_POLICY_HISTORY:
+    elif policy_kind == QoSPolicyKind.HISTORY:
         return 'HISTORY_QOS_POLICY'
-    elif policy_kind == RMW_QOS_POLICY_LIFESPAN:
+    elif policy_kind == QoSPolicyKind.LIFESPAN:
         return 'LIFESPAN_QOS_POLICY'
     else:
         return 'INVALID_QOS_POLICY'

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -20,8 +20,43 @@ from rclpy.impl.implementation_singleton import rclpy_action_implementation as _
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 
+class QoSPolicyKind(IntEnum):
+    """
+    Enum for types of QoS policies that a Publisher or Subscription can set.
+
+    This enum matches the one defined in rmw/incompatible_qos_events_statuses.h
+    """
+
+    RMW_QOS_POLICY_INVALID = 1 << 0
+    RMW_QOS_POLICY_DURABILITY = 1 << 1
+    RMW_QOS_POLICY_DEADLINE = 1 << 2
+    RMW_QOS_POLICY_LIVELINESS = 1 << 3
+    RMW_QOS_POLICY_RELIABILITY = 1 << 4
+    RMW_QOS_POLICY_HISTORY = 1 << 5
+    RMW_QOS_POLICY_LIFESPAN = 1 << 6
+
+
+def qos_policy_name_from_kind(policy_kind: QoSPolicyKind):
+    """Get QoS policy name from QoSPolicyKind enum."""
+
+    if policy_kind == RMW_QOS_POLICY_DURABILITY:
+        return 'DURABILITY_QOS_POLICY'
+    elif policy_kind == RMW_QOS_POLICY_DEADLINE:
+        return 'DEADLINE_QOS_POLICY'
+    elif policy_kind == RMW_QOS_POLICY_LIVELINESS:
+        return 'LIVELINESS_QOS_POLICY'
+    elif policy_kind == RMW_QOS_POLICY_RELIABILITY:
+        return 'RELIABILITY_QOS_POLICY'
+    elif policy_kind == RMW_QOS_POLICY_HISTORY:
+        return 'HISTORY_QOS_POLICY'
+    elif policy_kind == RMW_QOS_POLICY_LIFESPAN:
+        return 'LIFESPAN_QOS_POLICY'
+    else:
+        return 'INVALID_QOS_POLICY'
+
+
 class InvalidQoSProfileException(Exception):
-    """Raised when concstructing a QoSProfile with invalid arguments."""
+    """Raised when constructing a QoSProfile with invalid arguments."""
 
     def __init__(self, *args):
         Exception.__init__(self, 'Invalid QoSProfile', *args)

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -26,6 +26,22 @@ from rclpy.waitable import NumberOfEntities
 from rclpy.waitable import Waitable
 
 
+class QoSPolicyKind(IntEnum):
+    """
+    Enum for types of QoS policies that a Publisher or Subscription can set.
+
+    This enum matches the one defined in rmw/incompatible_qos_events_statuses.h
+    """
+
+    RMW_QOS_POLICY_INVALID = 1 << 0
+    RMW_QOS_POLICY_DURABILITY = 1 << 1
+    RMW_QOS_POLICY_DEADLINE = 1 << 2
+    RMW_QOS_POLICY_LIVELINESS = 1 << 3
+    RMW_QOS_POLICY_RELIABILITY = 1 << 4
+    RMW_QOS_POLICY_HISTORY = 1 << 5
+    RMW_QOS_POLICY_LIFESPAN = 1 << 6
+
+
 class QoSPublisherEventType(IntEnum):
     """
     Enum for types of QoS events that a Publisher can receive.
@@ -83,7 +99,7 @@ QoSRequestedIncompatibleQoSInfo = NamedTuple(
     'QoSRequestedIncompatibleQoSInfo', [
         ('total_count', 'int'),
         ('total_count_change', 'int'),
-        ('last_policy_id', 'int'),
+        ('last_policy_kind', 'int'),
     ])
 
 """
@@ -113,12 +129,7 @@ Payload type for Publisher Incompatible QoS callback.
 
 Mirrors rmw_offered_incompatible_qos_status_t from rmw/types.h
 """
-QoSOfferedIncompatibleQoSInfo = NamedTuple(
-    'QoSOfferedIncompatibleQoSInfo', [
-        ('total_count', 'int'),
-        ('total_count_change', 'int'),
-        ('last_policy_id', 'int'),
-    ])
+QoSOfferedIncompatibleQoSInfo = QoSRequestedIncompatibleQoSInfo
 
 
 class QoSEventHandler(Waitable):

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -116,7 +116,7 @@ Mirrors rmw_offered_incompatible_qos_status_t from rmw/types.h
 QoSOfferedIncompatibleQoSInfo = QoSRequestedIncompatibleQoSInfo
 
 
-class UnsupportedEventTypeException(Exception):
+class UnsupportedEventTypeError(Exception):
     """Raised when registering a callback for an event type that is not supported."""
 
     def __init__(self, *args):

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -35,6 +35,7 @@ class QoSPublisherEventType(IntEnum):
 
     RCL_PUBLISHER_OFFERED_DEADLINE_MISSED = 0
     RCL_PUBLISHER_LIVELINESS_LOST = 1
+    RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS = 2
 
 
 class QoSSubscriptionEventType(IntEnum):
@@ -46,7 +47,7 @@ class QoSSubscriptionEventType(IntEnum):
 
     RCL_SUBSCRIPTION_REQUESTED_DEADLINE_MISSED = 0
     RCL_SUBSCRIPTION_LIVELINESS_CHANGED = 1
-
+    RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS = 2
 
 """
 Payload type for Subscription Deadline callback.
@@ -73,6 +74,17 @@ QoSLivelinessChangedInfo = NamedTuple(
     ])
 
 """
+Payload type for Subscription Incompatible QoS callback.
+
+Mirrors rmw_requested_incompatible_qos_status_t from rmw/types.h
+"""
+QoSRequestedIncompatibleQoSInfo = NamedTuple(
+    'QoSRequestedIncompatibleQoSInfo', [
+        ('total_count', 'int'),
+        ('total_count_change', 'int'),
+    ])
+
+"""
 Payload type for Publisher Deadline callback.
 
 Mirrors rmw_offered_deadline_missed_status_t from rmw/types.h
@@ -90,6 +102,17 @@ Mirrors rmw_liveliness_lost_status_t from rmw/types.h
 """
 QoSLivelinessLostInfo = NamedTuple(
     'QoSLivelinessLostInfo', [
+        ('total_count', 'int'),
+        ('total_count_change', 'int'),
+    ])
+
+"""
+Payload type for Publisher Incompatible QoS callback.
+
+Mirrors rmw_offered_incompatible_qos_status_t from rmw/types.h
+"""
+QoSOfferedIncompatibleQoSInfo = NamedTuple(
+    'QoSOfferedIncompatibleQoSInfo', [
         ('total_count', 'int'),
         ('total_count_change', 'int'),
     ])
@@ -160,6 +183,7 @@ class SubscriptionEventCallbacks:
         *,
         deadline: Optional[Callable[[QoSRequestedDeadlineMissedInfo], None]] = None,
         liveliness: Optional[Callable[[QoSLivelinessChangedInfo], None]] = None,
+        incompatible_qos: Optional[Callable[[QoSRequestedIncompatibleQoSInfo], None]] = None,
     ) -> None:
         """
         Create a SubscriptionEventCallbacks container.
@@ -171,6 +195,7 @@ class SubscriptionEventCallbacks:
         """
         self.deadline = deadline
         self.liveliness = liveliness
+        self.incompatible_qos = incompatible_qos
 
     def create_event_handlers(
         self, callback_group: CallbackGroup, subscription_handle: Handle,
@@ -188,6 +213,12 @@ class SubscriptionEventCallbacks:
                 callback=self.liveliness,
                 event_type=QoSSubscriptionEventType.RCL_SUBSCRIPTION_LIVELINESS_CHANGED,
                 parent_handle=subscription_handle))
+        if self.incompatible_qos:
+            event_handlers.append(QoSEventHandler(
+                callback_group=callback_group,
+                callback=self.incompatible_qos,
+                event_type=QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS,
+                parent_handle=subscription_handle))
         return event_handlers
 
 
@@ -198,7 +229,8 @@ class PublisherEventCallbacks:
         self,
         *,
         deadline: Optional[Callable[[QoSOfferedDeadlineMissedInfo], None]] = None,
-        liveliness: Optional[Callable[[QoSLivelinessLostInfo], None]] = None
+        liveliness: Optional[Callable[[QoSLivelinessLostInfo], None]] = None,
+        incompatible_qos: Optional[Callable[[QoSRequestedIncompatibleQoSInfo], None]] = None
     ) -> None:
         """
         Create and return a PublisherEventCallbacks container.
@@ -210,6 +242,7 @@ class PublisherEventCallbacks:
         """
         self.deadline = deadline
         self.liveliness = liveliness
+        self.incompatible_qos = incompatible_qos
 
     def create_event_handlers(
         self, callback_group: CallbackGroup, publisher_handle: Handle,
@@ -226,5 +259,11 @@ class PublisherEventCallbacks:
                 callback_group=callback_group,
                 callback=self.liveliness,
                 event_type=QoSPublisherEventType.RCL_PUBLISHER_LIVELINESS_LOST,
+                parent_handle=publisher_handle))
+        if self.incompatible_qos:
+            event_handlers.append(QoSEventHandler(
+                callback_group=callback_group,
+                callback=self.incompatible_qos,
+                event_type=QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS,
                 parent_handle=publisher_handle))
         return event_handlers

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -26,22 +26,6 @@ from rclpy.waitable import NumberOfEntities
 from rclpy.waitable import Waitable
 
 
-class QoSPolicyKind(IntEnum):
-    """
-    Enum for types of QoS policies that a Publisher or Subscription can set.
-
-    This enum matches the one defined in rmw/incompatible_qos_events_statuses.h
-    """
-
-    RMW_QOS_POLICY_INVALID = 1 << 0
-    RMW_QOS_POLICY_DURABILITY = 1 << 1
-    RMW_QOS_POLICY_DEADLINE = 1 << 2
-    RMW_QOS_POLICY_LIVELINESS = 1 << 3
-    RMW_QOS_POLICY_RELIABILITY = 1 << 4
-    RMW_QOS_POLICY_HISTORY = 1 << 5
-    RMW_QOS_POLICY_LIFESPAN = 1 << 6
-
-
 class QoSPublisherEventType(IntEnum):
     """
     Enum for types of QoS events that a Publisher can receive.
@@ -130,6 +114,13 @@ Payload type for Publisher Incompatible QoS callback.
 Mirrors rmw_offered_incompatible_qos_status_t from rmw/types.h
 """
 QoSOfferedIncompatibleQoSInfo = QoSRequestedIncompatibleQoSInfo
+
+
+class UnsupportedEventTypeException(Exception):
+    """Raised when registering a callback for an event type that is not supported."""
+
+    def __init__(self, *args):
+        Exception.__init__(self, 'QoS event type is unsupported', *args)
 
 
 class QoSEventHandler(Waitable):

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -116,11 +116,8 @@ Mirrors rmw_offered_incompatible_qos_status_t from rmw/types.h
 QoSOfferedIncompatibleQoSInfo = QoSRequestedIncompatibleQoSInfo
 
 
-class UnsupportedEventTypeError(Exception):
-    """Raised when registering a callback for an event type that is not supported."""
-
-    def __init__(self, *args):
-        Exception.__init__(self, 'QoS event type is unsupported', *args)
+"""Raised when registering a callback for an event type that is not supported."""
+UnsupportedEventTypeError = _rclpy.UnsupportedEventTypeError
 
 
 class QoSEventHandler(Waitable):

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -49,6 +49,7 @@ class QoSSubscriptionEventType(IntEnum):
     RCL_SUBSCRIPTION_LIVELINESS_CHANGED = 1
     RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS = 2
 
+
 """
 Payload type for Subscription Deadline callback.
 

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -82,6 +82,7 @@ QoSRequestedIncompatibleQoSInfo = NamedTuple(
     'QoSRequestedIncompatibleQoSInfo', [
         ('total_count', 'int'),
         ('total_count_change', 'int'),
+        ('last_policy_id', 'int'),
     ])
 
 """
@@ -115,6 +116,7 @@ QoSOfferedIncompatibleQoSInfo = NamedTuple(
     'QoSOfferedIncompatibleQoSInfo', [
         ('total_count', 'int'),
         ('total_count_change', 'int'),
+        ('last_policy_id', 'int'),
     ])
 
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -43,12 +43,13 @@
 
 #include "rclpy_common/common.h"
 #include "rclpy_common/handle.h"
-#include "./_rclpy_qos_event.c"
 
 static PyObject * RCLInvalidROSArgsError;
 static PyObject * UnknownROSArgsError;
 static PyObject * NodeNameNonExistentError;
 static PyObject * RCLError;
+
+#include "./_rclpy_qos_event.c"
 
 void
 _rclpy_context_handle_destructor(void * p)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -44,10 +44,11 @@
 #include "rclpy_common/common.h"
 #include "rclpy_common/handle.h"
 
-static PyObject * RCLInvalidROSArgsError;
-static PyObject * UnknownROSArgsError;
 static PyObject * NodeNameNonExistentError;
 static PyObject * RCLError;
+static PyObject * RCLInvalidROSArgsError;
+static PyObject * UnknownROSArgsError;
+static PyObject * UnsupportedEventTypeError;
 
 #include "./_rclpy_qos_event.c"
 
@@ -5514,6 +5515,15 @@ PyMODINIT_FUNC PyInit__rclpy(void)
     "Thrown when a node name is not found.",
     RCLError, NULL);
   if (PyModule_AddObject(m, "NodeNameNonExistentError", NodeNameNonExistentError)) {
+    Py_DECREF(m);
+    return NULL;
+  }
+
+  UnsupportedEventTypeError = PyErr_NewExceptionWithDoc(
+    "_rclpy.UnsupportedEventTypeError",
+    "Thrown when registering a callback for an event type that is not supported.",
+    RCLError, NULL);
+  if (PyModule_AddObject(m, "UnsupportedEventTypeError", UnsupportedEventTypeError)) {
     Py_DECREF(m);
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_qos_event.c
+++ b/rclpy/src/rclpy/_rclpy_qos_event.c
@@ -19,9 +19,11 @@ typedef union _qos_event_callback_data {
   // Subscription events
   rmw_requested_deadline_missed_status_t requested_deadline_missed;
   rmw_liveliness_changed_status_t liveliness_changed;
+  rmw_requested_incompatible_qos_status_t requested_incompatible_qos;
   // Publisher events
   rmw_offered_deadline_missed_status_t offered_deadline_missed;
   rmw_liveliness_lost_status_t liveliness_lost;
+  rmw_offered_incompatible_qos_status_t offered_incompatible_qos;
 } _qos_event_callback_data_t;
 
 typedef PyObject * (* _qos_event_data_filler_function)(_qos_event_callback_data_t *);
@@ -161,6 +163,21 @@ _liveliness_changed_to_py_object(_qos_event_callback_data_t * data)
 
 static
 PyObject *
+_requested_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
+{
+  rmw_requested_incompatible_qos_status_t * actual_data = &data->requested_incompatible_qos;
+  PyObject * args = Py_BuildValue(
+      "ii",
+      actual_data->total_count,
+      actual_data->total_count_change);
+  if (!args) {
+    return NULL;
+  }
+  return _create_py_qos_event("QoSRequestedIncompatibleQoSInfo", args);
+}
+
+static
+PyObject *
 _offered_deadline_missed_to_py_object(_qos_event_callback_data_t * data)
 {
   rmw_offered_deadline_missed_status_t * actual_data = &data->offered_deadline_missed;
@@ -190,6 +207,21 @@ _liveliness_lost_to_py_object(_qos_event_callback_data_t * data)
 }
 
 static
+PyObject *
+_offered_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
+{
+  rmw_offered_incompatible_qos_status_t * actual_data = &data->offered_incompatible_qos;
+  PyObject * args = Py_BuildValue(
+      "ii",
+      actual_data->total_count,
+      actual_data->total_count_change);
+  if (!args) {
+    return NULL;
+  }
+  return _create_py_qos_event("QoSOfferedIncompatibleQoSInfo", args);
+}
+
+static
 _qos_event_data_filler_function
 _get_qos_event_data_filler_function_for(PyObject * pyparent, unsigned PY_LONG_LONG event_type)
 {
@@ -199,6 +231,8 @@ _get_qos_event_data_filler_function_for(PyObject * pyparent, unsigned PY_LONG_LO
         return &_requested_deadline_missed_to_py_object;
       case RCL_SUBSCRIPTION_LIVELINESS_CHANGED:
         return &_liveliness_changed_to_py_object;
+      case RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS:
+        return &_requested_incompatible_qos_to_py_object;
       default:
         PyErr_Format(
           PyExc_ValueError,
@@ -210,6 +244,8 @@ _get_qos_event_data_filler_function_for(PyObject * pyparent, unsigned PY_LONG_LO
         return &_offered_deadline_missed_to_py_object;
       case RCL_PUBLISHER_LIVELINESS_LOST:
         return &_liveliness_lost_to_py_object;
+      case RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS:
+        return &_offered_incompatible_qos_to_py_object;
       default:
         PyErr_Format(
           PyExc_ValueError,

--- a/rclpy/src/rclpy/_rclpy_qos_event.c
+++ b/rclpy/src/rclpy/_rclpy_qos_event.c
@@ -167,9 +167,10 @@ _requested_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
 {
   rmw_requested_incompatible_qos_status_t * actual_data = &data->requested_incompatible_qos;
   PyObject * args = Py_BuildValue(
-      "ii",
+      "iii",
       actual_data->total_count,
-      actual_data->total_count_change);
+      actual_data->total_count_change,
+      actual_data->last_policy_id);
   if (!args) {
     return NULL;
   }
@@ -212,9 +213,10 @@ _offered_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
 {
   rmw_offered_incompatible_qos_status_t * actual_data = &data->offered_incompatible_qos;
   PyObject * args = Py_BuildValue(
-      "ii",
+      "iii",
       actual_data->total_count,
-      actual_data->total_count_change);
+      actual_data->total_count_change,
+      actual_data->last_policy_id);
   if (!args) {
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_qos_event.c
+++ b/rclpy/src/rclpy/_rclpy_qos_event.c
@@ -167,10 +167,10 @@ _requested_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
 {
   rmw_requested_incompatible_qos_status_t * actual_data = &data->requested_incompatible_qos;
   PyObject * args = Py_BuildValue(
-      "iii",
-      actual_data->total_count,
-      actual_data->total_count_change,
-      actual_data->last_policy_id);
+    "iii",
+    actual_data->total_count,
+    actual_data->total_count_change,
+    actual_data->last_policy_id);
   if (!args) {
     return NULL;
   }
@@ -213,10 +213,10 @@ _offered_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
 {
   rmw_offered_incompatible_qos_status_t * actual_data = &data->offered_incompatible_qos;
   PyObject * args = Py_BuildValue(
-      "iii",
-      actual_data->total_count,
-      actual_data->total_count_change,
-      actual_data->last_policy_id);
+    "iii",
+    actual_data->total_count,
+    actual_data->total_count_change,
+    actual_data->last_policy_id);
   if (!args) {
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_qos_event.c
+++ b/rclpy/src/rclpy/_rclpy_qos_event.c
@@ -37,7 +37,7 @@ _check_rcl_return(rcl_ret_t ret, const char * error_msg)
     return true;
   }
 
-  PyObject * exception = PyExc_RuntimeError;
+  PyObject * exception = RCLError;
   PyObject * pyqos_event_module = NULL;
   PyObject * pyqos_event_exception = NULL;
 
@@ -47,7 +47,8 @@ _check_rcl_return(rcl_ret_t ret, const char * error_msg)
       goto throw_exception;
     }
 
-    PyObject * pyqos_event_exception = PyObject_GetAttrString(pyqos_event_module, "UnsupportedEventTypeException");
+    PyObject * pyqos_event_exception = PyObject_GetAttrString(
+      pyqos_event_module, "UnsupportedEventTypeError");
     if (NULL == pyqos_event_exception) {
       goto throw_exception;
     }

--- a/rclpy/src/rclpy/_rclpy_qos_event.c
+++ b/rclpy/src/rclpy/_rclpy_qos_event.c
@@ -14,16 +14,17 @@
 
 #include "rcl/event.h"
 #include "rclpy_common/handle.h"
+#include "rmw/incompatible_qos_events_statuses.h"
 
 typedef union _qos_event_callback_data {
   // Subscription events
   rmw_requested_deadline_missed_status_t requested_deadline_missed;
   rmw_liveliness_changed_status_t liveliness_changed;
-  rmw_requested_incompatible_qos_status_t requested_incompatible_qos;
+  rmw_requested_qos_incompatible_event_status_t requested_incompatible_qos;
   // Publisher events
   rmw_offered_deadline_missed_status_t offered_deadline_missed;
   rmw_liveliness_lost_status_t liveliness_lost;
-  rmw_offered_incompatible_qos_status_t offered_incompatible_qos;
+  rmw_offered_qos_incompatible_event_status_t offered_incompatible_qos;
 } _qos_event_callback_data_t;
 
 typedef PyObject * (* _qos_event_data_filler_function)(_qos_event_callback_data_t *);
@@ -165,12 +166,12 @@ static
 PyObject *
 _requested_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
 {
-  rmw_requested_incompatible_qos_status_t * actual_data = &data->requested_incompatible_qos;
+  rmw_requested_qos_incompatible_event_status_t * actual_data = &data->requested_incompatible_qos;
   PyObject * args = Py_BuildValue(
     "iii",
     actual_data->total_count,
     actual_data->total_count_change,
-    actual_data->last_policy_id);
+    actual_data->last_policy_kind);
   if (!args) {
     return NULL;
   }
@@ -211,12 +212,12 @@ static
 PyObject *
 _offered_incompatible_qos_to_py_object(_qos_event_callback_data_t * data)
 {
-  rmw_offered_incompatible_qos_status_t * actual_data = &data->offered_incompatible_qos;
+  rmw_offered_qos_incompatible_event_status_t * actual_data = &data->offered_incompatible_qos;
   PyObject * args = Py_BuildValue(
     "iii",
     actual_data->total_count,
     actual_data->total_count_change,
-    actual_data->last_policy_id);
+    actual_data->last_policy_kind);
   if (!args) {
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_qos_event.c
+++ b/rclpy/src/rclpy/_rclpy_qos_event.c
@@ -37,31 +37,9 @@ _check_rcl_return(rcl_ret_t ret, const char * error_msg)
     return true;
   }
 
-  PyObject * exception = RCLError;
-  PyObject * pyqos_event_module = NULL;
-  PyObject * pyqos_event_exception = NULL;
-
-  if (RCL_RET_UNSUPPORTED == ret) {
-    PyObject * pyqos_event_module = PyImport_ImportModule("rclpy.qos_event");
-    if (NULL == pyqos_event_module) {
-      goto throw_exception;
-    }
-
-    PyObject * pyqos_event_exception = PyObject_GetAttrString(
-      pyqos_event_module, "UnsupportedEventTypeError");
-    if (NULL == pyqos_event_exception) {
-      goto throw_exception;
-    }
-
-    exception = pyqos_event_exception;
-  }
-
-throw_exception:
+  PyObject * exception = (RCL_RET_UNSUPPORTED == ret) ? UnsupportedEventTypeError : RCLError;
   PyErr_Format(exception, "%s: %s", error_msg, rcl_get_error_string().str);
   rcl_reset_error();
-
-  Py_XDECREF(pyqos_event_module);
-  Py_XDECREF(pyqos_event_exception);
 
   return false;
 }

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 import rclpy
 from rclpy.handle import Handle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.qos import QoSPolicyKind
 from rclpy.qos_event import PublisherEventCallbacks
 from rclpy.qos_event import QoSLivelinessChangedInfo
 from rclpy.qos_event import QoSLivelinessLostInfo
@@ -28,17 +29,21 @@ from rclpy.qos_event import QoSRequestedDeadlineMissedInfo
 from rclpy.qos_event import QoSRequestedIncompatibleQoSInfo
 from rclpy.qos_event import QoSSubscriptionEventType
 from rclpy.qos_event import SubscriptionEventCallbacks
+from rclpy.qos_event import UnsupportedEventTypeError
+from rclpy.utilities import get_rmw_implementation_identifier
 
 from test_msgs.msg import Empty as EmptyMsg
 
 
 class TestQoSEvent(unittest.TestCase):
+    is_fastrtps = False
 
     @classmethod
     def setUpClass(cls):
         cls.context = rclpy.context.Context()
         rclpy.init(context=cls.context)
         cls.node = rclpy.create_node('TestQoSEvent', namespace='/rclpy/test', context=cls.context)
+        cls.is_fastrtps = 'rmw_fastrtps' in get_rmw_implementation_identifier()
 
     @classmethod
     def tearDownClass(cls):
@@ -78,10 +83,13 @@ class TestQoSEvent(unittest.TestCase):
 
         # Arg with three callbacks
         callbacks.incompatible_qos = incompatible_qos_callback
-        publisher = self.node.create_publisher(
-            EmptyMsg, 'test_topic', 10, event_callbacks=callbacks)
-        self.assertEqual(len(publisher.event_handlers), 3)
-        self.node.destroy_publisher(publisher)
+        try:
+            publisher = self.node.create_publisher(
+                EmptyMsg, 'test_topic', 10, event_callbacks=callbacks)
+            self.assertEqual(len(publisher.event_handlers), 3)
+            self.node.destroy_publisher(publisher)
+        except UnsupportedEventTypeError:
+            self.assertTrue(self.is_fastrtps)
 
     def test_subscription_constructor(self):
         callbacks = SubscriptionEventCallbacks()
@@ -117,10 +125,13 @@ class TestQoSEvent(unittest.TestCase):
 
         # Arg with three callbacks
         callbacks.incompatible_qos = incompatible_qos_callback
-        subscription = self.node.create_subscription(
-            EmptyMsg, 'test_topic', message_callback, 10, event_callbacks=callbacks)
-        self.assertEqual(len(subscription.event_handlers), 3)
-        self.node.destroy_subscription(subscription)
+        try:
+            subscription = self.node.create_subscription(
+                EmptyMsg, 'test_topic', message_callback, 10, event_callbacks=callbacks)
+            self.assertEqual(len(subscription.event_handlers), 3)
+            self.node.destroy_subscription(subscription)
+        except UnsupportedEventTypeError:
+            self.assertTrue(self.is_fastrtps)
 
     def _create_event_handle(self, parent_entity, event_type):
         with parent_entity.handle as parent_capsule:
@@ -138,8 +149,11 @@ class TestQoSEvent(unittest.TestCase):
             publisher, QoSPublisherEventType.RCL_PUBLISHER_OFFERED_DEADLINE_MISSED)
         self._do_create_destroy(
             publisher, QoSPublisherEventType.RCL_PUBLISHER_LIVELINESS_LOST)
-        self._do_create_destroy(
-            publisher, QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS)
+        try:
+            self._do_create_destroy(
+                publisher, QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS)
+        except UnsupportedEventTypeError:
+            self.assertTrue(self.is_fastrtps)
         self.node.destroy_publisher(publisher)
 
     def test_subscription_event_create_destroy(self):
@@ -149,8 +163,11 @@ class TestQoSEvent(unittest.TestCase):
             subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_LIVELINESS_CHANGED)
         self._do_create_destroy(
             subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_DEADLINE_MISSED)
-        self._do_create_destroy(
-            subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS)
+        try:
+            self._do_create_destroy(
+                subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS)
+        except UnsupportedEventTypeError:
+            self.assertTrue(self.is_fastrtps)
         self.node.destroy_subscription(subscription)
 
     def test_call_publisher_rclpy_event_apis(self):
@@ -173,20 +190,24 @@ class TestQoSEvent(unittest.TestCase):
             liveliness_event_index = _rclpy.rclpy_wait_set_add_entity('event', wait_set, capsule)
         self.assertIsNotNone(liveliness_event_index)
 
-        incompatible_qos_event_handle = self._create_event_handle(
-            publisher, QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS)
-        with incompatible_qos_event_handle as capsule:
-            incompatible_qos_event_index = _rclpy.rclpy_wait_set_add_entity(
-                    'event', wait_set, capsule)
-        self.assertIsNotNone(incompatible_qos_event_index)
+        try:
+            incompatible_qos_event_handle = self._create_event_handle(
+                publisher, QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS)
+            with incompatible_qos_event_handle as capsule:
+                incompatible_qos_event_index = _rclpy.rclpy_wait_set_add_entity(
+                        'event', wait_set, capsule)
+            self.assertIsNotNone(incompatible_qos_event_index)
+        except UnsupportedEventTypeError:
+            self.assertTrue(self.is_fastrtps)
 
         # We live in our own namespace and have created no other participants, so
         # there can't be any of these events.
         _rclpy.rclpy_wait(wait_set, 0)
         self.assertFalse(_rclpy.rclpy_wait_set_is_ready('event', wait_set, deadline_event_index))
         self.assertFalse(_rclpy.rclpy_wait_set_is_ready('event', wait_set, liveliness_event_index))
-        self.assertFalse(_rclpy.rclpy_wait_set_is_ready(
-            'event', wait_set, incompatible_qos_event_index))
+        if not self.is_fastrtps:
+            self.assertFalse(_rclpy.rclpy_wait_set_is_ready(
+                'event', wait_set, incompatible_qos_event_index))
 
         # Calling take data even though not ready should provide me an empty initialized message
         # Tests data conversion utilities in C side
@@ -214,19 +235,20 @@ class TestQoSEvent(unittest.TestCase):
         except NotImplementedError:
             pass
 
-        try:
-            with incompatible_qos_event_handle as event_capsule, \
-                    publisher.handle as publisher_capsule:
-                event_data = _rclpy.rclpy_take_event(
-                    event_capsule,
-                    publisher_capsule,
-                    QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS)
-            self.assertIsInstance(event_data, QoSOfferedIncompatibleQoSInfo)
-            self.assertEqual(event_data.total_count, 0)
-            self.assertEqual(event_data.total_count_change, 0)
-            self.assertEqual(event_data.last_policy_id, 0)
-        except NotImplementedError:
-            pass
+        if not self.is_fastrtps:
+            try:
+                with incompatible_qos_event_handle as event_capsule, \
+                        publisher.handle as publisher_capsule:
+                    event_data = _rclpy.rclpy_take_event(
+                        event_capsule,
+                        publisher_capsule,
+                        QoSPublisherEventType.RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS)
+                self.assertIsInstance(event_data, QoSOfferedIncompatibleQoSInfo)
+                self.assertEqual(event_data.total_count, 0)
+                self.assertEqual(event_data.total_count_change, 0)
+                self.assertEqual(event_data.last_policy_kind, QoSPolicyKind.INVALID)
+            except NotImplementedError:
+                pass
 
         self.node.destroy_publisher(publisher)
 
@@ -250,20 +272,24 @@ class TestQoSEvent(unittest.TestCase):
             liveliness_event_index = _rclpy.rclpy_wait_set_add_entity('event', wait_set, capsule)
         self.assertIsNotNone(liveliness_event_index)
 
-        incompatible_qos_event_handle = self._create_event_handle(
-            subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS)
-        with incompatible_qos_event_handle as capsule:
-            incompatible_qos_event_index = _rclpy.rclpy_wait_set_add_entity(
-                    'event', wait_set, capsule)
-        self.assertIsNotNone(incompatible_qos_event_index)
+        try:
+            incompatible_qos_event_handle = self._create_event_handle(
+                subscription, QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS)
+            with incompatible_qos_event_handle as capsule:
+                incompatible_qos_event_index = _rclpy.rclpy_wait_set_add_entity(
+                        'event', wait_set, capsule)
+            self.assertIsNotNone(incompatible_qos_event_index)
+        except UnsupportedEventTypeError:
+            self.assertTrue(self.is_fastrtps)
 
         # We live in our own namespace and have created no other participants, so
         # there can't be any of these events.
         _rclpy.rclpy_wait(wait_set, 0)
         self.assertFalse(_rclpy.rclpy_wait_set_is_ready('event', wait_set, deadline_event_index))
         self.assertFalse(_rclpy.rclpy_wait_set_is_ready('event', wait_set, liveliness_event_index))
-        self.assertFalse(_rclpy.rclpy_wait_set_is_ready(
-            'event', wait_set, incompatible_qos_event_index))
+        if not self.is_fastrtps:
+            self.assertFalse(_rclpy.rclpy_wait_set_is_ready(
+                'event', wait_set, incompatible_qos_event_index))
 
         # Calling take data even though not ready should provide me an empty initialized message
         # Tests data conversion utilities in C side
@@ -293,18 +319,19 @@ class TestQoSEvent(unittest.TestCase):
         except NotImplementedError:
             pass
 
-        try:
-            with incompatible_qos_event_handle as event_capsule, \
-                    subscription.handle as parent_capsule:
-                event_data = _rclpy.rclpy_take_event(
-                    event_capsule,
-                    parent_capsule,
-                    QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS)
-            self.assertIsInstance(event_data, QoSRequestedIncompatibleQoSInfo)
-            self.assertEqual(event_data.total_count, 0)
-            self.assertEqual(event_data.total_count_change, 0)
-            self.assertEqual(event_data.last_policy_id, 0)
-        except NotImplementedError:
-            pass
+        if not self.is_fastrtps:
+            try:
+                with incompatible_qos_event_handle as event_capsule, \
+                        subscription.handle as parent_capsule:
+                    event_data = _rclpy.rclpy_take_event(
+                        event_capsule,
+                        parent_capsule,
+                        QoSSubscriptionEventType.RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS)
+                self.assertIsInstance(event_data, QoSRequestedIncompatibleQoSInfo)
+                self.assertEqual(event_data.total_count, 0)
+                self.assertEqual(event_data.total_count_change, 0)
+                self.assertEqual(event_data.last_policy_kind, QoSPolicyKind.INVALID)
+            except NotImplementedError:
+                pass
 
         self.node.destroy_subscription(subscription)


### PR DESCRIPTION
**_Depends on [ros2/rcl:535](https://github.com/ros2/rcl/pull/535)_**

Related to [this](https://github.com/ros2/ros2/issues/822) feature request. The design and implementation details can also be found there.

- Added `INCOMPATIBLE_QOS` event type to `QoSPublisherEventType` and `QoSSubscriptionEventType`
- Added support for the above events in the `QoSEventHandler`
- modified `test_qos_event.py` to include the new events.

Signed-off-by: Jaison Titus <jaisontj92@gmail.com>