### PR TITLE
Add in semicolon on RCUTILS_LOGGING_AUTOINIT.

### DIFF
--- a/rclpy/src/rclpy/_rclpy_logging.c
+++ b/rclpy/src/rclpy/_rclpy_logging.c
@@ -170,7 +170,7 @@ rclpy_logging_rcutils_log(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  RCUTILS_LOGGING_AUTOINIT
+  RCUTILS_LOGGING_AUTOINIT;
   rcutils_log_location_t logging_location = {function_name, file_name, line_number};
   rcutils_log(&logging_location, severity, name, "%s", message);
   Py_RETURN_NONE;


### PR DESCRIPTION
This makes it look more like a C statement.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This goes along with https://github.com/ros2/rcutils/pull/290 ; see that PR for CI.