### PR TITLE
Fix flaky test expecting wrong return type of rclpy_take

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -322,8 +322,10 @@ class Executor:
 
     def _take_subscription(self, sub):
         with sub.handle as capsule:
-            msg, _ = _rclpy.rclpy_take(capsule, sub.msg_type, sub.raw)
-        return msg
+            msg_info = _rclpy.rclpy_take(capsule, sub.msg_type, sub.raw)
+            if msg_info is not None:
+                return msg_info[0]
+        return None
 
     async def _execute_subscription(self, sub, msg):
         if msg:

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3301,7 +3301,8 @@ rclpy_message_info_to_dict(rmw_message_info_t * message_info)
 /**
  * \param[in] pysubscription Capsule pointing to the subscription to process the message
  * \param[in] pymsg_type Instance of the message type to take
- * \return Tuple of (Python message with all fields populated with received message, message_info)
+ * \return Tuple of (Python message with all fields populated with received message, message_info),
+ *         or (None, None) if ther was no message to take.
  */
 static PyObject *
 rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3302,7 +3302,7 @@ rclpy_message_info_to_dict(rmw_message_info_t * message_info)
  * \param[in] pysubscription Capsule pointing to the subscription to process the message
  * \param[in] pymsg_type Instance of the message type to take
  * \return Tuple of (Python message with all fields populated with received message, message_info),
- *         or (None, None) if ther was no message to take.
+ *         or None if there was no message to take.
  */
 static PyObject *
 rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
@@ -3348,7 +3348,7 @@ rclpy_take(PyObject * Py_UNUSED(self), PyObject * args)
     }
 
     if (RCL_RET_SUBSCRIPTION_TAKE_FAILED == ret) {
-      return PyTuple_Pack(2, Py_None, Py_None);
+      Py_RETURN_NONE;
     }
 
     pytaken_msg = rclpy_convert_to_py(taken_msg, pymsg_type);

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -152,7 +152,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         while cycle_count < 5:
             with sub.handle as capsule:
                 result = _rclpy.rclpy_take(capsule, sub.msg_type, False)
-            if result is not None:
+            if result[0] is not None:
                 msg, info = result
                 self.assertNotEqual(0, info['source_timestamp'])
                 return

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -152,7 +152,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         while cycle_count < 5:
             with sub.handle as capsule:
                 result = _rclpy.rclpy_take(capsule, sub.msg_type, False)
-            if result[0] is not None:
+            if result is not None:
                 msg, info = result
                 self.assertNotEqual(0, info['source_timestamp'])
                 return

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -192,7 +192,9 @@ class SubscriptionWaitable(Waitable):
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.subscription_is_ready:
             self.subscription_is_ready = False
-            return _rclpy.rclpy_take(self.subscription, EmptyMsg, False)[0]
+            msg_info = _rclpy.rclpy_take(self.subscription, EmptyMsg, False)
+            if msg_info is not None:
+                return msg_info[0]
         return None
 
     async def execute(self, taken_data):


### PR DESCRIPTION
#542 made `rclpy_take()` return a 2-tuple of `(message, message_info)`, but wrote a test that expected `rclpy_take()` to return `None` when there is no message to take. However, it seems it actually crashed in that case. #550 fixed the crash by making `rclpy_take()` return `(None, None)` when there was no message to take from the middleware, but the test still expected `None`. This causes the test added in #542 to be flaky: https://github.com/ros2/rclpy/pull/551#issuecomment-620327015 . This PR fixes the issue by making the test expect `(None, None)` and documenting this return code in `rclpy_take()`.