### PR TITLE
Qos configurability

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -233,6 +233,7 @@ if(BUILD_TESTING)
       test/test_publisher.py
       test/test_qos.py
       test/test_qos_event.py
+      test/test_qos_overriding_options.py
       test/test_rate.py
       test/test_serialization.py
       test/test_subscription.py

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -63,6 +63,8 @@ from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
 from rclpy.qos_event import SubscriptionEventCallbacks
+from rclpy.qos_overriding_options import _declare_qos_parameteres
+from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import Service
 from rclpy.subscription import Subscription
 from rclpy.time_source import TimeSource
@@ -1127,6 +1129,7 @@ class Node:
         *,
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[PublisherEventCallbacks] = None,
+        qos_overriding_options: Optional[QoSOverridingOptions] = None,
     ) -> Publisher:
         """
         Create a new publisher.
@@ -1146,9 +1149,21 @@ class Node:
 
         callback_group = callback_group or self.default_callback_group
 
+        failed = False
+        try:
+            final_topic = self.resolve_topic_or_service_name(topic)
+        except RuntimeError:
+            failed = True
+        if failed:
+            self._validate_topic_or_service_name(topic)
+
+        if qos_overriding_options is None:
+            qos_overriding_options = QoSOverridingOptions([])
+        _declare_qos_parameteres(
+            Publisher, self, final_topic, qos_profile, qos_overriding_options)
+
         # this line imports the typesupport for the message module if not already done
         check_for_type_support(msg_type)
-        failed = False
         try:
             with self.handle as node_capsule:
                 publisher_capsule = _rclpy.rclpy_create_publisher(
@@ -1184,6 +1199,7 @@ class Node:
         *,
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[SubscriptionEventCallbacks] = None,
+        qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: bool = False
     ) -> Subscription:
         """
@@ -1207,9 +1223,21 @@ class Node:
 
         callback_group = callback_group or self.default_callback_group
 
+        failed = False
+        try:
+            final_topic = self.resolve_topic_or_service_name(topic)
+        except RuntimeError:
+            failed = True
+        if failed:
+            self._validate_topic_or_service_name(topic)
+
+        if qos_overriding_options is None:
+            qos_overriding_options = QoSOverridingOptions([])
+        _declare_qos_parameteres(
+            Subscription, self, final_topic, qos_profile, qos_overriding_options)
+
         # this line imports the typesupport for the message module if not already done
         check_for_type_support(msg_type)
