### PR TITLE
add QoSProfile.__str__

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -268,6 +268,11 @@ class QoSProfile:
             self.__getattribute__(slot) == other.__getattribute__(slot)
             for slot in self.__slots__)
 
+    def __str__(self):
+        return f'{type(self).__name__}(%s)' % (
+            ', '.join(f'{slot[1:]}=%s' % getattr(self, slot) for slot in self.__slots__)
+        )
+
 
 class QoSPolicyEnum(IntEnum):
     """


### PR DESCRIPTION
I found it helpful to print all the attributes of a `QoSProfile` instance.

CI builds testing `rclpy`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11393)](http://ci.ros2.org/job/ci_linux/11393/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6614)](http://ci.ros2.org/job/ci_linux-aarch64/6614/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9340)](http://ci.ros2.org/job/ci_osx/9340/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11286)](http://ci.ros2.org/job/ci_windows/11286/)