### PR TITLE
Destroy event handlers owned by publishers/subscriptions when calling publisher.destroy()/subscription.destroy()

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1411,7 +1411,7 @@ class Node:
         if subscription in self.__subscriptions:
             self.__subscriptions.remove(subscription)
             for event_handler in subscription.event_handlers:
-                self.__waitables.remove(handler)
+                self.__waitables.remove(event_handler)
             try:
                 subscription.destroy()
             except InvalidHandle:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1392,6 +1392,8 @@ class Node:
         """
         if publisher in self.__publishers:
             self.__publishers.remove(publisher)
+            for event_handler in publisher.event_handlers:
+                self.__waitables.remove(event_handler)
             try:
                 publisher.destroy()
             except InvalidHandle:
@@ -1408,6 +1410,8 @@ class Node:
         """
         if subscription in self.__subscriptions:
             self.__subscriptions.remove(subscription)
+            for event_handler in subscription.event_handlers:
+                self.__waitables.remove(handler)
             try:
                 subscription.destroy()
             except InvalidHandle:

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -19,6 +19,7 @@ from rclpy.handle import Handle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
+from rclpy.qos_event import QoSEventHandler
 
 MsgType = TypeVar('MsgType')
 
@@ -53,7 +54,7 @@ class Publisher:
         self.topic = topic
         self.qos_profile = qos_profile
 
-        self.event_handlers = event_callbacks.create_event_handlers(
+        self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
             callback_group, publisher_handle)
 
     def publish(self, msg: Union[MsgType, bytes]) -> None:
@@ -87,6 +88,8 @@ class Publisher:
         return self.__handle
 
     def destroy(self):
+        for handler in self.event_handlers:
+            handler.destroy()
         self.handle.destroy()
 
     def assert_liveliness(self) -> None:

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -188,7 +188,9 @@ class QoSEventHandler(Waitable):
         """Add entites to wait set."""
         with self._event_handle as event_capsule:
             self._event_index = _rclpy.rclpy_wait_set_add_entity('event', wait_set, event_capsule)
-    # End Waitable API
+
+    def destroy(self):
+        self._event_handle.destroy()
 
 
 class SubscriptionEventCallbacks:

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -19,6 +19,7 @@ from rclpy.callback_groups import CallbackGroup
 from rclpy.handle import Handle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.qos import QoSProfile
+from rclpy.qos_event import QoSEventHandler
 from rclpy.qos_event import SubscriptionEventCallbacks
 
 
@@ -67,7 +68,7 @@ class Subscription:
         self.qos_profile = qos_profile
         self.raw = raw
 
-        self.event_handlers = event_callbacks.create_event_handlers(
+        self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
             callback_group, subscription_handle)
 
     @property
@@ -75,6 +76,8 @@ class Subscription:
         return self.__handle
 
     def destroy(self):
+        for handler in self.event_handlers:
+            handler.destroy()
         self.handle.destroy()
 
     @property

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import unittest
 from unittest.mock import Mock
 
@@ -53,6 +54,9 @@ class TestQoSEvent(unittest.TestCase):
     def tearDown(self):
         self.node.destroy_node()
         rclpy.shutdown(context=self.context)
+        del self.context
+        del self.node
+        gc.collect()
 
     def test_publisher_constructor(self):
         callbacks = PublisherEventCallbacks()

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -54,9 +54,6 @@ class TestQoSEvent(unittest.TestCase):
     def tearDown(self):
         self.node.destroy_node()
         rclpy.shutdown(context=self.context)
-        del self.node
-        del self.context
-        gc.collect()
 
     def test_publisher_constructor(self):
         callbacks = PublisherEventCallbacks()

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -54,8 +54,8 @@ class TestQoSEvent(unittest.TestCase):
     def tearDown(self):
         self.node.destroy_node()
         rclpy.shutdown(context=self.context)
-        del self.context
         del self.node
+        del self.context
         gc.collect()
 
     def test_publisher_constructor(self):

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import unittest
 from unittest.mock import Mock
 


### PR DESCRIPTION
The other half of https://github.com/ros2/rclpy/pull/601 to completely fix https://github.com/ros2/rclpy/issues/588.

The assumption in comment https://github.com/ros2/rclpy/blob/be1deb6746ae260a88c47aa2399f3fd6f5bfddc9/rclpy/test/test_qos_event.py#L271-L272 was wrong because some of the objects created in the previous test cases were still around.