### PR TITLE
skip test relying on source timestamps with Connext

### DIFF
--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -19,6 +19,7 @@ from rcl_interfaces.srv import GetParameters
 import rclpy
 import rclpy.executors
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.utilities import get_rmw_implementation_identifier
 
 
 # TODO(sloretz) Reduce fudge once wait_for_service uses node graph events
@@ -91,6 +92,10 @@ class TestClient(unittest.TestCase):
             self.node.destroy_client(cli)
             self.node.destroy_service(srv)
 
+    # https://github.com/ros2/rmw_connext/issues/405
+    @unittest.skipIf(
+        get_rmw_implementation_identifier() == 'rmw_connext_cpp',
+        reason='Source timestamp not implemented for Connext')
     def test_service_timestamps(self):
         cli = self.node.create_client(GetParameters, 'get/parameters')
         srv = self.node.create_service(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -44,6 +44,7 @@ from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time_source import USE_SIM_TIME_NAME
+from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'
@@ -139,6 +140,10 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     def dummy_cb(self, msg):
         pass
 
+    # https://github.com/ros2/rmw_connext/issues/405
+    @unittest.skipIf(
+        get_rmw_implementation_identifier() == 'rmw_connext_cpp',
+        reason='Source timestamp not implemented for Connext')
     def test_take(self):
         basic_types_pub = self.node.create_publisher(BasicTypes, 'take_test', 1)
         sub = self.node.create_subscription(


### PR DESCRIPTION
Skip test with Connext which have been failing since they have been added:
* ros2/rclpy#545: http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/42/testReport/rclpy.rclpy.test.test_client/TestClient/test_service_timestamps/
* ros2/rclpy#542: http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/42/testReport/rclpy.rclpy.test.test_node/TestNodeAllowUndeclaredParameters/test_take/

The missing feature is ticketed in ros2/rmw_connext#405.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11858)](https://ci.ros2.org/job/ci_linux/11858/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11861)](https://ci.ros2.org/job/ci_linux/11861/)