### PR TITLE
Fix warning about pytaken_msg maybe being uninitialized

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3352,14 +3352,9 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
 
     pytaken_msg = rclpy_convert_to_py(taken_msg, pymsg_type);
     destroy_ros_message(taken_msg);
-    if (!pytaken_msg) {
-      // the function has set the Python error
-      return NULL;
-    }
   }
   if (!pytaken_msg) {
-    // This should be impossible
-    PyErr_Format(PyExc_RuntimeError, "Unable to take message");
+    // the function has set the Python error
     return NULL;
   }
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3309,7 +3309,7 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
   PyObject * pysubscription;
   PyObject * pymsg_type;
   PyObject * pyraw;
-  PyObject * pytaken_msg;
+  PyObject * pytaken_msg = NULL;
 
   if (!PyArg_ParseTuple(args, "OOO", &pysubscription, &pymsg_type, &pyraw)) {
     return NULL;
@@ -3356,6 +3356,11 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
       // the function has set the Python error
       return NULL;
     }
+  }
+  if (!pytaken_msg) {
+    // This should be impossible
+    PyErr_Format(PyExc_RuntimeError, "Unable to take message");
+    return NULL;
   }
 
   // make result tuple


### PR DESCRIPTION
Seen in https://ci.ros2.org/job/nightly_linux_release/1525/gcc/new/

This initializes `pytaken_msg` with `NULL`, and changes the check that `pytaken_msg` is not `NULL` to cover both raw and non-raw cases.