### PR TITLE
add online doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # rclpy
 ROS Client Library for the Python language.
 
+
 ## Building documentation
 
-Documentation can be built for `rclpy` using [Sphinx](http://www.sphinx-doc.org/en/master/).
+Documentation can be built for `rclpy` using [Sphinx](http://www.sphinx-doc.org/en/master/), or accessed [online](http://docs.ros2.org/latest/api/rclpy/index.html)
 
 #### Install dependencies
 


### PR DESCRIPTION
I figured it might be easier to direct users to an existing page, then asking them to build their own documentation. Feel free to close this if it's not a preferable change. 