### PR TITLE
Explicitly add DLL directories for Windows before importing

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -26,8 +26,8 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
-  <exec_depend>rpyutils</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>
+  <exec_depend>rpyutils</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rpyutils</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/rclpy/rclpy/impl/__init__.py
+++ b/rclpy/rclpy/impl/__init__.py
@@ -17,20 +17,17 @@ import os
 
 
 def _import(name):
+    # New in Python 3.8: on Windows we should call 'add_dll_directory()' for directories
+    # containing DLLs we depend on.
+    # https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
     dll_dir_handles = []
+    if os.name == 'nt' and hasattr(os, 'add_dll_directory'):
+        path_env = os.environ['PATH'].split(';')
+        for prefix_path in path_env:
+            if os.path.exists(prefix_path):
+                dll_dir_handles.append(os.add_dll_directory(prefix_path))
     try:
-        # New in Python 3.8: on Windows we should call 'add_dll_directory()' for directories
-        # containing DLLs we depend on.
-        # https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
-        if os.name == 'nt':
-            path_env = os.environ['PATH'].split(';')
-            for prefix_path in path_env:
-                if os.path.exists(prefix_path):
-                    dll_dir_handles.append(os.add_dll_directory(prefix_path))
-
-        imported_module = importlib.import_module(name, package='rclpy')
-
-        return imported_module
+        return importlib.import_module(name, package='rclpy')
     except ImportError as e:
         if e.path is not None and os.path.isfile(e.path):
             e.msg += \


### PR DESCRIPTION
New in Python 3.8, we should call os.add_dll_directory for directories
containing the DLLs we intend to import as well as their recursive
dependencies.

See https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew

Unblocks https://github.com/ros2/ci/pull/432 🤞 