### PR TITLE
Fix executor behavior on shutdown

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -293,7 +293,7 @@ class Executor:
             end = start + timeout_sec
             timeout_left = timeout_sec
 
-            while self._context.ok() and not future.done():
+            while self._context.ok() and not future.done() and not self._is_shutdown:
                 self.spin_once(timeout_sec=timeout_left)
                 now = time.monotonic()
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -286,7 +286,7 @@ class Executor:
     def spin_until_future_complete(self, future: Future, timeout_sec: float = None) -> None:
         """Execute callbacks until a given future is done or a timeout occurs."""
         if timeout_sec is None or timeout_sec < 0:
-            while self._context.ok() and not future.done():
+            while self._context.ok() and not future.done() and not self._is_shutdown:
                 self.spin_once(timeout_sec=timeout_sec)
         else:
             start = time.monotonic()

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -641,6 +641,8 @@ class Executor:
                 (timeout_timer is not None and timeout_timer.handle.pointer in timers_ready)
             ):
                 raise TimeoutException()
+        if self._is_shutdown:
+            raise ShutdownException
 
     def wait_for_ready_callbacks(self, *args, **kwargs) -> Tuple[Task, WaitableEntityType, 'Node']:
         """

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -280,20 +280,20 @@ class Executor:
 
     def spin(self) -> None:
         """Execute callbacks until shutdown."""
-        while self._context.ok() and not self._is_shutdown:
+        while self._context.ok():
             self.spin_once()
 
     def spin_until_future_complete(self, future: Future, timeout_sec: float = None) -> None:
         """Execute callbacks until a given future is done or a timeout occurs."""
         if timeout_sec is None or timeout_sec < 0:
-            while self._context.ok() and not future.done() and not self._is_shutdown:
+            while self._context.ok() and not future.done():
                 self.spin_once(timeout_sec=timeout_sec)
         else:
             start = time.monotonic()
             end = start + timeout_sec
             timeout_left = timeout_sec
 
-            while self._context.ok() and not future.done() and not self._is_shutdown:
+            while self._context.ok() and not future.done():
                 self.spin_once(timeout_sec=timeout_left)
                 now = time.monotonic()
 
@@ -677,17 +677,15 @@ class SingleThreadedExecutor(Executor):
 
     def spin_once(self, timeout_sec: float = None) -> None:
         try:
-            ready_callback = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
+            handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
         except ShutdownException:
             pass
         except TimeoutException:
             pass
         else:
-            if ready_callback is not None:
-                handler, entity, node = ready_callback
-                handler()
-                if handler.exception() is not None:
-                    raise handler.exception()
+            handler()
+            if handler.exception() is not None:
+                raise handler.exception()
 
 
 class MultiThreadedExecutor(Executor):
@@ -711,7 +709,7 @@ class MultiThreadedExecutor(Executor):
 
     def spin_once(self, timeout_sec: float = None) -> None:
         try:
-            ready_callback = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
+            handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
         except ExternalShutdownException:
             pass
         except ShutdownException:
@@ -719,6 +717,4 @@ class MultiThreadedExecutor(Executor):
         except TimeoutException:
             pass
         else:
-            if ready_callback is not None:
-                handler, entity, node = ready_callback
-                self._executor.submit(handler)
+            self._executor.submit(handler)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -311,7 +311,7 @@ class Executor:
         :param timeout_sec: Seconds to wait. Block forever if ``None`` or negative.
             Don't wait if 0.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _take_timer(self, tmr):
         with tmr.handle as capsule:
@@ -642,7 +642,7 @@ class Executor:
             ):
                 raise TimeoutException()
         if self._is_shutdown:
-            raise ShutdownException
+            raise ShutdownException()
 
     def wait_for_ready_callbacks(self, *args, **kwargs) -> Tuple[Task, WaitableEntityType, 'Node']:
         """

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -652,15 +652,12 @@ class Executor:
         .. Including the docstring for the hidden function for reference
         .. automethod:: _wait_for_ready_callbacks
         """
-        # if an old generator is done, this var makes the loop get a new one before returning
-        got_generator = False
-        while not got_generator:
+        while True:
             if self._cb_iter is None or self._last_args != args or self._last_kwargs != kwargs:
                 # Create a new generator
                 self._last_args = args
                 self._last_kwargs = kwargs
                 self._cb_iter = self._wait_for_ready_callbacks(*args, **kwargs)
-                got_generator = True
 
             try:
                 return next(self._cb_iter)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -280,7 +280,7 @@ class Executor:
 
     def spin(self) -> None:
         """Execute callbacks until shutdown."""
-        while self._context.ok():
+        while self._context.ok() and not self._is_shutdown:
             self.spin_once()
 
     def spin_until_future_complete(self, future: Future, timeout_sec: float = None) -> None:

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -93,10 +93,8 @@ class TestExecutor(unittest.TestCase):
         for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
             executor = cls(context=self.context)
             executor.shutdown()
-            self.assertRaises(
-                ShutdownException,
-                executor.wait_for_ready_callbacks
-            )
+            with self.assertRaises(ShutdownException):
+                executor.wait_for_ready_callbacks()
 
     def test_shutdown_exception_from_callback_generator(self):
         self.assertIsNotNone(self.node.handle)
@@ -104,10 +102,8 @@ class TestExecutor(unittest.TestCase):
             executor = cls(context=self.context)
             cb_generator = executor._wait_for_ready_callbacks()
             executor.shutdown()
-            self.assertRaises(
-                ShutdownException,
-                lambda: next(cb_generator)
-            )
+            with self.assertRaises(ShutdownException):
+                next(cb_generator)
 
     def test_remove_node(self):
         self.assertIsNotNone(self.node.handle)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -19,6 +19,7 @@ import unittest
 
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import ShutdownException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.task import Future
 
@@ -86,6 +87,27 @@ class TestExecutor(unittest.TestCase):
             self.assertFalse(got_callback)
         finally:
             executor.shutdown()
+
+    def test_shutdown_executor_before_waiting_for_callbacks(self):
+        self.assertIsNotNone(self.node.handle)
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            executor = cls(context=self.context)
+            executor.shutdown()
+            self.assertRaises(
+                ShutdownException,
+                executor.wait_for_ready_callbacks
+            )
+
+    def test_shutdown_exception_from_callback_generator(self):
+        self.assertIsNotNone(self.node.handle)
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            executor = cls(context=self.context)
+            cb_generator = executor._wait_for_ready_callbacks()
+            executor.shutdown()
+            self.assertRaises(
+                ShutdownException,
+                lambda: next(cb_generator)
+            )
 
     def test_remove_node(self):
         self.assertIsNotNone(self.node.handle)


### PR DESCRIPTION
Fixes #435 and reverts the changes in #563. 

Note that this PR makes `wait_for_ready_callbacks()` return a `Tuple[Task, WaitableEntityType, 'Node']` as it's type annotation specifies.  Before this method could return `None` and this was implicitly handled in the `spin_once` method for the single and multi thread executors.