### PR TITLE
Find test dependency rosidl_generator_py

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -166,6 +166,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(rosidl_generator_py REQUIRED)
 
   rosidl_generator_py_get_typesupports(_typesupport_impls)
   ament_index_get_prefix_path(ament_index_build_path SKIP_AMENT_PREFIX_PATH)


### PR DESCRIPTION
The package provides the cmake macro 'rosidl_generator_py_get_typesupports'.
There was no error before since calling 'ament_lint_auto_find_test_dependencies' appears to
be calling find_package for us. Though, I'm not sure we want to rely on the ament_lint command
since I presume it is responsible for finding linter dependencies, which rosidl_generator_py is not.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8984)](http://ci.ros2.org/job/ci_linux/8984/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4756)](https://ci.ros2.org/job/ci_linux-aarch64/4756/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7356)](http://ci.ros2.org/job/ci_osx/7356/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8923)](https://ci.ros2.org/job/ci_windows/8923/) (Edit: unrelated failure https://github.com/ros2/rclpy/issues/494)