### PR TITLE
[foxy] Destroy event handlers owned by publishers/subscriptions when calling publisher.destroy()/subscription.destroy() (#603)

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1392,6 +1392,8 @@ class Node:
         """
         if publisher in self.__publishers:
             self.__publishers.remove(publisher)
+            for event_handler in publisher.event_handlers:
+                self.__waitables.remove(event_handler)
             try:
                 publisher.destroy()
             except InvalidHandle:
@@ -1408,6 +1410,8 @@ class Node:
         """
         if subscription in self.__subscriptions:
             self.__subscriptions.remove(subscription)
+            for event_handler in subscription.event_handlers:
+                self.__waitables.remove(event_handler)
             try:
                 subscription.destroy()
             except InvalidHandle:

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -19,6 +19,7 @@ from rclpy.handle import Handle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
+from rclpy.qos_event import QoSEventHandler
 
 MsgType = TypeVar('MsgType')
 
@@ -53,7 +54,7 @@ class Publisher:
         self.topic = topic
         self.qos_profile = qos_profile
 
-        self.event_handlers = event_callbacks.create_event_handlers(
+        self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
             callback_group, publisher_handle)
 
     def publish(self, msg: Union[MsgType, bytes]) -> None:
@@ -87,6 +88,8 @@ class Publisher:
         return self.__handle
 
     def destroy(self):
+        for handler in self.event_handlers:
+            handler.destroy()
         self.handle.destroy()
 
     def assert_liveliness(self) -> None:

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -176,7 +176,9 @@ class QoSEventHandler(Waitable):
         """Add entites to wait set."""
         with self._event_handle as event_capsule:
             self._event_index = _rclpy.rclpy_wait_set_add_entity('event', wait_set, event_capsule)
-    # End Waitable API
+
+    def destroy(self):
+        self._event_handle.destroy()
 
 
 class SubscriptionEventCallbacks:

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -19,6 +19,7 @@ from rclpy.callback_groups import CallbackGroup
 from rclpy.handle import Handle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.qos import QoSProfile
+from rclpy.qos_event import QoSEventHandler
 from rclpy.qos_event import SubscriptionEventCallbacks
 
 
@@ -67,7 +68,7 @@ class Subscription:
         self.qos_profile = qos_profile
         self.raw = raw
 
-        self.event_handlers = event_callbacks.create_event_handlers(
+        self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
             callback_group, subscription_handle)
 
     @property
@@ -75,6 +76,8 @@ class Subscription:
         return self.__handle
 
     def destroy(self):
+        for handler in self.event_handlers:
+            handler.destroy()
         self.handle.destroy()
 
     @property


### PR DESCRIPTION
Backport #603 to Foxy.