### PR TITLE
Skip flaky timer test on windows

### DIFF
--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -23,7 +23,12 @@ from rclpy.executors import SingleThreadedExecutor
 
 TEST_PERIODS = (
     0.1,
-    0.01,
+    pytest.param(
+        0.01,
+        marks=(
+            pytest.mark.skipif(os.name == 'nt', reason='Flaky on windows'),
+        )
+    ),
     pytest.param(
         0.001,
         marks=(


### PR DESCRIPTION
Fixes failures on Windows CI https://ci.ros2.org/view/nightly/job/nightly_win_rel/1537/testReport/junit/(root)/projectroot/test_timer/.