### PR TITLE
Add enclaves introspection method in `Node`

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1648,7 +1648,8 @@ class Node:
         """
         Get a list of names, namespaces and security contexts for discovered nodes.
 
-        :return: List of tuples containing two strings: the node name and node namespace.
+        :return: List of tuples containing three strings: the node name, node namespace
+            and security context.
         """
         with self.handle as capsule:
             return _rclpy.rclpy_get_node_names_and_namespaces_with_security_contexts(capsule)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1646,7 +1646,7 @@ class Node:
 
     def get_node_names_and_namespaces_with_enclaves(self) -> List[Tuple[str, str, str]]:
         """
-        Get a list of names, namespaces and security contexts for discovered nodes.
+        Get a list of names, namespaces and enclaves for discovered nodes.
 
         :return: List of tuples containing three strings: the node name, node namespace
             and enclave.

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1644,6 +1644,15 @@ class Node:
         with self.handle as capsule:
             return _rclpy.rclpy_get_node_names_and_namespaces(capsule)
 
+    def get_node_names_and_namespaces_with_security_contexts(self) -> List[Tuple[str, str, str]]:
+        """
+        Get a list of names, namespaces and security contexts for discovered nodes.
+
+        :return: List of tuples containing two strings: the node name and node namespace.
+        """
+        with self.handle as capsule:
+            return _rclpy.rclpy_get_node_names_and_namespaces_with_security_contexts(capsule)
+
     def _count_publishers_or_subscribers(self, topic_name, func):
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
         validate_full_topic_name(fq_topic_name)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1644,15 +1644,15 @@ class Node:
         with self.handle as capsule:
             return _rclpy.rclpy_get_node_names_and_namespaces(capsule)
 
-    def get_node_names_and_namespaces_with_security_contexts(self) -> List[Tuple[str, str, str]]:
+    def get_node_names_and_namespaces_with_enclaves(self) -> List[Tuple[str, str, str]]:
         """
         Get a list of names, namespaces and security contexts for discovered nodes.
 
         :return: List of tuples containing three strings: the node name, node namespace
