### PR TITLE
Fixes max_jitter calculation

### DIFF
--- a/rclpy/test/test_rate.py
+++ b/rclpy/test/test_rate.py
@@ -30,6 +30,8 @@ class RateRunner:
     def __init__(self, rate):
         self.avg_period = None
         self.max_jitter = None
+        self.min_period = None
+        self.max_period = None
         self.done = False
 
         self._num_measurements = 10
@@ -37,7 +39,8 @@ class RateRunner:
         self._thread.start()
 
     def __str__(self):
-        return 'avg period: {} max jitter: {}'.format(self.avg_period, self.max_jitter)
+        return 'avg period: {} max jitter: {} min: {} max: {} '.format(
+            self.avg_period, self.max_jitter, self.min_period, self.max_period)
 
     def _run(self, rate):
         try:
@@ -53,7 +56,9 @@ class RateRunner:
                 last_wake_time = now
 
             self.avg_period = sum(measurements) / len(measurements)
-            self.max_jitter = max([abs(m) - self.avg_period for m in measurements])  # noqa: C407
+            self.max_jitter = max([abs(m - self.avg_period) for m in measurements])  # noqa: C407
+            self.min_period = min(measurements)
+            self.max_period = max(measurements)
         finally:
             self.done = True
 


### PR DESCRIPTION
The calculation of the max_jitter, which is a criterion for this test's success, was incorrect. This fixes the `abs()` calculation and adds min/max to the `__str__()` call.