### PR TITLE
[foxy backport] Add pytest.ini so tests succeed without warnings when run locally. (#587)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Backport #587 to Foxy.

This should help resolve one of the outstanding failures in ros2/ci#503