### PR TITLE
Use absolute topic name for rosout.

### DIFF
--- a/rclpy/test/test_logging_rosout.py
+++ b/rclpy/test/test_logging_rosout.py
@@ -65,7 +65,7 @@ def test_enable_rosout(
     # create subscriber of 'rosout' topic
     node.create_subscription(
         Log,
-        'rosout',
+        '/rosout',
         raw_subscription_callback,
         1,
         raw=True


### PR DESCRIPTION
Matches the change made in https://github.com/ros2/rcl/pull/549 to fix test failures in nightlies.