### PR TITLE
Add support for functions passed to Context.on_shutdown

### DIFF
--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -14,6 +14,7 @@
 
 import sys
 import threading
+from types import MethodType
 from typing import Callable
 from typing import List
 from typing import Optional
@@ -94,4 +95,7 @@ class Context:
             if not self.ok():
                 callback()
             else:
-                self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
+                if type(callback) == MethodType:
+                    self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
+                else:
+                    self._callbacks.append(weakref.ref(callback, self._remove_callback))


### PR DESCRIPTION
Add support for on_shutdown functions not just methods.

Otherwise you get an error like this: 
```
  File "./test_shutdown.py", line 37, in <module>
    main()
  File "./test_shutdown.py", line 22, in main
    rclpy.get_default_context().on_shutdown(lambda : print("lambda on shutdown called"))
  File "/opt/ros/eloquent/lib/python3.6/site-packages/rclpy/context.py", line 82, in on_shutdown
    self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
  File "/usr/lib/python3.6/weakref.py", line 50, in __new__
    .format(type(meth))) from None
TypeError: argument should be a bound method, not <class 'function'>
```

I also added unit tests to cover the callback types and the weak pointers being broken.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9836)](http://ci.ros2.org/job/ci_linux/9836/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5453)](http://ci.ros2.org/job/ci_linux-aarch64/5453/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7999)](http://ci.ros2.org/job/ci_osx/7999/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9692)](http://ci.ros2.org/job/ci_windows/9692/)