### PR TITLE
Make use of rcutils log severity defined enum instead of duplicating code

### DIFF
--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -26,12 +26,12 @@ class LoggingSeverity(IntEnum):
     This enum must match the one defined in rcutils/logging.h
     """
 
-    UNSET = 0
-    DEBUG = 10
-    INFO = 20
-    WARN = 30
-    ERROR = 40
-    FATAL = 50
+    UNSET = _rclpy_logging.rclpy_get_unset_logging_severity()
+    DEBUG = _rclpy_logging.rclpy_get_debug_logging_severity()
+    INFO = _rclpy_logging.rclpy_get_info_logging_severity()
+    WARN = _rclpy_logging.rclpy_get_warn_logging_severity()
+    ERROR = _rclpy_logging.rclpy_get_error_logging_severity()
+    FATAL = _rclpy_logging.rclpy_get_fatal_logging_severity()
 
 
 _root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -199,6 +199,54 @@ rclpy_logging_severity_level_from_string(PyObject * Py_UNUSED(self), PyObject * 
   return PyLong_FromLongLong(severity);
 }
 
+/// Get log unset severity level as int from rcutils
+/// \return RCUTILS_LOG_SEVERITY_UNSET
+static PyObject *
+rclpy_get_unset_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_UNSET);
+}
+
+/// Get log debug severity level as int from rcutils
+/// \return RCUTILS_LOG_SEVERITY_DEBUG
+static PyObject *
+rclpy_get_debug_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_DEBUG);
+}
+
+/// Get log info severity level as int from rcutils
+/// \return RCUTILS_LOG_SEVERITY_INFO
+static PyObject *
+rclpy_get_info_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_INFO);
+}
+
+/// Get log warn severity level as int from rcutils
+/// \return RCUTILS_LOG_SEVERITY_WARN
+static PyObject *
+rclpy_get_warn_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_WARN);
+}
+
+/// Get log error severity level as int from rcutils
+/// \return RCUTILS_LOG_SEVERITY_ERROR
+static PyObject *
+rclpy_get_error_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_ERROR);
+}
+
+/// Get log fatal severity level as int from rcutils
+/// \return RCUTILS_LOG_SEVERITY_FATAL
+static PyObject *
+rclpy_get_fatal_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_FATAL);
+}
+
 /// Define the public methods of this module
 static PyMethodDef rclpy_logging_methods[] = {
   {
@@ -229,6 +277,30 @@ static PyMethodDef rclpy_logging_methods[] = {
   {
     "rclpy_logging_severity_level_from_string", rclpy_logging_severity_level_from_string,
     METH_VARARGS, "Determine log level from string"
+  },
+  {
+    "rclpy_get_unset_logging_severity", rclpy_get_unset_logging_severity,
+    METH_VARARGS, "Get log unset severity level as int from rcutils"
+  },
+  {
+    "rclpy_get_debug_logging_severity", rclpy_get_debug_logging_severity,
+    METH_VARARGS, "Get log debug severity level as int from rcutils"
+  },
+  {
+    "rclpy_get_info_logging_severity", rclpy_get_info_logging_severity,
+    METH_VARARGS, "Get log info severity level as int from rcutils"
+  },
+  {
+    "rclpy_get_warn_logging_severity", rclpy_get_warn_logging_severity,
+    METH_VARARGS, "Get log warn severity level as int from rcutils"
+  },
+  {
+    "rclpy_get_error_logging_severity", rclpy_get_error_logging_severity,
+    METH_VARARGS, "Get log error severity level as int from rcutils"
+  },
+  {
+    "rclpy_get_fatal_logging_severity", rclpy_get_fatal_logging_severity,
+    METH_VARARGS, "Get log fatal severity level as int from rcutils"
   },
 
   {NULL, NULL, 0, NULL}  /* sentinel */

--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -199,24 +199,24 @@ rclpy_logging_severity_level_from_string(PyObject * Py_UNUSED(self), PyObject * 
   return PyLong_FromLongLong(severity);
 }
 
-/// Get log unset severity level as int from rcutils
-/// \return RCUTILS_LOG_SEVERITY_UNSET
+/// Get log unset severity level as int from rcutils.
+/// \return RCUTILS_LOG_SEVERITY_UNSET as a PyLong.
 static PyObject *
 rclpy_get_unset_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_UNSET);
 }
 
-/// Get log debug severity level as int from rcutils
-/// \return RCUTILS_LOG_SEVERITY_DEBUG
+/// Get log debug severity level as int from rcutils.
+/// \return RCUTILS_LOG_SEVERITY_DEBUG as a PyLong.
 static PyObject *
 rclpy_get_debug_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_DEBUG);
 }
 
-/// Get log info severity level as int from rcutils
-/// \return RCUTILS_LOG_SEVERITY_INFO
+/// Get log info severity level as int from rcutils.
+/// \return RCUTILS_LOG_SEVERITY_INFO as a PyLong.
 static PyObject *
 rclpy_get_info_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
@@ -224,7 +224,7 @@ rclpy_get_info_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED
 }
 
 /// Get log warn severity level as int from rcutils
-/// \return RCUTILS_LOG_SEVERITY_WARN
+/// \return RCUTILS_LOG_SEVERITY_WARN as a PyLong.
 static PyObject *
 rclpy_get_warn_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
@@ -232,15 +232,15 @@ rclpy_get_warn_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED
 }
 
 /// Get log error severity level as int from rcutils
-/// \return RCUTILS_LOG_SEVERITY_ERROR
+/// \return RCUTILS_LOG_SEVERITY_ERROR as a PyLong.
 static PyObject *
 rclpy_get_error_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {
   return PyLong_FromLongLong(RCUTILS_LOG_SEVERITY_ERROR);
 }
 
-/// Get log fatal severity level as int from rcutils
-/// \return RCUTILS_LOG_SEVERITY_FATAL
+/// Get log fatal severity level as int from rcutils.
+/// \return RCUTILS_LOG_SEVERITY_FATAL as a PyLong.
 static PyObject *
 rclpy_get_fatal_logging_severity(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
 {


### PR DESCRIPTION
Follow up of https://github.com/ros2/rclpy/pull/458. Remove log severity hard coded and copied values from rcutils