### PR TITLE
Add support for functions passed to Context.on_shutdown

### DIFF
--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -14,6 +14,7 @@
 
 import sys
 import threading
+from types import MethodType
 from typing import Callable
 from typing import List
 from typing import Optional
@@ -94,4 +95,7 @@ class Context:
             if not self.ok():
                 callback()
             else:
-                self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
+                if isinstance(callback, MethodType):
+                    self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
+                else:
+                    self._callbacks.append(weakref.ref(callback, self._remove_callback))


### PR DESCRIPTION
This is a redo of #531 which I accidentally merged.

With the feedback from @claireyywang 

Re: isinstance 
I switched to isinstance which is slightly more generic to support inheritance, but in this case I don't think there's other cases that will appear. 

Re: testing
You should be able to invoke the individual tests, but I just ran all of rclpy's suite it took just over 1 minute to validate. 

New CI: 
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9884)](http://ci.ros2.org/job/ci_linux/9884/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5501)](http://ci.ros2.org/job/ci_linux-aarch64/5501/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8042)](http://ci.ros2.org/job/ci_osx/8042/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9741)](http://ci.ros2.org/job/ci_windows/9741/)
