### PR TITLE
use f-string to fix flake8 warning

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -71,8 +71,7 @@ class ParameterException(Exception):
     """Base exception for parameter-related errors."""
 
     def __init__(self, error_msg, parameters, *args):
-        Exception.__init__(self, '{error_msg}: {parameters}'.format(
-            error_msg=error_msg, parameters=parameters), *args)
+        Exception.__init__(self, f'{error_msg}: {parameters}')
 
 
 class ParameterNotDeclaredException(ParameterException):

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -71,7 +71,8 @@ class ParameterException(Exception):
     """Base exception for parameter-related errors."""
 
     def __init__(self, error_msg, parameters, *args):
-        Exception.__init__(self, '{error_msg}: {parameters}'.format(error_msg, parameters), *args)
+        Exception.__init__(self, '{error_msg}: {parameters}'.format(
+            error_msg=error_msg, parameters=parameters), *args)
 
 
 class ParameterNotDeclaredException(ParameterException):


### PR DESCRIPTION
Resolves a flake8 error which would manifest as a KeyError at runtime
when this exception is created.

Spotted in [nightlies](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1519/testReport/rclpy/flake8/F999____rclpy_exceptions_py_74_34_/) it took a minute to reproduce since the flake8 version we install claims to be incompatible with [pyflakes 2.2.0](https://pypi.org/project/pyflakes/#history) which was just released, which is likely why the error has the F999 code.