### PR TITLE
[backport eloquent] improve error message if rclpy C extensions are not found

### DIFF
--- a/rclpy/rclpy/impl/__init__.py
+++ b/rclpy/rclpy/impl/__init__.py
@@ -14,12 +14,24 @@
 
 import importlib
 import os
+from pathlib import Path
 
 
 def _import(name):
     try:
         return importlib.import_module(name, package='rclpy')
     except ImportError as e:
+        if e.path is None:
+            import sysconfig
+            expected_path = Path(__file__).parents[1] / (
+                name[1:] + sysconfig.get_config_var('EXT_SUFFIX'))
+            assert not expected_path.is_file()
+            e.msg += \
+                f"\nThe C extension '{expected_path}' isn't present on the " \
+                "system. Please refer to 'https://index.ros.org/doc/ros2/" \
+                'Troubleshooting/Installation-Troubleshooting/#import-' \
+                "failing-without-library-present-on-the-system' for " \
+                'possible solutions'
         if e.path is not None and os.path.isfile(e.path):
             e.msg += \
                 "\nThe C extension '%s' failed to be imported while being present on the system." \


### PR DESCRIPTION
Backport of #580.