### PR TITLE
[Foxy Backport] Doc+fix rclpy_handle_get_pointer_from_capsule() (#569)

### DIFF
--- a/rclpy/src/rclpy_common/include/rclpy_common/handle.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/handle.h
@@ -60,6 +60,14 @@ PyObject *
 rclpy_create_handle_capsule(void * ptr, const char * name, rclpy_handle_destructor_t destructor);
 
 /// Returns the object managed by the rclpy_handle_t wrapped in a PyCapsule.
+/**
+ *  PyExec_RuntimeError is set if the PyCapsule is valid but the `rclpy_handle_t` is not.
+ *  Any exception set by PyCapsule_GetPointer() may be set.
+ *
+ * \param capsule A valid PyCapsule created using rclpy_create_handle_capsule().
+ * \param name Name of the PyCapsule.
+ * \returns Pointer to the object managed by the rclpy_handle_t, or NULL on error.
+ */
 RCLPY_COMMON_PUBLIC
 void *
 rclpy_handle_get_pointer_from_capsule(PyObject * capsule, const char * name);

--- a/rclpy/src/rclpy_common/src/handle.c
+++ b/rclpy/src/rclpy_common/src/handle.c
@@ -150,5 +150,9 @@ void *
 rclpy_handle_get_pointer_from_capsule(PyObject * capsule, const char * name)
 {
   rclpy_handle_t * handle = PyCapsule_GetPointer(capsule, name);
+  if (!handle) {
+    // Exception already set
+    return NULL;
+  }
   return _rclpy_handle_get_pointer(handle);
 }


### PR DESCRIPTION
* Doc+fix rclpy_handle_get_pointer_from_capsule()

Document parameters and return value
Fix case where RuntimeError is set when an exception is already set if
the PyCapsule is invalid or the PyCapsule name does not match.

Signed-off-by: Shane Loretz<sloretz@openrobotics.org>
Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>

* Typos

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>

* Period at end of sentence

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>