### PR TITLE
Add method to take with message_info

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -322,7 +322,7 @@ class Executor:
 
     def _take_subscription(self, sub):
         with sub.handle as capsule:
-            msg = _rclpy.rclpy_take(capsule, sub.msg_type, sub.raw)
+            msg, _ = _rclpy.rclpy_take(capsule, sub.msg_type, sub.raw)
         return msg
 
     async def _execute_subscription(self, sub, msg):

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3310,10 +3310,8 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
   PyObject * tuple = PyTuple_Pack(2, pytaken_msg, mi_dict);
-  if (tuple == NULL) {
-    Py_DECREF(pytaken_msg);
-    Py_DECREF(mi_dict);
-  }
+  Py_DECREF(pytaken_msg);
+  Py_DECREF(mi_dict);
   return tuple;
 }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3222,11 +3222,11 @@ rclpy_message_info_to_dict(rmw_message_info_t * message_info)
   }
 
   // we bail out at the end in case of errors
-  PyObject * source_timestamp = PyLong_FromLong(message_info->source_timestamp);
+  PyObject * source_timestamp = PyLong_FromLongLong(message_info->source_timestamp);
   if (source_timestamp != NULL) {
     PyDict_SetItemString(dict, "source_timestamp", source_timestamp);
   }
-  PyObject * received_timestamp = PyLong_FromLong(message_info->source_timestamp);
+  PyObject * received_timestamp = PyLong_FromLongLong(message_info->source_timestamp);
   if (received_timestamp != NULL) {
     PyDict_SetItemString(dict, "received_timestamp", source_timestamp);
   }

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3295,10 +3295,6 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
       if (!pytaken_msg) {
         // the function has set the Python error
         return NULL;
-      } else {
-        // if take failed, just do nothing
-        destroy_ros_message(taken_msg);
-        return NULL;
       }
     }
   }

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import pathlib
+import time
 import unittest
 from unittest.mock import Mock
 
@@ -25,7 +25,6 @@ from rcl_interfaces.msg import ParameterValue
 from rcl_interfaces.msg import SetParametersResult
 from rcl_interfaces.srv import GetParameters
 import rclpy
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.clock import ClockType
 from rclpy.duration import Duration
 from rclpy.exceptions import InvalidParameterException
@@ -36,6 +35,7 @@ from rclpy.exceptions import ParameterAlreadyDeclaredException
 from rclpy.exceptions import ParameterImmutableException
 from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.executors import SingleThreadedExecutor
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSDurabilityPolicy
@@ -154,7 +154,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
                 result = _rclpy.rclpy_take(capsule, sub.msg_type, False)
             if result is not None:
                 msg, info = result
-                self.assertNotEqual(0, info["source_timestamp"])
+                self.assertNotEqual(0, info['source_timestamp'])
                 return
             else:
                 time.sleep(0.1)

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -192,7 +192,7 @@ class SubscriptionWaitable(Waitable):
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.subscription_is_ready:
             self.subscription_is_ready = False
-            return _rclpy.rclpy_take(self.subscription, EmptyMsg, False)
+            return _rclpy.rclpy_take(self.subscription, EmptyMsg, False)[0]
         return None
 
     async def execute(self, taken_data):


### PR DESCRIPTION
This implements the Python side of https://github.com/ros2/design/issues/259 and needs https://github.com/ros2/rcl/pull/619

The message info is simply returned as a dictionary. I figured if we want to encapsulate it into something else, we can always do that in Python. That shouldn't break API.

So far, only subscriptions have a method to take with info.

