### PR TITLE
Doc+fix rclpy_handle_get_pointer_from_capsule()

### DIFF
--- a/rclpy/src/rclpy_common/include/rclpy_common/handle.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/handle.h
@@ -61,7 +61,7 @@ rclpy_create_handle_capsule(void * ptr, const char * name, rclpy_handle_destruct
 
 /// Returns the object managed by the rclpy_handle_t wrapped in a PyCapsule.
 /**
- *  PyExec_RuntimeError is set if the PyCapsule is valid but the `rclpy_handle_t` is not
+ *  PyExec_RuntimeError is set if the PyCapsule is valid but the `rclpy_handle_t` is not.
  *  Any exception set by PyCapsule_GetPointer() may be set.
  *
  * \param capsule A valid PyCapsule created using rclpy_create_handle_capsule().

--- a/rclpy/src/rclpy_common/include/rclpy_common/handle.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/handle.h
@@ -61,12 +61,12 @@ rclpy_create_handle_capsule(void * ptr, const char * name, rclpy_handle_destruct
 
 /// Returns the object managed by the rclpy_handle_t wrapped in a PyCapsule.
 /**
- *  PyExec_RuntimeError is set if the PyCapsule is valid by the `rclpy_handle_t` is not
+ *  PyExec_RuntimeError is set if the PyCapsule is valid but the `rclpy_handle_t` is not
  *  Any exception set by PyCapsule_GetPointer() may be set.
  *
- * \param capsule A valid PyCapsule pointer created using rclpy_create_handle_capsule().
+ * \param capsule A valid PyCapsule created using rclpy_create_handle_capsule().
  * \param name Name of the PyCapsule.
- * \returns Pointer to the object whos lifetime is managed by the rclpy_handle_t, or NULL.
+ * \returns Pointer to the object managed by the rclpy_handle_t, or NULL on error.
  */
 RCLPY_COMMON_PUBLIC
 void *

--- a/rclpy/src/rclpy_common/include/rclpy_common/handle.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/handle.h
@@ -60,6 +60,14 @@ PyObject *
 rclpy_create_handle_capsule(void * ptr, const char * name, rclpy_handle_destructor_t destructor);
 
 /// Returns the object managed by the rclpy_handle_t wrapped in a PyCapsule.
+/**
+ *  PyExec_RuntimeError is set if the PyCapsule is valid by the `rclpy_handle_t` is not
+ *  Any exception set by PyCapsule_GetPointer() may be set.
+ *
+ * \param capsule A valid PyCapsule pointer created using rclpy_create_handle_capsule().
+ * \param name Name of the PyCapsule.
+ * \returns Pointer to the object whos lifetime is managed by the rclpy_handle_t, or NULL.
+ */
 RCLPY_COMMON_PUBLIC
 void *
 rclpy_handle_get_pointer_from_capsule(PyObject * capsule, const char * name);

--- a/rclpy/src/rclpy_common/src/handle.c
+++ b/rclpy/src/rclpy_common/src/handle.c
@@ -150,5 +150,9 @@ void *
 rclpy_handle_get_pointer_from_capsule(PyObject * capsule, const char * name)
 {
   rclpy_handle_t * handle = PyCapsule_GetPointer(capsule, name);
+  if (!handle) {
+    // Exception already set
+    return NULL;
+  }
   return _rclpy_handle_get_pointer(handle);
 }


### PR DESCRIPTION
This documents `rclpy_handle_get_pointer_from_capsule()` and fixes a case where `RuntimeError` is set when an exception was already set by [PyCapsule_GetPointer](https://docs.python.org/3.7/c-api/capsule.html#c.PyCapsule_GetPointer).