### PR TITLE
qos_policy_name_from_kind() should accept either a QoSPolicyKind or an int

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -14,6 +14,7 @@
 
 from enum import Enum
 from enum import IntEnum
+from typing import Union
 
 import warnings
 
@@ -42,9 +43,9 @@ class QoSPolicyKind(IntEnum):
     AVOID_ROS_NAMESPACE_CONVENTIONS = 1 << 9,
 
 
-def qos_policy_name_from_kind(policy_kind: QoSPolicyKind):
+def qos_policy_name_from_kind(policy_kind: Union[QoSPolicyKind, int]):
     """Get QoS policy name from QoSPolicyKind enum."""
-    return policy_kind.name
+    return QoSPolicyKind(policy_kind).name
 
 
 class InvalidQoSProfileException(Exception):

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -187,12 +187,12 @@ class TestQoSEvent(unittest.TestCase):
                 pub_log_msg,
                 "New subscription discovered on topic '{}', requesting incompatible QoS. "
                 'No messages will be sent to it. '
-                'Last incompatible policy: DURABILITY_QOS_POLICY'.format(self.topic_name))
+                'Last incompatible policy: DURABILITY'.format(self.topic_name))
             self.assertEqual(
                 sub_log_msg,
                 "New publisher discovered on topic '{}', offering incompatible QoS. "
                 'No messages will be received from it. '
-                'Last incompatible policy: DURABILITY_QOS_POLICY'.format(self.topic_name))
+                'Last incompatible policy: DURABILITY'.format(self.topic_name))
 
         rclpy.logging._root_logger = original_logger
 


### PR DESCRIPTION
Fix error introduced in https://github.com/ros2/rclpy/pull/634.

`qos_policy_name_from_kind()` was previously accepting either `QoSPolicyKind` or an `int` (which wasn't properly documented in the type annotation).
The changes introduced on that function only accepted a `QoSPolicyKind`, this patch reintroduce `int` support.

Here https://github.com/ros2/rclpy/blob/0a3a2bf895e0e50a66433c185fa60b9aa9bf7632/rclpy/rclpy/qos_event.py#L251
`event.last_policy_kind` is an `int`.

The error wasn't caught because fastrtps doesn't support the feature, but it the following nightlies were failing:
- http://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_focal_amd64/
- http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/