### PR TITLE
Make sure to use Py_XDECREF in rclpy_get_service_names_and_types

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4254,7 +4254,7 @@ cleanup:
     PyErr_Format(
       RCLError,
       "Failed to destroy service_names_and_types: %s", rcl_get_error_string().str);
-    Py_DECREF(pyservice_names_and_types);
+    Py_XDECREF(pyservice_names_and_types);
     rcl_reset_error();
     return NULL;
   }


### PR DESCRIPTION
When there is an error, it is possible that pyservice_names_and_types
is NULL, so make sure to use Py_XDECREF when cleaning up.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>