### PR TITLE
Fix bad rmw_time_t to nanoseconds conversion.

### DIFF
--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -162,9 +162,9 @@ _convert_rmw_time_to_ns(const rmw_time_t * duration, int64_t * nanoseconds)
   return true;
 fail_convert_rmw_time_to_ns:
   PyErr_Format(
-      PyExc_RuntimeError,
-      "Failed to convert rmw_time_t (sec: %llu, nsec: %llu) to int64_t",
-      duration->sec, duration->nsec);
+    PyExc_RuntimeError,
+    "Failed to convert rmw_time_t (sec: %llu, nsec: %llu) to int64_t",
+    duration->sec, duration->nsec);
   return false;
 }
 


### PR DESCRIPTION
Fixes https://github.com/ros2/ros2cli/issues/503 (i.e. the failure, not the hang). `rmw_time_t` instances were being forced into an `rcutils_time_duration_t` value (actually, first into a single `uint64_t` total nanosecond count, then into an unsigned `PY_LONG_LONG`, and then into an `rcutils_time_duration_t` i.e. an `int64_t`), causing overflows.

---

This happened in the first place because, RMW graph APIs are not currently bound to return anything reasonable for QoS related durations that do not make sense in a given context. That is the case for data reader (subscribers' backbone) lifespans in `rmw_connext_cpp` (see [here](https://github.com/ros2/rmw_connext/blob/7781a5e5982032be9460840e33646028af21129e/rmw_connext_shared_cpp/src/qos.cpp#L259) and [here](https://github.com/ros2/rmw_connext/blob/ae7117ec9942953d159b6a25feb2bb0a0e17c857/rmw_connext_shared_cpp/src/types/custom_subscriber_listener.cpp#L55-L56)), which come with whatever value was in the stack at the moment that `rmw_qos_profile_t` variable enters scope.

I see there's some discussion in https://github.com/ros2/rmw/issues/210 about introducing some consistency in `rmw_time_t` values. I'll defer to them on what to do about RMWs in general. 