-        failed = False
         try:
             with self.handle as capsule:
                 subscription_capsule = _rclpy.rclpy_create_subscription(

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1151,7 +1151,7 @@ class Node:
 
         failed = False
         try:
-            final_topic = self.resolve_topic_or_service_name(topic)
+            final_topic = self.resolve_topic_name(topic)
         except RuntimeError:
             failed = True
         if failed:
@@ -1225,7 +1225,7 @@ class Node:
 
         failed = False
         try:
-            final_topic = self.resolve_topic_or_service_name(topic)
+            final_topic = self.resolve_topic_name(topic)
         except RuntimeError:
             failed = True
         if failed:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -63,7 +63,7 @@ from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
 from rclpy.qos_event import SubscriptionEventCallbacks
-from rclpy.qos_overriding_options import _declare_qos_parameteres
+from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import Service
 from rclpy.subscription import Subscription
@@ -1159,7 +1159,7 @@ class Node:
 
         if qos_overriding_options is None:
             qos_overriding_options = QoSOverridingOptions([])
-        _declare_qos_parameteres(
+        _declare_qos_parameters(
             Publisher, self, final_topic, qos_profile, qos_overriding_options)
 
         # this line imports the typesupport for the message module if not already done
@@ -1233,7 +1233,7 @@ class Node:
 
         if qos_overriding_options is None:
             qos_overriding_options = QoSOverridingOptions([])
-        _declare_qos_parameteres(
+        _declare_qos_parameters(
             Subscription, self, final_topic, qos_profile, qos_overriding_options)
 
         # this line imports the typesupport for the message module if not already done

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1153,9 +1153,10 @@ class Node:
         try:
             final_topic = self.resolve_topic_name(topic)
         except RuntimeError:
-            failed = True
-        if failed:
+            # if it's name validation error, raise a more appropriate exception.
             self._validate_topic_or_service_name(topic)
+            # else reraise the previous exception
+            raise
 
         if qos_overriding_options is None:
             qos_overriding_options = QoSOverridingOptions([])
@@ -1163,6 +1164,7 @@ class Node:
             Publisher, self, final_topic, qos_profile, qos_overriding_options)
 
         # this line imports the typesupport for the message module if not already done
+        failed = False
         check_for_type_support(msg_type)
         try:
             with self.handle as node_capsule:
@@ -1223,13 +1225,13 @@ class Node:
 
         callback_group = callback_group or self.default_callback_group
 
-        failed = False
         try:
             final_topic = self.resolve_topic_name(topic)
         except RuntimeError:
-            failed = True
-        if failed:
+            # if it's name validation error, raise a more appropriate exception.
             self._validate_topic_or_service_name(topic)
+            # else reraise the previous exception
+            raise
 
         if qos_overriding_options is None:
             qos_overriding_options = QoSOverridingOptions([])
@@ -1237,6 +1239,7 @@ class Node:
             Subscription, self, final_topic, qos_profile, qos_overriding_options)
 
         # this line imports the typesupport for the message module if not already done
+        failed = False
         check_for_type_support(msg_type)
         try:
             with self.handle as capsule:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -43,8 +43,8 @@ from rclpy.clock import Clock
 from rclpy.clock import ROSClock
 from rclpy.constants import S_TO_NS
 from rclpy.context import Context
-from rclpy.exceptions import InvalidTopicNameException
 from rclpy.exceptions import InvalidParameterValueException
+from rclpy.exceptions import InvalidTopicNameException
 from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import ParameterAlreadyDeclaredException
 from rclpy.exceptions import ParameterImmutableException

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -20,6 +20,7 @@ from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 from typing import TypeVar
 from typing import Union
@@ -530,7 +531,10 @@ class Node:
 
         return self._parameters.get(name, alternative_value)
 
-    def get_parameters_by_prefix(self, prefix: str) -> List[Parameter]:
+    def get_parameters_by_prefix(self, prefix: str) -> Dict[str, Optional[Union[
+        bool, int, float, str, bytes,
+        Sequence[bool], Sequence[int], Sequence[float], Sequence[str]
+    ]]]:
         """
         Get parameters that have a given prefix in their names as a dictionary.
 
@@ -547,16 +551,14 @@ class Node:
         :param prefix: The prefix of the parameters to get.
         :return: Dict of parameters with the given prefix.
         """
-        parameters_with_prefix = {}
         if prefix:
             prefix = prefix + PARAMETER_SEPARATOR_STRING
         prefix_len = len(prefix)
-        for parameter_name in self._parameters:
-            if parameter_name.startswith(prefix):
-                parameters_with_prefix.update(
-                    {parameter_name[prefix_len:]: self._parameters.get(parameter_name)})
-
-        return parameters_with_prefix
+        return {
+            param_name[prefix_len:]: param_value
+            for param_name, param_value in self._parameters.items()
+            if param_name.startswith(prefix)
+        }
 
     def set_parameters(self, parameter_list: List[Parameter]) -> List[SetParametersResult]:
         """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -43,6 +43,7 @@ from rclpy.clock import Clock
 from rclpy.clock import ROSClock
 from rclpy.constants import S_TO_NS
 from rclpy.context import Context
+from rclpy.exceptions import InvalidTopicNameException
 from rclpy.exceptions import InvalidParameterValueException
 from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import ParameterAlreadyDeclaredException
@@ -1154,7 +1155,10 @@ class Node:
             final_topic = self.resolve_topic_name(topic)
         except RuntimeError:
             # if it's name validation error, raise a more appropriate exception.
-            self._validate_topic_or_service_name(topic)
+            try:
+                self._validate_topic_or_service_name(topic)
+            except InvalidTopicNameException as ex:
+                raise ex from None
             # else reraise the previous exception
             raise
 
@@ -1229,7 +1233,10 @@ class Node:
             final_topic = self.resolve_topic_name(topic)
         except RuntimeError:
             # if it's name validation error, raise a more appropriate exception.
-            self._validate_topic_or_service_name(topic)
+            try:
+                self._validate_topic_or_service_name(topic)
+            except InvalidTopicNameException as ex:
+                raise ex from None
             # else reraise the previous exception
             raise
 

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -75,6 +75,18 @@ class QoSOverridingOptions:
         """Get the optional entity id."""
         return self._id
 
+    @classmethod
+    def with_default_policies(
+        cls, *,
+        callback: Optional[Callable[[QoSProfile], bool]] = None,
+        id: Optional[Text] = None
+    ) -> 'QoSOverridingOptions':
+        return cls(
+            policy_kinds=(QoSPolicyKind.HISTORY, QoSPolicyKind.DEPTH, QoSPolicyKind.RELIABILITY),
+            callback=callback,
+            id=id,
+        )
+
 
 def _declare_qos_parameteres(
     entity_type: Union[Type[Publisher], Type[Subscription]],

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -51,7 +51,7 @@ class QoSOverridingOptions:
         """
         Construct a QoSOverridingOptions object.
 
-        :param policy_kinds: Qos kinds that will have a declared parameter.
+        :param policy_kinds: QoS kinds that will have a declared parameter.
         :param callback: Callback that will be used to validate the qos profile
             after the paramter overrides get applied.
         :param entity_id: Optional identifier, to disambiguate in the case that different qos

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -73,7 +73,7 @@ class QoSOverridingOptions:
 
     @property
     def entity_id(self) -> Optional[Text]:
-        """Get the optional entity id."""
+        """Get the optional entity ID."""
         return self._entity_id
 
     @classmethod

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -145,7 +145,7 @@ def _get_qos_policy_parameter(qos: QoSProfile, policy: QoSPolicyKind) -> Paramet
     ):
         value = value.name.lower()
         if value == 'unknown':
