### PR TITLE
Fix the type annotation on get_parameters_by_prefix

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -525,7 +525,7 @@ class Node:
 
         return self._parameters.get(name, alternative_value)
 
-    def get_parameters_by_prefix(self, prefix: str) -> List[Parameter]:
+    def get_parameters_by_prefix(self, prefix: str) -> Dict[str, Parameter]:
         """
         Get parameters that have a given prefix in their names as a dictionary.
 


### PR DESCRIPTION
It definitely returns a dictionary of strings to Parameters,
not a list.  The documentation and code was right, but just
the type annotation was wrong.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>