### PR TITLE
relax rate jitter test for individual periods

### DIFF
--- a/rclpy/test/test_rate.py
+++ b/rclpy/test/test_rate.py
@@ -22,7 +22,8 @@ from rclpy.executors import SingleThreadedExecutor
 # Hz
 FREQ = 10.0
 PERIOD = 1.0 / FREQ
-PASS_MAX_JITTER = PERIOD * 0.1
+PASS_MAX_AVERAGE_JITTER = PERIOD * 0.1
+PASS_MAX_SINGLE_JITTER = PERIOD * 0.25
 
 
 class RateRunner:
@@ -84,8 +85,8 @@ class TestRate:
         while not runner.done:
             self.executor.spin_once()
 
-        assert runner.max_jitter <= PASS_MAX_JITTER, str(runner)
-        assert abs(runner.avg_period - PERIOD) <= PASS_MAX_JITTER, str(runner)
+        assert runner.max_jitter <= PASS_MAX_SINGLE_JITTER, str(runner)
+        assert abs(runner.avg_period - PERIOD) <= PASS_MAX_AVERAGE_JITTER, str(runner)
 
     def test_rate_invalid_period(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #513.

The test uses a timer with a rate of 100ms and expected each and every period to not have a jitter of more than 10ms. On a non-realtime system (especially Windows) that isn't a realistic expectation. Therefore this test has been flaky for a while: https://ci.ros2.org/view/nightly/job/nightly_win_rel/1613/testReport/rclpy.rclpy.test.test_rate/TestRate/test_rate_valid_period/

The patch continues to check for a maximum jitter of 10ms over the *average* of all deltas: `abs(runner.avg_period - PERIOD) <= PASS_MAX_AVERAGE_JITTER`. If there are some outliers the average should still be close.

But the check for the biggest individual delta is relaxed from 10ms to 25ms since checking for 10ms on each period is more of a performance test (which isn't satisfies across all platforms all the time): `runner.max_jitter <= PASS_MAX_SINGLE_JITTER`

The usual CI builds testing only `rclpy`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11476)](http://ci.ros2.org/job/ci_linux/11476/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6682)](http://ci.ros2.org/job/ci_linux-aarch64/6682/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9414)](http://ci.ros2.org/job/ci_osx/9414/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11372)](http://ci.ros2.org/job/ci_windows/11372/)

And an extra `retest-until fail 3` on Windows Release: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11371)](https://ci.ros2.org/job/ci_windows/11371/)