### PR TITLE
fix _get_parameter_types_callback Enum to ParameterType conversion

### DIFF
--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -85,7 +85,7 @@ class ParameterService:
     def _get_parameter_types_callback(self, request, response):
         node = self._get_node()
         for name in request.names:
-            response.types.append(node.get_parameter_or(name).type_)
+            response.types.append(node.get_parameter_or(name).type_.value)
         return response
 
     def _list_parameters_callback(self, request, response):


### PR DESCRIPTION
As discussed in #618, this fixes the conversion from Python Enum type to the `int` type in `ParameterType.msg`.

Before:
```
...
"parameter_service.py", line 90, in _get_parameter_types_callback
response.types.append(node.get_parameter_or(name).type_)
TypeError: an integer is required (got type Type)
```

Fixes #618 