### PR TITLE
Node get fully qualified name

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1660,6 +1660,11 @@ class Node:
         with self.handle as capsule:
             return _rclpy.rclpy_get_node_names_and_namespaces_with_enclaves(capsule)
 
+    def get_fully_qualified_name(self) -> str:
+        """Get the node's fully qualified name"""
+        with self.handle as capsule:
+            return _rclpy.rclpy_node_get_fully_qualified_name(capsule)
+
     def _count_publishers_or_subscribers(self, topic_name, func):
         fq_topic_name = expand_topic_name(topic_name, self.get_name(), self.get_namespace())
         validate_full_topic_name(fq_topic_name)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1661,7 +1661,11 @@ class Node:
             return _rclpy.rclpy_get_node_names_and_namespaces_with_enclaves(capsule)
 
     def get_fully_qualified_name(self) -> str:
-        """Get the node's fully qualified name"""
+        """
+        Get the node's fully qualified name.
+
+        :return: Fully qualified node name.
+        """
         with self.handle as capsule:
             return _rclpy.rclpy_node_get_fully_qualified_name(capsule)
 

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3797,6 +3797,15 @@ rclpy_get_node_names_and_namespaces_with_enclaves(
   return rclpy_get_node_names_impl(args, true);
 }
 
+/// Get the fully qualified name of the node.
+/**
+ *  Raises ValueError if pynode is not a node capsule
+ *  Raises RuntimeError  if there is an rcl error
+ *
+ * \param[in] pynode Capsule pointing to the node
+ * \return None on failure
+ *         String containing the fully qualified name of the node otherwise
+ */
 static PyObject *
 rclpy_node_get_fully_qualified_name(PyObject * Py_UNUSED(self), PyObject * args)
 {

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -3797,6 +3797,28 @@ rclpy_get_node_names_and_namespaces_with_enclaves(
   return rclpy_get_node_names_impl(args, true);
 }
 
+static PyObject *
+rclpy_node_get_fully_qualified_name(PyObject * Py_UNUSED(self), PyObject * args)
+{
+  PyObject * pynode;
+
+  if (!PyArg_ParseTuple(args, "O", &pynode)) {
+    return NULL;
+  }
+
+  rcl_node_t * node = rclpy_handle_get_pointer_from_capsule(pynode, "rcl_node_t");
+  if (!node) {
+    return NULL;
+  }
+
+  const char * fully_qualified_node_name = rcl_node_get_fully_qualified_name(node);
+  if (!fully_qualified_node_name) {
+    Py_RETURN_NONE;
+  }
+
+  return PyUnicode_FromString(fully_qualified_node_name);
+}
+
 /// Get a list of service names and types associated with the given node name.
 /**
  * Raises ValueError if pynode is not a node capsule
@@ -5771,6 +5793,12 @@ static PyMethodDef rclpy_methods[] = {
     rclpy_get_node_names_and_namespaces_with_enclaves,
     METH_VARARGS,
     "Get node names, namespaces, and enclaves list from graph API."
+  },
+  {
+    "rclpy_node_get_fully_qualified_name",
+    rclpy_node_get_fully_qualified_name,
+    METH_VARARGS,
+    "Get the fully qualified name of node."
   },
   {
     "rclpy_get_node_parameters", rclpy_get_node_parameters, METH_VARARGS,

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1862,7 +1862,8 @@ class TestCreateNode(unittest.TestCase):
             context=context,
             cli_args=['--ros-args', '-r', '__ns:=' + remapped_ns]
         )
-        assert node_with_remapped_ns.get_fully_qualified_name() == '{}/{}'.format(remapped_ns, name)
+        expected_name = '{}/{}'.format(remapped_ns, name)
+        assert node_with_remapped_ns.get_fully_qualified_name() == expected_name
         node_with_remapped_ns.destroy_node()
 
         node_with_remapped_name = rclpy.create_node(
@@ -1871,7 +1872,8 @@ class TestCreateNode(unittest.TestCase):
             context=context,
             cli_args=['--ros-args', '-r', '__node:=' + remapped_name]
         )
-        assert node_with_remapped_name.get_fully_qualified_name() == '{}/{}'.format(ns, remapped_name)
+        expected_name = '{}/{}'.format(ns, remapped_name)
+        assert node_with_remapped_name.get_fully_qualified_name() == expected_name
         node_with_remapped_name.destroy_node()
 
         node_with_remapped_ns_name = rclpy.create_node(
@@ -1880,7 +1882,8 @@ class TestCreateNode(unittest.TestCase):
             context=context,
             cli_args=['--ros-args', '-r', '__node:=' + remapped_name, '-r', '__ns:=' + remapped_ns]
         )
-        assert node_with_remapped_ns_name.get_fully_qualified_name() == '{}/{}'.format(remapped_ns, remapped_name)
+        expected_name = '{}/{}'.format(remapped_ns, remapped_name)
+        assert node_with_remapped_ns_name.get_fully_qualified_name() == expected_name
         node_with_remapped_ns_name.destroy_node()
 
         rclpy.shutdown(context=context)
@@ -1896,7 +1899,8 @@ class TestCreateNode(unittest.TestCase):
             namespace=ns,
             context=g_context,
         )
-        assert node_with_global_arguments.get_fully_qualified_name() == '{}/{}'.format(ns, global_remap_name)
+        expected_name = '{}/{}'.format(ns, global_remap_name)
+        assert node_with_global_arguments.get_fully_qualified_name() == expected_name
         node_with_global_arguments.destroy_node()
 
         node_skip_global_params = rclpy.create_node(


### PR DESCRIPTION
Add the binding to c function rcl_node_get_fully_qualified_name, which will be used in the composition API. Refer to the cpp implementation:
https://github.com/ros2/rclcpp/blob/9a7e33f3b18dcc631fb36a0806a4868384e19477/rclcpp_components/src/component_manager.cpp#L214