### PR TITLE
[dashing] Remove f-strings

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -296,7 +296,7 @@ class ActionClient(Waitable):
             else:
                 self._node.get_logger().warning(
                     'Ignoring unexpected goal response. There may be more than '
-                    f"one action server for the action '{self._action_name}'"
+                    "one action server for the action '{}'".format(self._action_name)
                 )
 
         if 'cancel' in taken_data:
@@ -306,7 +306,7 @@ class ActionClient(Waitable):
             else:
                 self._node.get_logger().warning(
                     'Ignoring unexpected cancel response. There may be more than '
-                    f"one action server for the action '{self._action_name}'"
+                    "one action server for the action '{}'".format(self._action_name)
                 )
 
         if 'result' in taken_data:
@@ -316,7 +316,7 @@ class ActionClient(Waitable):
             else:
                 self._node.get_logger().warning(
                     'Ignoring unexpected result response. There may be more than '
-                    f"one action server for the action '{self._action_name}'"
+                    "one action server for the action '{}'".format(self._action_name)
                 )
 
         if 'feedback' in taken_data:


### PR DESCRIPTION
They are not compatible with Python 3.5 and accidentally introduced in #475.

Fixes #481