### PR TITLE
MultiThreadedExecutor spin_until_future complete should not continue waiting when the future is done

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -324,7 +324,7 @@ class Executor:
         Wait for and execute a single callback.
 
         This should behave in the same way as :meth:`spin_once`.
-        If needed by the implementation, it should be awake other threads waiting.
+        If needed by the implementation, it should awake other threads waiting.
 
         :param future: The executor will wait until this future is done.
         :param timeout_sec: Maximum seconds to wait. Block forever if ``None`` or negative.

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -735,7 +735,7 @@ class MultiThreadedExecutor(Executor):
     def _spin_once_impl(
         self,
         timeout_sec: float = None,
-        wait_condition: Callable[[], bool] = lambda: True
+        wait_condition: Callable[[], bool] = lambda: False
     ) -> None:
         try:
             handler, entity, node = self.wait_for_ready_callbacks(

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -755,4 +755,5 @@ class MultiThreadedExecutor(Executor):
         self._spin_once_impl(timeout_sec)
 
     def spin_once_until_future_complete(self, future: Future, timeout_sec: float = None) -> None:
+        future.add_done_callback(lambda x: self.wake())
         self._spin_once_impl(timeout_sec, future.done)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -460,7 +460,8 @@ class Executor:
         :param timeout_sec: Seconds to wait. Block forever if ``None`` or negative.
             Don't wait if 0.
         :param nodes: A list of nodes to wait on. Wait on all nodes if ``None``.
-        :param condition: A callable that makes the function return immediately when it evaluates to True.
+        :param condition: A callable that makes the function return immediately when it evaluates
+            to True.
         """
         timeout_timer = None
         timeout_nsec = timeout_sec_to_nsec(timeout_sec)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -460,7 +460,7 @@ class Executor:
         :param timeout_sec: Seconds to wait. Block forever if ``None`` or negative.
             Don't wait if 0.
         :param nodes: A list of nodes to wait on. Wait on all nodes if ``None``.
-        :param condition: A callable that makes the function return immedaitely when it's True.
+        :param condition: A callable that makes the function return immediately when it evaluates to True.
         """
         timeout_timer = None
         timeout_nsec = timeout_sec_to_nsec(timeout_sec)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -449,7 +449,7 @@ class Executor:
         self,
         timeout_sec: float = None,
         nodes: List['Node'] = None,
-        condition: Callable[[], bool] = lambda: True,
+        condition: Callable[[], bool] = lambda: False,
     ) -> Generator[Tuple[Task, WaitableEntityType, 'Node'], None, None]:
         """
         Yield callbacks that are ready to be executed.


### PR DESCRIPTION
Fixes https://github.com/ros2/rclpy/issues/585.