### PR TITLE
Call init and shutdown thread safely

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -68,7 +68,6 @@ def init(*, args: Optional[List[str]] = None, context: Context = None) -> None:
         (see :func:`.get_default_context`).
     """
     context = get_default_context() if context is None else context
-    # imported locally to avoid loading extensions on module import
     return context.init(args)
 
 

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -40,8 +40,8 @@ all ROS nodes associated with the context), the :func:`shutdown` function should
 This will invalidate all entities derived from the context.
 """
 
-import sys
 from typing import List
+from typing import Optional
 from typing import TYPE_CHECKING
 
 from rclpy.context import Context
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from rclpy.node import Node  # noqa: F401
 
 
-def init(*, args: List[str] = None, context: Context = None) -> None:
+def init(*, args: Optional[List[str]] = None, context: Context = None) -> None:
     """
     Initialize ROS communications for a given context.
 
@@ -69,8 +69,7 @@ def init(*, args: List[str] = None, context: Context = None) -> None:
     """
     context = get_default_context() if context is None else context
     # imported locally to avoid loading extensions on module import
-    from rclpy.impl.implementation_singleton import rclpy_implementation
-    return rclpy_implementation.rclpy_init(args if args is not None else sys.argv, context.handle)
+    return context.init(args)
 
 
 # The global spin functions need an executor to do the work

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -41,6 +41,11 @@ class Context:
         return self._handle
 
     def init(self, args: Optional[List[str]] = None):
+        """
+        Initialize ROS communications for a given context.
+
+        :param args: List of command line arguments.
+        """
         # imported locally to avoid loading extensions on module import
         from rclpy.impl.implementation_singleton import rclpy_implementation
         with self._lock:

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import threading
 from typing import Callable
+from typing import List
+from typing import Optional
 import weakref
 
 
@@ -36,6 +39,12 @@ class Context:
     @property
     def handle(self):
         return self._handle
+
+    def init(self, args: Optional[List[str]] = None):
+        from rclpy.impl.implementation_singleton import rclpy_implementation
+        with self._lock:
+            rclpy_implementation.rclpy_init(
+                args if args is not None else sys.argv, self._handle)
 
     def ok(self):
         """Check if context hasn't been shut down."""

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -41,6 +41,7 @@ class Context:
         return self._handle
 
     def init(self, args: Optional[List[str]] = None):
+        # imported locally to avoid loading extensions on module import
         from rclpy.impl.implementation_singleton import rclpy_implementation
         with self._lock:
             rclpy_implementation.rclpy_init(


### PR DESCRIPTION
The rcl functions aren't thread safe.
The upper layer has to lock.
