### PR TITLE
Deprecate verbose qos policy value names

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1128,7 +1128,7 @@ class Node:
         :param topic: The name of the topic the publisher will publish to.
         :param qos_profile: A QoSProfile or a history depth to apply to the publisher.
           In the case that a history depth is provided, the QoS history is set to
-          RMW_QOS_POLICY_HISTORY_KEEP_LAST, the QoS history depth is set to the value
+          KEEP_LAST, the QoS history depth is set to the value
           of the parameter, and all other QoS settings are set to their default values.
         :param callback_group: The callback group for the publisher's event handlers.
             If ``None``, then the node's default callback group is used.
@@ -1188,7 +1188,7 @@ class Node:
             received by the subscription.
         :param qos_profile: A QoSProfile or a history depth to apply to the subscription.
           In the case that a history depth is provided, the QoS history is set to
-          RMW_QOS_POLICY_HISTORY_KEEP_LAST, the QoS history depth is set to the value
+          KEEP_LAST, the QoS history depth is set to the value
           of the parameter, and all other QoS settings are set to their default values.
         :param callback_group: The callback group for the subscription. If ``None``, then the
             nodes default callback group is used.

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -96,7 +96,7 @@ class Publisher:
         """
         Manually assert that this Publisher is alive.
 
-        If the QoS Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC, the
+        If the QoS Liveliness policy is set to MANUAL_BY_TOPIC, the
         application must call this at least as often as ``QoSProfile.liveliness_lease_duration``.
         """
         with self.handle as capsule:

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -321,6 +321,7 @@ def _deprecated_policy_value_aliases(pairs):
         return policy_cls
     return decorator
 
