### PR TITLE
improve error message if rclpy C extensions are not found

### DIFF
--- a/rclpy/rclpy/impl/__init__.py
+++ b/rclpy/rclpy/impl/__init__.py
@@ -14,6 +14,7 @@
 
 import importlib
 import os
+from pathlib import Path
 
 from rpyutils import add_dll_directories_from_env
 
@@ -28,10 +29,9 @@ def _import(name):
     except ImportError as e:
         if e.path is None:
             import sysconfig
-            expected_path = os.path.join(
-                os.path.dirname(os.path.dirname(__file__)),
+            expected_path = Path(__file__).parents[1] / (
                 name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
-            assert not os.path.isfile(expected_path)
+            assert not expected_path.is_file()
             e.msg += \
                 f"\nThe C extension '{expected_path}' isn't present on the " \
                 "system. Please refer to 'https://index.ros.org/doc/ros2/" \

--- a/rclpy/rclpy/impl/__init__.py
+++ b/rclpy/rclpy/impl/__init__.py
@@ -26,6 +26,18 @@ def _import(name):
         with add_dll_directories_from_env('PATH'):
             return importlib.import_module(name, package='rclpy')
     except ImportError as e:
+        if e.path is None:
+            import sysconfig
+            expected_path = os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
+            assert not os.path.isfile(expected_path)
+            e.msg += \
+                "\nThe C extension '%s' isn't present on the system." \
+                " Please refer to '%s' for possible solutions" % (
+                    expected_path,
+                    'https://index.ros.org/doc/ros2/Troubleshooting/Installation-Troubleshooting/'
+                    '#import-failing-without-library-present-on-the-system')
         if e.path is not None and os.path.isfile(e.path):
             e.msg += \
                 "\nThe C extension '%s' failed to be imported while being present on the system." \

--- a/rclpy/rclpy/impl/__init__.py
+++ b/rclpy/rclpy/impl/__init__.py
@@ -33,11 +33,11 @@ def _import(name):
                 name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
             assert not os.path.isfile(expected_path)
             e.msg += \
-                "\nThe C extension '%s' isn't present on the system." \
-                " Please refer to '%s' for possible solutions" % (
-                    expected_path,
-                    'https://index.ros.org/doc/ros2/Troubleshooting/Installation-Troubleshooting/'
-                    '#import-failing-without-library-present-on-the-system')
+                f"\nThe C extension '{expected_path}' isn't present on the " \
+                "system. Please refer to 'https://index.ros.org/doc/ros2/" \
+                'Troubleshooting/Installation-Troubleshooting/#import-' \
+                "failing-without-library-present-on-the-system' for " \
+                'possible solutions'
         if e.path is not None and os.path.isfile(e.path):
             e.msg += \
                 "\nThe C extension '%s' failed to be imported while being present on the system." \


### PR DESCRIPTION
There have been numerous tickets / questions regarding problems loading the `rclpy` C extensions (just the latest example https://answers.ros.org/question/355064/ros2-modulenotfounderror-no-module-named-rclpy_rclpy/):

> ModuleNotFoundError: No module named ‘rclpy._rclpy’

This PR adds more context to this specific failure (the expected library not being found / existing). See the referenced PR to add the linked section to the docs.