### PR TITLE
Use Py_XDECREF for pytopic_names_and_types.

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -4220,7 +4220,7 @@ cleanup:
     PyErr_Format(
       RCLError,
       "Failed to destroy topic_names_and_types: %s", rcl_get_error_string().str);
-    Py_DECREF(pytopic_names_and_types);
+    Py_XDECREF(pytopic_names_and_types);
     rcl_reset_error();
     return NULL;
   }


### PR DESCRIPTION
If we got here through PyList_New failing, then pytopic_names_and_types
could be NULL.  Therefore, we need to use Py_XDECREF to handle
the situation.  Pointed out by clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>