-            raise ValueError('User provided qos profile is invalid')
+            raise ValueError('User provided QoS profile is invalid')
     if policy in (
         QoSPolicyKind.LIFESPAN, QoSPolicyKind.DEADLINE, QoSPolicyKind.LIVELINESS_LEASE_DURATION
     ):

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -39,7 +39,7 @@ class InvalidQosOverridesError(Exception):
 
 
 class QoSOverridingOptions:
-    """Options to customize qos parameter overrides."""
+    """Options to customize QoS parameter overrides."""
 
     def __init__(
         self,

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -24,6 +24,7 @@ from rcl_interfaces.msg import ParameterDescriptor
 
 import rclpy
 from rclpy.duration import Duration
+from rclpy.exceptions import ParameterAlreadyDeclaredException
 from rclpy.parameter import Parameter
 from rclpy.publisher import Publisher
 from rclpy.qos import QoSPolicyKind
@@ -120,10 +121,13 @@ def _declare_qos_parameters(
         descriptor = ParameterDescriptor()
         descriptor.description = description.format(policy_name)
         descriptor.read_only = True
-        param = node.declare_parameter(
-            name.format(policy_name),
-            _get_qos_policy_parameter(qos, policy),
-            descriptor)
+        try:
+            param = node.declare_parameter(
+                name.format(policy_name),
+                _get_qos_policy_parameter(qos, policy),
+                descriptor)
+        except ParameterAlreadyDeclaredException:
+            param = node.get_parameter(name.format(policy_name))
         _override_qos_policy_with_param(qos, policy, param)
     if options.callback is not None and not options.callback(qos):
         raise InvalidQosOverridesError(

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -103,7 +103,7 @@ def _declare_qos_parameteres(
     :param node: Node used to declare the parameters.
     :param topic_name: Topic name of the entity being created.
     :param qos: Default QoS settings of the entity being created, that will be overridden
-        with the user provided qos parameter overrides.
+        with the user provided QoS parameter overrides.
     :param options: Options that indicates which parameters are going to be declared.
     """
     if not issubclass(entity_type, (Publisher, Subscription)):

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -52,7 +52,7 @@ class QoSOverridingOptions:
         Construct a QoSOverridingOptions object.
 
         :param policy_kinds: QoS kinds that will have a declared parameter.
-        :param callback: Callback that will be used to validate the qos profile
+        :param callback: Callback that will be used to validate the QoS profile
             after the paramter overrides get applied.
         :param entity_id: Optional identifier, to disambiguate in the case that different qos
             policies for the same topic are desired.

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -89,7 +89,7 @@ class QoSOverridingOptions:
         )
 
 
-def _declare_qos_parameteres(
+def _declare_qos_parameters(
     entity_type: Union[Type[Publisher], Type[Subscription]],
     node: 'Node',
     topic_name: Text,

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -63,7 +63,7 @@ class QoSOverridingOptions:
 
     @property
     def policy_kinds(self) -> Iterable[QoSPolicyKind]:
-        """Get qos policy kinds that will have a parameter override."""
+        """Get QoS policy kinds that will have a parameter override."""
         return self._policy_kinds
 
     @property

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -102,7 +102,7 @@ def _declare_qos_parameteres(
     :param entity_type: Either `rclpy.node.Publisher` or `rclpy.node.Subscription`.
     :param node: Node used to declare the parameters.
     :param topic_name: Topic name of the entity being created.
-    :param qos: Default qos settings of the entity being created, that will be overriden
+    :param qos: Default QoS settings of the entity being created, that will be overridden
         with the user provided qos parameter overrides.
     :param options: Options that indicates which parameters are going to be declared.
     """

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -169,7 +169,7 @@ def _override_qos_policy_with_param(qos: QoSProfile, policy: QoSPolicyKind, para
             value = policy_enum_class[value.upper()]
         except KeyError:
             raise RuntimeError(
-                f'Unexpected qos override for policy `{policy.name.lower()}`: `{value}`')
+                f'Unexpected QoS override for policy `{policy.name.lower()}`: `{value}`')
     if policy in (
         QoSPolicyKind.LIFESPAN, QoSPolicyKind.DEADLINE, QoSPolicyKind.LIVELINESS_LEASE_DURATION
     ):

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -127,7 +127,7 @@ def _declare_qos_parameteres(
         _override_qos_policy_with_param(qos, policy, param)
     if options.callback is not None and not options.callback(qos):
         raise InvalidQosOverridesError(
-            description.format('Provided qos overrides') + ', are not valid')
+            description.format('Provided QoS overrides') + ', are not valid')
 
 
 def _get_allowed_policies(entity_type: Union[Type[Publisher], Type[Subscription]]):

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -97,7 +97,7 @@ def _declare_qos_parameteres(
     options: QoSOverridingOptions
 ) -> QoSProfile:
     """
-    Declare qos parameters for a Publisher or a Subscription.
+    Declare QoS parameters for a Publisher or a Subscription.
 
     :param entity_type: Either `rclpy.node.Publisher` or `rclpy.node.Subscription`.
     :param node: Node used to declare the parameters.

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -137,7 +137,7 @@ def _get_allowed_policies(entity_type: Union[Type[Publisher], Type[Subscription]
     return allowed_policies
 
 
-def _get_qos_policy_parameter(qos: QoSProfile, policy: QoSPolicyKind) -> Parameter:
+def _get_qos_policy_parameter(qos: QoSProfile, policy: QoSPolicyKind) -> Union[str, int, bool]:
     value = getattr(qos, policy.name.lower())
     if policy in (
         QoSPolicyKind.LIVELINESS, QoSPolicyKind.RELIABILITY,

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -17,18 +17,21 @@ from typing import Iterable
 from typing import Optional
 from typing import Text
 from typing import Type
+from typing import TYPE_CHECKING
 from typing import Union
 
 from rcl_interfaces.msg import ParameterDescriptor
 
 import rclpy
 from rclpy.duration import Duration
-from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.publisher import Publisher
 from rclpy.qos import QoSPolicyKind
 from rclpy.qos import QoSProfile
 from rclpy.subscription import Subscription
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
 
 
 class InvalidQosOverridesError(Exception):
@@ -40,8 +43,8 @@ class QoSOverridingOptions:
 
     def __init__(
         self,
-        *,
         policy_kinds: Iterable[QoSPolicyKind],
+        *,
         callback: Optional[Callable[[QoSProfile], bool]] = None,
         entity_id: Optional[Text] = None
     ):
@@ -88,12 +91,13 @@ class QoSOverridingOptions:
 
 def _declare_qos_parameteres(
     entity_type: Union[Type[Publisher], Type[Subscription]],
-    node: Node,
+    node: 'Node',
     topic_name: Text,
     qos: QoSProfile,
-    options: QoSOverridingOptions) -> QoSProfile:
+    options: QoSOverridingOptions
+) -> QoSProfile:
     """
-    Internal, declare qos parameters for a Publisher or a Subscription.
+    Declare qos parameters for a Publisher or a Subscription.
 
     :param entity_type: Either `rclpy.node.Publisher` or `rclpy.node.Subscription`.
     :param node: Node used to declare the parameters.
@@ -103,7 +107,7 @@ def _declare_qos_parameteres(
     :param options: Options that indicates which parameters are going to be declared.
     """
     if not issubclass(entity_type, (Publisher, Subscription)):
-        raise TypeError("Argument `entity_type` should be a subclass of Publisher or Subscription")
+        raise TypeError('Argument `entity_type` should be a subclass of Publisher or Subscription')
     entity_type_str = 'publisher' if issubclass(entity_type, Publisher) else Subscription
     id_suffix = '' if options.entity_id is None else f'_{options.entity_id}'
     name = f'qos_overrides.{topic_name}.{entity_type_str}{id_suffix}.' '{}'
@@ -160,7 +164,7 @@ def _override_qos_policy_with_param(qos: QoSProfile, policy: QoSPolicyKind, para
             return x[0].upper() + x[1:]
         # e.g. `policy=QosPolicyKind.LIVELINESS` -> `policy_enum_class=rclpy.qos.LivelinessPolicy`
         policy_enum_class = getattr(
-            rclpy.qos, f"{capitalize_first_letter(policy_name)}Policy")
+            rclpy.qos, f'{capitalize_first_letter(policy_name)}Policy')
         try:
             value = policy_enum_class[value.upper()]
         except KeyError:

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -108,7 +108,7 @@ def _declare_qos_parameteres(
     """
     if not issubclass(entity_type, (Publisher, Subscription)):
         raise TypeError('Argument `entity_type` should be a subclass of Publisher or Subscription')
-    entity_type_str = 'publisher' if issubclass(entity_type, Publisher) else Subscription
+    entity_type_str = 'publisher' if issubclass(entity_type, Publisher) else 'subscription'
     id_suffix = '' if options.entity_id is None else f'_{options.entity_id}'
     name = f'qos_overrides.{topic_name}.{entity_type_str}{id_suffix}.' '{}'
     description = '{}' f' for {entity_type_str} `{topic_name}` with id `{options.entity_id}`'

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -54,7 +54,7 @@ class QoSOverridingOptions:
         :param policy_kinds: QoS kinds that will have a declared parameter.
         :param callback: Callback that will be used to validate the QoS profile
             after the paramter overrides get applied.
-        :param entity_id: Optional identifier, to disambiguate in the case that different qos
+        :param entity_id: Optional identifier, to disambiguate in the case that different QoS
             policies for the same topic are desired.
         """
         self._policy_kinds = policy_kinds

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -1,0 +1,170 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+from typing import Iterable
+from typing import Optional
+from typing import Text
+from typing import Type
+from typing import Union
+
+from rcl_interfaces.msg import ParameterDescriptor
+
+import rclpy
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from rclpy.publisher import Publisher
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSPolicyKind
+from rclpy.subscription import Subscription
+
+
+class InvalidQosOverridesError(Exception):
+    pass
+
+
+class QoSOverridingOptions:
+    """
+    Options to customize qos parameter overrides.
+    """
+
+    def __init__(
+        self,
+        *,
+        policy_kinds: Iterable[QoSPolicyKind],
+        callback: Optional[Callable[[QoSProfile], bool]] = None,
+        id: Optional[Text] = None
+    ):
+        """
+        Construct a QoSOverridingOptions object.
+
+        :param policy_kinds: Qos kinds that will have a declared parameter.
+        :param callback: Callback that will be used to validate the qos profile
+            after the paramter overrides get applied.
+        :param id: Optional identifier, to disambiguate in the case that different qos
+            policies for the same topic are desired.
+        """
+        self._policy_kinds = policy_kinds
+        self._callback = callback
+        self._id = id
+
+    @property
+    def policy_kinds(self) -> Iterable[QoSPolicyKind]:
+        """Get qos policy kinds that will have a parameter override."""
+        return self._policy_kinds
+
+    @property
+    def callback(self) -> Optional[Callable[[QoSProfile], bool]]:
+        """Get the validation callback."""
+        return self._callback
+
+    @property
+    def id(self) -> Optional[Text]:
+        """Get the optional entity id."""
+        return self._id
+
+
+def _declare_qos_parameteres(
+    entity_type: Union[Type[Publisher], Type[Subscription]],
+    node: Node,
+    topic_name: Text,
+    qos: QoSProfile,
+    options: QoSOverridingOptions) -> QoSProfile:
+    """
+    Internal.
+    Declares qos parameters for a Publisher or a Subscription.
+
+    :param entity_type: Either `rclpy.node.Publisher` or `rclpy.node.Subscription`.
+    :param node: Node used to declare the parameters.
+    :param topic_name: Topic name of the entity being created.
+    :param qos: Default qos settings of the entity being created, that will be overriden
+        with the user provided qos parameter overrides.
+    :param options: Options that indicates which parameters are going to be declared.
+    """
+    if not issubclass(entity_type, (Publisher, Subscription)):
+        raise TypeError("Argument `entity_type` should be a subclass of Publisher or Subscription")
+    entity_type_str = 'publisher' if issubclass(entity_type, Publisher) else Subscription
+    id_suffix = '' if options.id is None else f'_{options.id}'
+    name = f'qos_overrides.{topic_name}.{entity_type_str}{id_suffix}.' '{}'
+    description = '{}' f' for {entity_type_str} `{topic_name}` with id `{id}`'
+    allowed_policies = _get_allowed_policies(entity_type)
+    for policy in options.policy_kinds:
+        if policy not in allowed_policies:
+            continue
+        policy_name = policy.name.lower()
+        descriptor = ParameterDescriptor()
+        descriptor.description = description.format(policy_name)
+        descriptor.read_only = True
+        param = node.declare_parameter(
+            name.format(policy_name),
+            _get_qos_policy_parameter(qos, policy),
+            descriptor)
+        _override_qos_policy_with_param(qos, policy, param)
+    if options.callback is not None and not options.callback(qos):
+        raise InvalidQosOverridesError(
+            description.format('Provided qos overrides') + ', are not valid')
+
+
+def _get_allowed_policies(entity_type: Union[Type[Publisher], Type[Subscription]]):
+    allowed_policies = list(QoSPolicyKind.__members__.values())
+    if issubclass(entity_type, Subscription):
+        allowed_policies.remove(QoSPolicyKind.LIFESPAN)
+    return allowed_policies
+
+
+def _get_qos_policy_parameter(qos: QoSProfile, policy: QoSPolicyKind) -> Parameter:
+    value = getattr(qos, policy.name.lower())
+    if policy in (
+        QoSPolicyKind.LIVELINESS, QoSPolicyKind.RELIABILITY,
+        QoSPolicyKind.HISTORY, QoSPolicyKind.DURABILITY
+    ):
+        value = value.name.lower()
+        if value == 'unknown':
+            raise ValueError('User provided qos profile is invalid')
+    if policy in (
+        QoSPolicyKind.LIFESPAN, QoSPolicyKind.DEADLINE, QoSPolicyKind.LIVELINESS_LEASE_DURATION
+    ):
+        value = value.nanoseconds()
+    return value
+
+
+def _override_qos_policy_with_param(qos: QoSProfile, policy: QoSPolicyKind, param: Parameter):
+    # policy_enum_map = {
+    #     QoSPolicyKind.LIVELINESS: rclpy.qos.LivelinessPolicy,
+    #     QoSPolicyKind.RELIABILITY: rclpy.qos.LivelinessPolicy,
+    #     QoSPolicyKind.LIVELINESS: rclpy.qos.LivelinessPolicy,
+    #     QoSPolicyKind.LIVELINESS: rclpy.qos.LivelinessPolicy,
+    # }
+    value = param.value
+    policy_name = policy.name.lower()
+    if policy in (
+        QoSPolicyKind.LIVELINESS, QoSPolicyKind.RELIABILITY,
+        QoSPolicyKind.HISTORY, QoSPolicyKind.DURABILITY
+    ):
+        def capitalize_first_letter(x):
+            return x[0].upper() + x[1:]
+        # e.g. `policy=QosPolicyKind.LIVELINESS` -> `policy_enum_class=rclpy.qos.LivelinessPolicy`
+        policy_enum_class = getattr(
+            rclpy.qos, f"{capitalize_first_letter(policy_name)}Policy")
+        try:
+            value = policy_enum_class[value.upper()]
+        except KeyError:
+            raise RuntimeError(
+                f'Unexpected qos override for policy `{policy.name.lower()}`: `{value}`')
+    if policy in (
+        QoSPolicyKind.LIFESPAN, QoSPolicyKind.DEADLINE, QoSPolicyKind.LIVELINESS_LEASE_DURATION
+    ):
+        value = Duration(nanoseconds=value)
+    setattr(qos, policy.name.lower(), value)

--- a/rclpy/test/test_qos_overriding_options.py
+++ b/rclpy/test/test_qos_overriding_options.py
@@ -18,7 +18,6 @@ import rclpy
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.publisher import Publisher
-from rclpy.qos import QoSPolicyKind
 from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import _declare_qos_parameteres
 from rclpy.qos_overriding_options import InvalidQosOverridesError
@@ -76,7 +75,7 @@ def test_declare_qos_parameters_with_overrides():
 
 
 def test_declare_qos_parameters_with_happy_callback():
-    node = Node("my_node")
+    node = Node('my_node')
     _declare_qos_parameteres(
         Publisher, node, '/my_topic', QoSProfile(depth=10),
         QoSOverridingOptions.with_default_policies(callback=lambda x: True)

--- a/rclpy/test/test_qos_overriding_options.py
+++ b/rclpy/test/test_qos_overriding_options.py
@@ -56,22 +56,23 @@ def test_declare_qos_parameters_with_overrides():
         Parameter('qos_overrides./my_topic.publisher.depth', value=100),
         Parameter('qos_overrides./my_topic.publisher.reliability', value='best_effort'),
     ])
-    _declare_qos_parameters(
-        Publisher, node, '/my_topic', QoSProfile(depth=10),
-        QoSOverridingOptions.with_default_policies()
-    )
-    qos_overrides = node.get_parameters_by_prefix('qos_overrides')
-    assert len(qos_overrides) == 3
-    expected_params = (
-        ('/my_topic.publisher.depth', 100),
-        ('/my_topic.publisher.history', 'keep_last'),
-        ('/my_topic.publisher.reliability', 'best_effort'),
-    )
-    for actual, expected in zip(
-        sorted(qos_overrides.items(), key=lambda x: x[0]), expected_params
-    ):
-        assert actual[0] == expected[0]  # same param name
-        assert actual[1].value == expected[1]  # same param value
+    for i in range(2):  # try twice, the second time the parameters will be get and not declared
+        _declare_qos_parameters(
+            Publisher, node, '/my_topic', QoSProfile(depth=10),
+            QoSOverridingOptions.with_default_policies()
+        )
+        qos_overrides = node.get_parameters_by_prefix('qos_overrides')
+        assert len(qos_overrides) == 3
+        expected_params = (
+            ('/my_topic.publisher.depth', 100),
+            ('/my_topic.publisher.history', 'keep_last'),
+            ('/my_topic.publisher.reliability', 'best_effort'),
+        )
+        for actual, expected in zip(
+            sorted(qos_overrides.items(), key=lambda x: x[0]), expected_params
+        ):
+            assert actual[0] == expected[0]  # same param name
+            assert actual[1].value == expected[1]  # same param value
 
 
 def test_declare_qos_parameters_with_happy_callback():

--- a/rclpy/test/test_qos_overriding_options.py
+++ b/rclpy/test/test_qos_overriding_options.py
@@ -19,7 +19,7 @@ from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.publisher import Publisher
 from rclpy.qos import QoSProfile
-from rclpy.qos_overriding_options import _declare_qos_parameteres
+from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import InvalidQosOverridesError
 from rclpy.qos_overriding_options import QoSOverridingOptions
 
@@ -33,7 +33,7 @@ def init_shutdown():
 
 def test_declare_qos_parameters():
     node = Node('my_node')
-    _declare_qos_parameteres(
+    _declare_qos_parameters(
         Publisher, node, '/my_topic', QoSProfile(depth=10),
         QoSOverridingOptions.with_default_policies()
     )
@@ -56,7 +56,7 @@ def test_declare_qos_parameters_with_overrides():
         Parameter('qos_overrides./my_topic.publisher.depth', value=100),
         Parameter('qos_overrides./my_topic.publisher.reliability', value='best_effort'),
     ])
-    _declare_qos_parameteres(
+    _declare_qos_parameters(
         Publisher, node, '/my_topic', QoSProfile(depth=10),
         QoSOverridingOptions.with_default_policies()
     )
@@ -76,7 +76,7 @@ def test_declare_qos_parameters_with_overrides():
 
 def test_declare_qos_parameters_with_happy_callback():
     node = Node('my_node')
-    _declare_qos_parameteres(
+    _declare_qos_parameters(
         Publisher, node, '/my_topic', QoSProfile(depth=10),
         QoSOverridingOptions.with_default_policies(callback=lambda x: True)
     )
@@ -98,7 +98,7 @@ def test_declare_qos_parameters_with_unhappy_callback():
     node = Node('my_node')
 
     with pytest.raises(InvalidQosOverridesError):
-        _declare_qos_parameteres(
+        _declare_qos_parameters(
             Publisher, node, '/my_topic', QoSProfile(depth=10),
             QoSOverridingOptions.with_default_policies(callback=lambda x: False)
         )
@@ -106,7 +106,7 @@ def test_declare_qos_parameters_with_unhappy_callback():
 
 def test_declare_qos_parameters_with_id():
     node = Node('my_node')
-    _declare_qos_parameteres(
+    _declare_qos_parameters(
         Publisher, node, '/my_topic', QoSProfile(depth=10),
         QoSOverridingOptions.with_default_policies(entity_id='i_have_an_id')
     )

--- a/rclpy/test/test_qos_overriding_options.py
+++ b/rclpy/test/test_qos_overriding_options.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+from rclpy.publisher import Publisher
+from rclpy.qos import QoSPolicyKind, QoSProfile
+from rclpy.qos_overriding_options import _declare_qos_parameteres, QoSOverridingOptions
+
+
+def test_declare_qos_parameters():
+    rclpy.init()
+    node = Node("my_node")
+    _declare_qos_parameteres(
+        Publisher, node, '/my_topic', QoSProfile(depth=10),
+        QoSOverridingOptions(policy_kinds=(QoSPolicyKind.RELIABILITY, QoSPolicyKind.HISTORY))
+    )
+    rclpy.shutdown()

--- a/rclpy/test/test_qos_overriding_options.py
+++ b/rclpy/test/test_qos_overriding_options.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import rclpy
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 from rclpy.publisher import Publisher
 from rclpy.qos import QoSPolicyKind, QoSProfile
-from rclpy.qos_overriding_options import _declare_qos_parameteres, QoSOverridingOptions
+from rclpy.qos_overriding_options import _declare_qos_parameteres
+from rclpy.qos_overriding_options import InvalidQosOverridesError
+from rclpy.qos_overriding_options import QoSOverridingOptions
 
 
 def test_declare_qos_parameters():
@@ -24,6 +29,97 @@ def test_declare_qos_parameters():
     node = Node("my_node")
     _declare_qos_parameteres(
         Publisher, node, '/my_topic', QoSProfile(depth=10),
-        QoSOverridingOptions(policy_kinds=(QoSPolicyKind.RELIABILITY, QoSPolicyKind.HISTORY))
+        QoSOverridingOptions.with_default_policies()
     )
+    qos_overrides = node.get_parameters_by_prefix('qos_overrides')
+    assert len(qos_overrides) == 3
+    expected_params = (
+        ('/my_topic.publisher.depth', 10),
+        ('/my_topic.publisher.history', 'keep_last'),
+        ('/my_topic.publisher.reliability', 'reliable'),
+    )
+    for actual, expected in zip (
+        sorted(qos_overrides.items(), key=lambda x: x[0]), expected_params
+    ):
+        assert actual[0] == expected[0]  # same param name
+        assert actual[1].value == expected[1]  # same param value
+
+    rclpy.shutdown()
+
+
+def test_declare_qos_parameters_with_overrides():
+    rclpy.init()
+    node = Node("my_node", parameter_overrides=[
+        Parameter('qos_overrides./my_topic.publisher.depth', value=100),
+        Parameter('qos_overrides./my_topic.publisher.reliability', value='best_effort'),
+    ])
+    _declare_qos_parameteres(
+        Publisher, node, '/my_topic', QoSProfile(depth=10),
+        QoSOverridingOptions.with_default_policies()
+    )
+    qos_overrides = node.get_parameters_by_prefix('qos_overrides')
+    assert len(qos_overrides) == 3
+    expected_params = (
+        ('/my_topic.publisher.depth', 100),
+        ('/my_topic.publisher.history', 'keep_last'),
+        ('/my_topic.publisher.reliability', 'best_effort'),
+    )
+    for actual, expected in zip (
+        sorted(qos_overrides.items(), key=lambda x: x[0]), expected_params
+    ):
+        assert actual[0] == expected[0]  # same param name
+        assert actual[1].value == expected[1]  # same param value
+
+    rclpy.shutdown()
+
+
+def test_declare_qos_parameters_with_happy_callback():
+    rclpy.init()
+    node = Node("my_node")
+    _declare_qos_parameteres(
+        Publisher, node, '/my_topic', QoSProfile(depth=10),
+        QoSOverridingOptions.with_default_policies(callback=lambda x: True)
+    )
+    qos_overrides = node.get_parameters_by_prefix('qos_overrides')
+    assert len(qos_overrides) == 3
+    expected_params = (
+        ('/my_topic.publisher.depth', 10),
+        ('/my_topic.publisher.history', 'keep_last'),
+        ('/my_topic.publisher.reliability', 'reliable'),
+    )
+    rclpy.shutdown()
+
+
+def test_declare_qos_parameters_with_unhappy_callback():
+    rclpy.init()
+    node = Node("my_node")
+
+    with pytest.raises(InvalidQosOverridesError):
+        _declare_qos_parameteres(
+            Publisher, node, '/my_topic', QoSProfile(depth=10),
+            QoSOverridingOptions.with_default_policies(callback=lambda x: False)
+        )
+    rclpy.shutdown()
+
+
+def test_declare_qos_parameters_with_id():
+    rclpy.init()
+    node = Node("my_node")
+    _declare_qos_parameteres(
+        Publisher, node, '/my_topic', QoSProfile(depth=10),
+        QoSOverridingOptions.with_default_policies(id='i_have_an_id')
+    )
+    qos_overrides = node.get_parameters_by_prefix('qos_overrides')
+    assert len(qos_overrides) == 3
+    expected_params = (
+        ('/my_topic.publisher_i_have_an_id.depth', 10),
+        ('/my_topic.publisher_i_have_an_id.history', 'keep_last'),
+        ('/my_topic.publisher_i_have_an_id.reliability', 'reliable'),
+    )
+    for actual, expected in zip (
+        sorted(qos_overrides.items(), key=lambda x: x[0]), expected_params
+    ):
+        assert actual[0] == expected[0]  # same param name
+        assert actual[1].value == expected[1]  # same param value
+
     rclpy.shutdown()


### PR DESCRIPTION
~Depends on https://github.com/ros2/rclpy/pull/636.~ (update:merged)
Equivalent to https://github.com/ros2/rclcpp/pull/1408.

It adds all the needed helper function and classes to enable qos configurability.
~I haven't yet modified `Node.create_publisher` and `Node.create_subscription`.~ (update: done)