### PR TITLE
Add wrappers for RMW serialize and deserialize functions

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -203,6 +203,7 @@ if(BUILD_TESTING)
     test/test_qos.py
     test/test_qos_event.py
     test/test_rate.py
+    test/test_serialization.py
     test/test_task.py
     test/test_time_source.py
     test/test_time.py

--- a/rclpy/rclpy/serialization.py
+++ b/rclpy/rclpy/serialization.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.type_support import check_for_type_support
+
+
+def deserialize_message(serialized_message: bytes, message_type):
+    """
+    Deserialize a ROS message.
+
+    :param serialized_message: The ROS message to deserialized.
+    :param message_types: The type of the serialized ROS message.
+    :return: The deserialized ROS message.
+    """
+
+    # this line imports the typesupport for the message module if not already done
+    check_for_type_support(message_type)
+    return _rclpy.rclpy_deserialize(serialized_message, message_type)
+
+
+def serialize_message(message) -> bytes:
+    """
+    Serialize a ROS message.
+
+    :param message: The ROS message to serialize.
+    :return: The serialized bytes.
+    """
+
+    # this line imports the typesupport for the message module if not already done
+    check_for_type_support(message)
+    return _rclpy.rclpy_serialize(message)
+

--- a/rclpy/rclpy/serialization.py
+++ b/rclpy/rclpy/serialization.py
@@ -16,6 +16,18 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.type_support import check_for_type_support
 
 
+def serialize_message(message) -> bytes:
+    """
+    Serialize a ROS message.
+
+    :param message: The ROS message to serialize.
+    :return: The serialized bytes.
+    """
+    # this line imports the typesupport for the message module if not already done
+    check_for_type_support(message)
+    return _rclpy.rclpy_serialize(message)
+
+
 def deserialize_message(serialized_message: bytes, message_type):
     """
     Deserialize a ROS message.
@@ -27,15 +39,3 @@ def deserialize_message(serialized_message: bytes, message_type):
     # this line imports the typesupport for the message module if not already done
     check_for_type_support(message_type)
     return _rclpy.rclpy_deserialize(serialized_message, message_type)
-
-
-def serialize_message(message) -> bytes:
-    """
-    Serialize a ROS message.
-
-    :param message: The ROS message to serialize.
-    :return: The serialized bytes.
-    """
-    # this line imports the typesupport for the message module if not already done
-    check_for_type_support(message)
-    return _rclpy.rclpy_serialize(message)

--- a/rclpy/rclpy/serialization.py
+++ b/rclpy/rclpy/serialization.py
@@ -23,9 +23,10 @@ def serialize_message(message) -> bytes:
     :param message: The ROS message to serialize.
     :return: The serialized bytes.
     """
+    message_type = type(message)
     # this line imports the typesupport for the message module if not already done
-    check_for_type_support(message)
-    return _rclpy.rclpy_serialize(message)
+    check_for_type_support(message_type)
+    return _rclpy.rclpy_serialize(message, message_type)
 
 
 def deserialize_message(serialized_message: bytes, message_type):

--- a/rclpy/rclpy/serialization.py
+++ b/rclpy/rclpy/serialization.py
@@ -24,7 +24,6 @@ def deserialize_message(serialized_message: bytes, message_type):
     :param message_types: The type of the serialized ROS message.
     :return: The deserialized ROS message.
     """
-
     # this line imports the typesupport for the message module if not already done
     check_for_type_support(message_type)
     return _rclpy.rclpy_deserialize(serialized_message, message_type)
@@ -37,8 +36,6 @@ def serialize_message(message) -> bytes:
     :param message: The ROS message to serialize.
     :return: The serialized bytes.
     """
-
     # this line imports the typesupport for the message module if not already done
     check_for_type_support(message)
     return _rclpy.rclpy_serialize(message)
-

--- a/rclpy/rclpy/serialization.py
+++ b/rclpy/rclpy/serialization.py
@@ -33,7 +33,7 @@ def deserialize_message(serialized_message: bytes, message_type):
     Deserialize a ROS message.
 
     :param serialized_message: The ROS message to deserialized.
