### PR TITLE
Add useful debug info when trying to publish the wrong type

### DIFF
--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -70,7 +70,7 @@ class Publisher:
             elif isinstance(msg, bytes):
                 _rclpy.rclpy_publish_raw(capsule, msg)
             else:
-                raise  TypeError('Expected {}, got {}'.format(self.msg_type, type(msg)))
+                raise TypeError('Expected {}, got {}'.format(self.msg_type, type(msg)))
 
     def get_subscription_count(self) -> int:
         """Get the amount of subscribers that this publisher has."""

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -70,7 +70,7 @@ class Publisher:
             elif isinstance(msg, bytes):
                 _rclpy.rclpy_publish_raw(capsule, msg)
             else:
-                raise TypeError()
+                raise  TypeError('Expected {}, got {}'.format(self.msg_type, type(msg)))
 
     def get_subscription_count(self) -> int:
         """Get the amount of subscribers that this publisher has."""


### PR DESCRIPTION
I stumbled upon https://stackoverflow.com/questions/62324936/ros2-typeerror-when-publishing-custom-message-to-topic-python the other day and thought: "Should be an easy fix, if you know what you did wrong" and this PR should help with that. 