### PR TITLE
Embolden the warning in the docs about Client.call() potentially deadlocking

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -68,7 +68,7 @@ class Client:
         """
         Make a service request and wait for the result.
 
-        Do not call this method in a callback or a deadlock may occur.
+        .. warning:: Do not call this method in a callback or a deadlock may occur.
 
         :param request: The service request.
         :return: The service response.


### PR DESCRIPTION
The potential for the synchronous `call()` to cause a deadlock if called from inside a callback warrants a more serious warning than how it is currently being documented.