### PR TITLE
Avoid unsigned/signed comparison warning

### DIFF
--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -391,7 +391,7 @@ _rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic
   if (!py_endpoint_gid) {
     goto fail;
   }
-  for (int i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
+  for (size_t i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
     PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_gid[i]);
     if (!py_val_at_index) {
       goto fail;


### PR DESCRIPTION
Required because of change here https://github.com/ros2/rmw/blob/cbb5fc008f4304a62cf070663e3174c9f7970f9f/rmw/include/rmw/types.h#L40 in https://github.com/ros2/rmw/pull/189.