-    :param message_types: The type of the serialized ROS message.
+    :param message_type: The type of the serialized ROS message.
     :return: The deserialized ROS message.
     """
     # this line imports the typesupport for the message module if not already done

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4700,19 +4700,8 @@ rclpy_serialize(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   // Get type support
-  PyObject * pymetaclass = PyObject_GetAttrString(pymsg, "__class__");
-  if (!pymetaclass) {
-    return NULL;
-  }
-  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
-  Py_DECREF(pymetaclass);
-  if (!pyts) {
-    return NULL;
-  }
-
   rosidl_message_type_support_t * ts =
-    (rosidl_message_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
-  Py_DECREF(pyts);
+    (rosidl_message_type_support_t *)rclpy_common_get_type_support(pymsg);
   if (!ts) {
     return NULL;
   }
@@ -4762,18 +4751,8 @@ rclpy_deserialize(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   // Get type support
-  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
-  if (!pymetaclass) {
-    return NULL;
-  }
-  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
-  Py_DECREF(pymetaclass);
-  if (!pyts) {
-    return NULL;
-  }
   rosidl_message_type_support_t * ts =
-    (rosidl_message_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
-  Py_DECREF(pyts);
+    (rosidl_message_type_support_t *)rclpy_common_get_type_support(pymsg_type);
   if (!ts) {
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4695,13 +4695,14 @@ static PyObject *
 rclpy_serialize(PyObject * Py_UNUSED(self), PyObject * args)
 {
   PyObject * pymsg;
-  if (!PyArg_ParseTuple(args, "O", &pymsg)) {
+  PyObject * pymsg_type;
+  if (!PyArg_ParseTuple(args, "OO", &pymsg, &pymsg_type)) {
     return NULL;
   }
 
   // Get type support
   rosidl_message_type_support_t * ts =
-    (rosidl_message_type_support_t *)rclpy_common_get_type_support(pymsg);
+    (rosidl_message_type_support_t *)rclpy_common_get_type_support(pymsg_type);
   if (!ts) {
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4691,6 +4691,140 @@ rclpy_get_node_parameters(PyObject * Py_UNUSED(self), PyObject * args)
   return node_params;
 }
 
+static PyObject *
+rclpy_serialize(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pymsg;
+  if (!PyArg_ParseTuple(args, "O", &pymsg)) {
+    return NULL;
+  }
+
+  // Get type support
+  PyObject * pymetaclass = PyObject_GetAttrString(pymsg, "__class__");
+  if (!pymetaclass) {
+    return NULL;
+  }
+  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
+  Py_DECREF(pymetaclass);
+  if (!pyts) {
+    return NULL;
+  }
+
+  rosidl_message_type_support_t * ts =
+    (rosidl_message_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
+  Py_DECREF(pyts);
+  if (!ts) {
+    return NULL;
+  }
+
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * ros_msg = rclpy_convert_from_py(pymsg, &destroy_ros_message);
+  if (!ros_msg) {
+    return NULL;
+  }
+
+  // Create a serialized message object
+  rcl_serialized_message_t serialized_msg = rmw_get_zero_initialized_serialized_message();
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t rcutils_ret = rmw_serialized_message_init(&serialized_msg, 0u, &allocator);
+  if (RCUTILS_RET_OK != rcutils_ret) {
+    destroy_ros_message(ros_msg);
+    PyErr_Format(RCLError,
+      "Failed to initialize serialized message: %s", rcutils_get_error_string().str);
+    return NULL;
+  }
+
+  // Serialize
+  rmw_ret_t rmw_ret = rmw_serialize(ros_msg, ts, &serialized_msg);
+  destroy_ros_message(ros_msg);
+  if (RMW_RET_OK != rmw_ret) {
+    PyErr_Format(RCLError, "Failed to serialize ROS message");
+    rcutils_ret = rmw_serialized_message_fini(&serialized_msg);
+    if (RCUTILS_RET_OK != rcutils_ret) {
+      PyErr_Format(RCLError,
+        "Failed to finalize serialized message: %s", rcutils_get_error_string().str);
+    }
+    return NULL;
+  }
+
+  // Bundle serialized message in a bytes object
+  return Py_BuildValue("y#", serialized_msg.buffer, serialized_msg.buffer_length);
+}
+
+static PyObject *
+rclpy_deserialize(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  const char * serialized_buffer;
+  int serialized_buffer_size;
+  PyObject * pymsg_type;
+  if (!PyArg_ParseTuple(args, "y#O", &serialized_buffer, &serialized_buffer_size, &pymsg_type)) {
+    return NULL;
+  }
+
+  // Get type support
+  PyObject * pymetaclass = PyObject_GetAttrString(pymsg_type, "__class__");
+  if (!pymetaclass) {
+    return NULL;
+  }
+  PyObject * pyts = PyObject_GetAttrString(pymetaclass, "_TYPE_SUPPORT");
+  Py_DECREF(pymetaclass);
+  if (!pyts) {
+    return NULL;
+  }
+  rosidl_message_type_support_t * ts =
+    (rosidl_message_type_support_t *)PyCapsule_GetPointer(pyts, NULL);
+  Py_DECREF(pyts);
+  if (!ts) {
+    return NULL;
+  }
+
+  // Create a serialized message object
+  rcl_serialized_message_t serialized_msg = rmw_get_zero_initialized_serialized_message();
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t rcutils_ret = rmw_serialized_message_init(
+    &serialized_msg, serialized_buffer_size, &allocator);
+  if (RCUTILS_RET_OK != rcutils_ret) {
+    PyErr_Format(RCLError,
+      "Failed to initialize serialized message: %s", rcutils_get_error_string().str);
+    return NULL;
+  }
+
+  // Copy the data
+  memcpy(serialized_msg.buffer, serialized_buffer, serialized_buffer_size);
+  serialized_msg.buffer_length = serialized_buffer_size;
+  // TODO(jacobperron): Try just copy pointer to avoid extra allocation and copy
+  // serialized_msg.buffer_capacity = pyserialized_buffer.len;
+  // serialized_msg.buffer_length = pyserialized_buffer.len;
+  // serialized_msg.buffer = (uint8_t *)pyserialized_buffer.buf;
+
+  destroy_ros_message_signature * destroy_ros_message = NULL;
+  void * deserialized_ros_msg = rclpy_create_from_py(pymsg_type, &destroy_ros_message);
+  if (!deserialized_ros_msg) {
+    return NULL;
+  }
+
+  // Deserialize
+  // TODO(jacobperron): Deserializing floating-point types results in more digits than expected.
+  //                    For example, 3.14159 deserializes to 3.141590118408203
+  rmw_ret_t rmw_ret = rmw_deserialize(&serialized_msg, ts, deserialized_ros_msg);
+
+  rcutils_ret = rmw_serialized_message_fini(&serialized_msg);
+  if (RCUTILS_RET_OK != rcutils_ret) {
+    PyErr_Format(RCLError,
+      "Failed to finalize serialized message: %s", rcutils_get_error_string().str);
+    return NULL;
+  }
+
+  if (RMW_RET_OK != rmw_ret) {
+    destroy_ros_message(deserialized_ros_msg);
+    PyErr_Format(RCLError, "Failed to deserialize ROS message");
+    return NULL;
+  }
+
+  PyObject * pydeserialized_ros_msg = rclpy_convert_to_py(deserialized_ros_msg, pymsg_type);
+  destroy_ros_message(deserialized_ros_msg);
+  return pydeserialized_ros_msg;
+}
 
 /// Define the public methods of this module
 static PyMethodDef rclpy_methods[] = {
@@ -5036,6 +5170,14 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_remove_clock_callback", rclpy_remove_clock_callback, METH_VARARGS,
     "Remove a time jump callback from a clock."
+  },
+  {
+    "rclpy_serialize", rclpy_serialize, METH_VARARGS,
+    "Serialize a ROS message."
+  },
+  {
+    "rclpy_deserialize", rclpy_deserialize, METH_VARARGS,
+    "Deserialize a ROS message."
   },
 
   {NULL, NULL, 0, NULL}  /* sentinel */

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4771,8 +4771,6 @@ rclpy_deserialize(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   // Deserialize
-  // TODO(jacobperron): Deserializing floating-point types results in more digits than expected.
-  //                    For example, 3.14159 deserializes to 3.141590118408203
   rmw_ret_t rmw_ret = rmw_deserialize(&serialized_msg, ts, deserialized_ros_msg);
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rclpy/test/test_serialization.py
+++ b/rclpy/test/test_serialization.py
@@ -56,12 +56,18 @@ def test_serialize_deserialize(msgs, msg_type):
         assert msg == msg_deserialized
 
 
-# TODO(jacobperron): Fix this failing test.
-#                    I'm pretty sure that during (de)serialization we convert to a C float before
-#                    converting to a PyObject. This causes a loss of precision.
-# def test_set_float32():
-#     msg = BasicTypes()
-#     msg.float32_value = 3.14
-#     msg_serialized = serialize_message(msg)
-#     msg_deserialized = deserialize_message(msg_serialized, BasicTypes)
-#     assert msg == msg_deserialized
+def test_set_float32():
+    """Test message serialization/deserialization of float32 type."""
+    # During (de)serialization we convert to a C float before converting to a PyObject.
+    # This can result in a loss of precision
+    msg = BasicTypes()
+    msg.float32_value = 1.125  # can be represented without rounding
+    msg_serialized = serialize_message(msg)
+    msg_deserialized = deserialize_message(msg_serialized, BasicTypes)
+    assert msg.float32_value == msg_deserialized.float32_value
+
+    msg = BasicTypes()
+    msg.float32_value = 3.14  # can NOT be represented without rounding
+    msg_serialized = serialize_message(msg)
+    msg_deserialized = deserialize_message(msg_serialized, BasicTypes)
+    assert msg.float32_value == round(msg_deserialized.float32_value, 2)

--- a/rclpy/test/test_serialization.py
+++ b/rclpy/test/test_serialization.py
@@ -1,0 +1,67 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rclpy.serialization import deserialize_message
+from rclpy.serialization import serialize_message
+
+from test_msgs.message_fixtures import get_test_msg
+from test_msgs.msg import Arrays
+from test_msgs.msg import BasicTypes
+from test_msgs.msg import BoundedSequences
+from test_msgs.msg import Builtins
+from test_msgs.msg import Constants
+from test_msgs.msg import Defaults
+from test_msgs.msg import Empty
+from test_msgs.msg import MultiNested
+from test_msgs.msg import Nested
+from test_msgs.msg import Strings
+from test_msgs.msg import UnboundedSequences
+from test_msgs.msg import WStrings
+
+test_msgs = [
+  (get_test_msg('Arrays'), Arrays),
+  (get_test_msg('BasicTypes'), BasicTypes),
+  (get_test_msg('BoundedSequences'), BoundedSequences),
+  (get_test_msg('Builtins'), Builtins),
+  (get_test_msg('Constants'), Constants),
+  (get_test_msg('Defaults'), Defaults),
+  (get_test_msg('Empty'), Empty),
+  (get_test_msg('MultiNested'), MultiNested),
+  (get_test_msg('Nested'), Nested),
+  (get_test_msg('Strings'), Strings),
+  (get_test_msg('UnboundedSequences'), UnboundedSequences),
+  (get_test_msg('WStrings'), WStrings),
+]
+
+
+@pytest.mark.parametrize('msgs,msg_type', test_msgs)
+def test_serialize_deserialize(msgs, msg_type):
+    """Test message serialization/deserialization."""
+    for msg in msgs:
+        msg_serialized = serialize_message(msg)
+        msg_deserialized = deserialize_message(msg_serialized, msg_type)
+        assert msg == msg_deserialized
+
+
+# TODO(jacobperron): Fix this failing test.
+#                    I'm pretty sure that during (de)serialization we convert to a C float before
+#                    converting to a PyObject. This causes a loss of precision.
+# def test_set_float32():
+#     msg = BasicTypes()
+#     msg.float32_value = 3.14
+#     msg_serialized = serialize_message(msg)
+#     msg_deserialized = deserialize_message(msg_serialized, BasicTypes)
+#     assert msg == msg_deserialized


### PR DESCRIPTION
Related to https://github.com/ros2/rosbag2/issues/232

Added a serialization submodule with functions for serializing and deserializing ROS messages.

I noticed an issue related to the serialization of floating-point values. I believe it's a bug related to loss of precision for 32-bit floating point values as (de)serialization happens with underlying C-types. I'm not sure how to resolve it at the moment, but left a TODO and test that if uncommented
demonstrates the bug.