### PR TITLE
Pass rcutils_include_dirs to cppcheck 

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -187,7 +187,7 @@ endif()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # Give cppcheck hints about macro definitions coming from outside this package
-  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rcutils_INCLUDE_DIRS})
+  get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS rcutils::rcutils INTERFACE_INCLUDE_DIRECTORIES)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_pytest REQUIRED)

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -185,6 +185,9 @@ if(NOT WIN32)
 endif()
 
 if(BUILD_TESTING)
+  # Give cppcheck hints about macro definitions coming from outside this package
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rcutils_INCLUDE_DIRS})
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -185,9 +185,6 @@ if(NOT WIN32)
 endif()
 
 if(BUILD_TESTING)
-  # Give cppcheck hints about macro definitions coming from outside this package
-  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rcutils_INCLUDE_DIRS})
-
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -186,6 +186,8 @@ endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # Give cppcheck hints about macro definitions coming from outside this package
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rcutils_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_pytest REQUIRED)


### PR DESCRIPTION
This fixes the rclpy's `unknown macro` error on osx and windows, but it may not be the best strategy, cuz it will require manually pass in `include_dirs` to cppcheck in all other repos listed on this test report https://ci.ros2.org/view/nightly/job/nightly_win_rel/1576/testReport/

We've encountered the same error before and managed to fix it in this ticket https://github.com/ament/ament_lint/issues/116/ I'm not sure why this is happening again. 

Original issue https://github.com/ros2/ros2/issues/942