-            and security context.
+            and enclave.
         """
         with self.handle as capsule:
-            return _rclpy.rclpy_get_node_names_and_namespaces_with_security_contexts(capsule)
+            return _rclpy.rclpy_get_node_names_and_namespaces_with_enclaves(capsule)
 
     def _count_publishers_or_subscribers(self, topic_name, func):
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3423,6 +3423,18 @@ rclpy_shutdown(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_NONE;
 }
 
+/// Get the list of nodes discovered by the provided node
+/**
+ *  Raises ValueError if pynode is not a node capsule
+ *  Raises RuntimeError  if there is an rcl error
+ *
+ * \param[in] args arguments tuple, composed by only one argument:
+ *  - node: Capsule pointing to the node
+ * \param[in] use_security_contexts specifies if the output includes the security context or not
+ * \return Python list of tuples, containing:
+ *  node name, node namespace, and
+ *  security_context if `use_security_contexts` is true.
+ */
 static PyObject *
 rclpy_get_node_names_impl(PyObject * args, bool use_security_contexts)
 {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3475,10 +3475,9 @@ rclpy_get_node_names_impl(PyObject * args, bool use_security_contexts)
     goto cleanup;
   }
 
-  size_t tuple_size = use_security_contexts ? 3 : 2;
   size_t idx;
   for (idx = 0; idx < node_names.size; ++idx) {
-    PyObject * pytuple = PyTuple_New(tuple_size);
+    PyObject * pytuple = PyTuple_New(use_security_contexts ? 3 : 2);
     if (!pytuple) {
       goto cleanup;
     }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3423,108 +3423,8 @@ rclpy_shutdown(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_NONE;
 }
 
-/// Get the list of nodes discovered by the provided node
-/**
- *  Raises ValueError if pynode is not a node capsule
- *  Raises RuntimeError  if there is an rcl error
- *
- * \param[in] pynode Capsule pointing to the node
- * \return Python list of tuples where each tuple contains the two strings:
- *   the node name and node namespace
- */
 static PyObject *
-rclpy_get_node_names_and_namespaces(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  PyObject * pynode;
-
-  if (!PyArg_ParseTuple(args, "O", &pynode)) {
-    return NULL;
-  }
-
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-  rcl_node_t * node = rclpy_handle_get_pointer_from_capsule(pynode, "rcl_node_t");
-  if (!node) {
-    return NULL;
-  }
-  rcutils_string_array_t node_names = rcutils_get_zero_initialized_string_array();
-  rcutils_string_array_t node_namespaces = rcutils_get_zero_initialized_string_array();
-  rcl_ret_t ret = rcl_get_node_names(node, allocator, &node_names, &node_namespaces);
-  if (ret != RCL_RET_OK) {
-    PyErr_Format(
-      RCLError, "Failed to get_node_names: %s", rcl_get_error_string().str);
-    rcl_reset_error();
-    return NULL;
-  }
-
-  rcutils_ret_t fini_names_ret;
-  rcutils_ret_t fini_namespaces_ret;
-  PyObject * pynode_names_and_namespaces = PyList_New(node_names.size);
-  if (!pynode_names_and_namespaces) {
-    goto cleanup;
-  }
-  size_t idx;
-  for (idx = 0; idx < node_names.size; ++idx) {
-    PyObject * pytuple = PyTuple_New(2);
-    if (!pytuple) {
-      goto cleanup;
-    }
-    PyObject * pynode_name = PyUnicode_FromString(node_names.data[idx]);
-    if (!pynode_name) {
-      Py_DECREF(pytuple);
-      goto cleanup;
-    }
-    // Steals the reference
-    PyTuple_SET_ITEM(pytuple, 0, pynode_name);
-    PyObject * pynode_namespace = PyUnicode_FromString(node_namespaces.data[idx]);
-    if (!pynode_namespace) {
-      Py_DECREF(pytuple);
-      goto cleanup;
-    }
-    // Steals the reference
-    PyTuple_SET_ITEM(pytuple, 1, pynode_namespace);
-    // Steals the reference
-    PyList_SET_ITEM(pynode_names_and_namespaces, idx, pytuple);
-  }
-
-cleanup:
-  fini_names_ret = rcutils_string_array_fini(&node_names);
-  fini_namespaces_ret = rcutils_string_array_fini(&node_namespaces);
-  if (PyErr_Occurred()) {
-    Py_XDECREF(pynode_names_and_namespaces);
-    return NULL;
-  }
-  if (fini_names_ret != RCUTILS_RET_OK) {
-    PyErr_Format(
-      RCLError,
-      "Failed to destroy node_names: %s", rcl_get_error_string().str);
-    Py_DECREF(pynode_names_and_namespaces);
-    rcl_reset_error();
-    return NULL;
-  }
-  if (fini_namespaces_ret != RCUTILS_RET_OK) {
-    PyErr_Format(
-      RCLError,
-      "Failed to destroy node_namespaces: %s", rcl_get_error_string().str);
-    Py_DECREF(pynode_names_and_namespaces);
-    rcl_reset_error();
-    return NULL;
-  }
-
-  return pynode_names_and_namespaces;
-}
-
-/// Get the list of nodes discovered by the provided node, with their respective security contexts.
-/**
- *  Raises ValueError if pynode is not a node capsule
- *  Raises RuntimeError  if there is an rcl error
- *
- * \param[in] pynode Capsule pointing to the node
- * \return Python list of tuples where each tuple contains three strings:
- *   the node name,node namespace and the security context.
- */
-static PyObject *
-rclpy_get_node_names_and_namespaces_with_security_contexts(
-  PyObject * Py_UNUSED(self), PyObject * args)
+rclpy_get_node_names_impl(PyObject * args, bool use_security_contexts)
 {
   PyObject * pynode;
 
@@ -3540,8 +3440,14 @@ rclpy_get_node_names_and_namespaces_with_security_contexts(
   rcutils_string_array_t node_names = rcutils_get_zero_initialized_string_array();
   rcutils_string_array_t node_namespaces = rcutils_get_zero_initialized_string_array();
   rcutils_string_array_t security_contexts = rcutils_get_zero_initialized_string_array();
-  rcl_ret_t ret = rcl_get_node_names_with_security_contexts(
-    node, allocator, &node_names, &node_namespaces, &security_contexts);
+  rcl_ret_t ret = RCL_RET_OK;
+  if (use_security_contexts) {
+    ret = rcl_get_node_names_with_security_contexts(
+      node, allocator, &node_names, &node_namespaces, &security_contexts);
+  } else {
+    ret = rcl_get_node_names(
+      node, allocator, &node_names, &node_namespaces);
+  }
   if (ret != RCL_RET_OK) {
     PyErr_Format(
       RCLError, "Failed to get node names: %s", rcl_get_error_string().str);
@@ -3556,9 +3462,11 @@ rclpy_get_node_names_and_namespaces_with_security_contexts(
   if (!pynode_names_and_namespaces) {
     goto cleanup;
   }
+
+  size_t tuple_size = use_security_contexts ? 3 : 2;
   size_t idx;
   for (idx = 0; idx < node_names.size; ++idx) {
-    PyObject * pytuple = PyTuple_New(3);
+    PyObject * pytuple = PyTuple_New(tuple_size);
     if (!pytuple) {
       goto cleanup;
     }
@@ -3576,13 +3484,15 @@ rclpy_get_node_names_and_namespaces_with_security_contexts(
     }
     // Steals the reference
     PyTuple_SET_ITEM(pytuple, 1, pynode_namespace);
-    PyObject * pynode_security_contexts = PyUnicode_FromString(security_contexts.data[idx]);
-    if (!pynode_security_contexts) {
-      Py_DECREF(pytuple);
-      goto cleanup;
+    if (use_security_contexts) {
+      PyObject * pynode_security_contexts = PyUnicode_FromString(security_contexts.data[idx]);
+      if (!pynode_security_contexts) {
+        Py_DECREF(pytuple);
+        goto cleanup;
+      }
+      // Steals the reference
+      PyTuple_SET_ITEM(pytuple, 2, pynode_security_contexts);
     }
-    // Steals the reference
-    PyTuple_SET_ITEM(pytuple, 2, pynode_security_contexts);
     // Steals the reference
     PyList_SET_ITEM(pynode_names_and_namespaces, idx, pytuple);
   }
@@ -3621,6 +3531,37 @@ cleanup:
   }
 
   return pynode_names_and_namespaces;
+}
+
+/// Get the list of nodes discovered by the provided node
+/**
+ *  Raises ValueError if pynode is not a node capsule
+ *  Raises RuntimeError  if there is an rcl error
+ *
+ * \param[in] pynode Capsule pointing to the node
+ * \return Python list of tuples where each tuple contains the two strings:
+ *   the node name and node namespace
+ */
+static PyObject *
+rclpy_get_node_names_and_namespaces(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  return rclpy_get_node_names_impl(args, false);
+}
+
+/// Get the list of nodes discovered by the provided node, with their respective security contexts.
+/**
+ *  Raises ValueError if pynode is not a node capsule
+ *  Raises RuntimeError  if there is an rcl error
+ *
+ * \param[in] pynode Capsule pointing to the node
+ * \return Python list of tuples where each tuple contains three strings:
+ *   the node name,node namespace and the security context.
+ */
+static PyObject *
+rclpy_get_node_names_and_namespaces_with_security_contexts(
+  PyObject * Py_UNUSED(self), PyObject * args)
+{
+  return rclpy_get_node_names_impl(args, true);
 }
 
 /// Get a list of service names and types associated with the given node name.

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3567,7 +3567,7 @@ rclpy_get_node_names_and_namespaces(PyObject * Py_UNUSED(self), PyObject * args)
  *
  * \param[in] pynode Capsule pointing to the node
  * \return Python list of tuples where each tuple contains three strings:
- *   the node name,node namespace and the security context.
+ *   node name, namespace and security context.
  */
 static PyObject *
 rclpy_get_node_names_and_namespaces_with_security_contexts(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -177,6 +177,10 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # test that it doesn't raise
         self.node.get_node_names_and_namespaces()
 
+    def test_node_names_and_namespaces_with_security_contexts(self):
+        # test that it doesn't raise
+        self.node.get_node_names_and_namespaces_with_security_contexts()
+
     def assert_qos_equal(self, expected_qos_profile, actual_qos_profile, *, is_publisher):
         # Depth and history are skipped because they are not retrieved.
         self.assertEqual(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -177,9 +177,9 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # test that it doesn't raise
         self.node.get_node_names_and_namespaces()
 
-    def test_node_names_and_namespaces_with_security_contexts(self):
+    def test_node_names_and_namespaces_with_enclaves(self):
         # test that it doesn't raise
-        self.node.get_node_names_and_namespaces_with_security_contexts()
+        self.node.get_node_names_and_namespaces_with_enclaves()
 
     def assert_qos_equal(self, expected_qos_profile, actual_qos_profile, *, is_publisher):
         # Depth and history are skipped because they are not retrieved.


### PR DESCRIPTION
Fixes https://github.com/ros2/rclpy/issues/529.

With this, policy generation from a running example can be reactivated in `sros2`.