### PR TITLE
Disable 100Hz test in test_timer.py for Windows

### DIFF
--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -23,7 +23,12 @@ from rclpy.executors import SingleThreadedExecutor
 
 TEST_PERIODS = (
     0.1,
-    0.01,
+    pytest.param(
+        0.01,
+        marks=(
+            pytest.mark.skipif(os.name == 'nt', reason='Flaky on windows'),
+        )
+    ),
     pytest.param(
         0.001,
         marks=(


### PR DESCRIPTION
This is related to issue #513, but this test fails periodically on windows, and quite regularly on the windows container builds. This PR disables the 0.01s period version for the test.

Without fix:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9428)](http://ci.ros2.org/job/ci_linux/9428/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5109)](http://ci.ros2.org/job/ci_linux-aarch64/5109/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7709)](http://ci.ros2.org/job/ci_osx/7709/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9346)](http://ci.ros2.org/job/ci_windows/9346/)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=200)](http://ci.ros2.org/job/ci_windows-container/200/)

With fix:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9429)](http://ci.ros2.org/job/ci_linux/9429/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5110)](http://ci.ros2.org/job/ci_linux-aarch64/5110/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7710)](http://ci.ros2.org/job/ci_osx/7710/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9347)](http://ci.ros2.org/job/ci_windows/9347/)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=201)](http://ci.ros2.org/job/ci_windows-container/201/)