+
 @_deprecated_policy_value_aliases((
     ('RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT', 'SYSTEM_DEFAULT'),
     ('RMW_QOS_POLICY_HISTORY_KEEP_LAST', 'KEEP_LAST'),

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4421,8 +4421,8 @@ rclpy_get_rmw_qos_profile(PyObject * Py_UNUSED(self), PyObject * args)
 
 /// Manually assert that an entity is alive.
 /**
-  * When using RMW_QOS_POLICY_MANUAL_BY_TOPIC, the application must call this function at least as
-  * often as the qos policy liveliness_lease_duration.
+  * When using RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC, the application must call this function
+  * at least as often as the qos policy liveliness_lease_duration.
   * The passed entity can be a Publisher.
   *
   * Raises RuntimeError on failure to assert liveliness

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -249,11 +249,11 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # Add a publisher
         qos_profile = QoSProfile(
             depth=10,
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+            history=QoSHistoryPolicy.KEEP_ALL,
             deadline=Duration(seconds=1, nanoseconds=12345),
             lifespan=Duration(seconds=20, nanoseconds=9887665),
-            reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
             liveliness_lease_duration=Duration(seconds=5, nanoseconds=23456),
             liveliness=QoSLivelinessPolicy.MANUAL_BY_TOPIC)
         self.node.create_publisher(BasicTypes, topic_name, qos_profile)
@@ -272,11 +272,11 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # Add a subscription
         qos_profile2 = QoSProfile(
             depth=0,
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+            history=QoSHistoryPolicy.KEEP_LAST,
             deadline=Duration(seconds=15, nanoseconds=1678),
             lifespan=Duration(seconds=29, nanoseconds=2345),
-            reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.VOLATILE,
             liveliness_lease_duration=Duration(seconds=5, nanoseconds=23456),
             liveliness=QoSLivelinessPolicy.AUTOMATIC)
         self.node.create_subscription(BasicTypes, topic_name, lambda msg: print(msg), qos_profile2)

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -36,20 +36,20 @@ class TestQosProfile(unittest.TestCase):
     def test_depth_only_constructor(self):
         qos = QoSProfile(depth=1)
         assert qos.depth == 1
-        assert qos.history == QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST
+        assert qos.history == QoSHistoryPolicy.KEEP_LAST
 
     def test_eq_operator(self):
-        profile_1 = QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=1)
+        profile_1 = QoSProfile(history=QoSHistoryPolicy.KEEP_LAST, depth=1)
         profile_same = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=1)
+            history=QoSHistoryPolicy.KEEP_LAST, depth=1)
         profile_different_depth = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth=2)
+            history=QoSHistoryPolicy.KEEP_LAST, depth=2)
         profile_different_duration = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+            history=QoSHistoryPolicy.KEEP_LAST,
             depth=1,
             deadline=Duration(seconds=2))
         profile_equal_duration = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+            history=QoSHistoryPolicy.KEEP_LAST,
             depth=1,
             deadline=Duration(seconds=2))
 
@@ -59,37 +59,37 @@ class TestQosProfile(unittest.TestCase):
         self.assertEqual(profile_different_duration, profile_equal_duration)
 
     def test_simple_round_trip(self):
-        source_profile = QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL)
+        source_profile = QoSProfile(history=QoSHistoryPolicy.KEEP_ALL)
         self.convert_and_assert_equality(source_profile)
 
     def test_big_nanoseconds(self):
         # Under 31 bits
         no_problem = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+            history=QoSHistoryPolicy.KEEP_ALL,
             lifespan=Duration(seconds=2))
         self.convert_and_assert_equality(no_problem)
 
         # Total nanoseconds in duration is too large to store in 32 bit signed int
         int32_problem = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+            history=QoSHistoryPolicy.KEEP_ALL,
             lifespan=Duration(seconds=4))
         self.convert_and_assert_equality(int32_problem)
 
         # Total nanoseconds in duration is too large to store in 32 bit unsigned int
         uint32_problem = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+            history=QoSHistoryPolicy.KEEP_ALL,
             lifespan=Duration(seconds=5))
         self.convert_and_assert_equality(uint32_problem)
 
     def test_alldata_round_trip(self):
         source_profile = QoSProfile(
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+            history=QoSHistoryPolicy.KEEP_ALL,
             depth=12,
-            reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE,
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.VOLATILE,
             lifespan=Duration(seconds=4),
             deadline=Duration(nanoseconds=1e6),
-            liveliness=QoSLivelinessPolicy.RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
+            liveliness=QoSLivelinessPolicy.MANUAL_BY_TOPIC,
             liveliness_lease_duration=Duration(nanoseconds=12),
             avoid_ros_namespace_conventions=True
         )
@@ -101,7 +101,7 @@ class TestQosProfile(unittest.TestCase):
             QoSProfile()
         with self.assertRaises(InvalidQoSProfileException):
             # History is KEEP_LAST, but no depth is provided
-            QoSProfile(history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST)
+            QoSProfile(history=QoSHistoryPolicy.KEEP_LAST)
 
     def test_policy_short_names(self):
         # Full test on History to show the mechanism works
@@ -110,13 +110,13 @@ class TestQosProfile(unittest.TestCase):
             ['system_default', 'keep_last', 'keep_all', 'unknown'])
         assert (
             QoSHistoryPolicy.get_from_short_key('system_default') ==
-            QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT.value)
+            QoSHistoryPolicy.SYSTEM_DEFAULT.value)
         assert (
             QoSHistoryPolicy.get_from_short_key('KEEP_ALL') ==
-            QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_ALL.value)
+            QoSHistoryPolicy.KEEP_ALL.value)
         assert (
             QoSHistoryPolicy.get_from_short_key('KEEP_last') ==
-            QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST.value)
+            QoSHistoryPolicy.KEEP_LAST.value)
 
     def test_preset_profiles(self):
         # Make sure the Enum does what we expect

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -170,12 +170,12 @@ class TestQoSEvent(unittest.TestCase):
         rclpy.logging._root_logger = MockLogger()
 
         qos_profile_publisher = QoSProfile(
-            depth=10, durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE)
+            depth=10, durability=QoSDurabilityPolicy.VOLATILE)
         self.node.create_publisher(EmptyMsg, self.topic_name, qos_profile_publisher)
 
         message_callback = Mock()
         qos_profile_subscription = QoSProfile(
-            depth=10, durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+            depth=10, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
         self.node.create_subscription(
             EmptyMsg, self.topic_name, message_callback, qos_profile_subscription)
 

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -95,10 +95,10 @@ class TestQosProfile(unittest.TestCase):
             'Endpoint type: INVALID\n' \
             'GID: \n' \
             'QoS profile:\n' \
-            '  Reliability: RMW_QOS_POLICY_RELIABILITY_UNKNOWN\n' \
-            '  Durability: RMW_QOS_POLICY_DURABILITY_UNKNOWN\n' \
+            '  Reliability: UNKNOWN\n' \
+            '  Durability: UNKNOWN\n' \
             '  Lifespan: 0 nanoseconds\n' \
             '  Deadline: 0 nanoseconds\n' \
-            '  Liveliness: RMW_QOS_POLICY_LIVELINESS_UNKNOWN\n' \
+            '  Liveliness: UNKNOWN\n' \
             '  Liveliness lease duration: 0 nanoseconds'
         self.assertEqual(expected_info_str, actual_info_str)


### PR DESCRIPTION
Deprecate the verbose versions (e.g. `rclpy.qos.HistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST`) in favor of the less verbose versions (e.g. `rclpy.qos.HistoryPolicy.KEEP_LAST`), so we can remove the verbose version in a future.