### PR TITLE
Handle unknown global ROS arguments.

### DIFF
--- a/rclpy/test/test_init_shutdown.py
+++ b/rclpy/test/test_init_shutdown.py
@@ -23,6 +23,15 @@ def test_init():
     rclpy.shutdown(context=context)
 
 
+def test_init_with_unknown_ros_args():
+    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+    context = rclpy.context.Context()
+    unknown_ros_args_error_pattern = r'Found unknown ROS arguments:.*\[\'unknown\'\]'
+    with pytest.raises(_rclpy.UnknownROSArgsError, match=unknown_ros_args_error_pattern):
+        rclpy.init(context=context, args=['--ros-args', 'unknown'])
+
+
 def test_init_with_non_utf8_arguments():
     context = rclpy.context.Context()
     # Embed non decodable characters e.g. due to


### PR DESCRIPTION
Follow up PR after https://github.com/ros2/rclpy/pull/415, for the exact same set of reasons. We should probably backport this on the next Eloquent patch release.