### PR TITLE
Enable test_get_publishers_subscriptions_info_by_topic() unit test for more rmw_implementations

### DIFF
--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -42,7 +42,6 @@ from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time_source import USE_SIM_TIME_NAME
-from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -205,8 +205,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             actual_qos_profile.liveliness_lease_duration,
             'liveliness_lease_duration is unequal')
 
-    @unittest.skipIf(get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp',
-                     'Implementation is not supported')
     def test_get_publishers_subscriptions_info_by_topic(self):
         topic_name = 'test_topic_endpoint_info'
         fq_topic_name = '{namespace}/{name}'.format(namespace=TEST_NAMESPACE, name=topic_name)


### PR DESCRIPTION
This is for addressing the comment at https://github.com/ros2/rmw_connext/issues/380#issuecomment-576794050.

Since https://github.com/ros2/rmw_connext/pull/391 is ready for review, this change can be reviewed and merged along with it.