### PR TITLE
added wake executor to Node.create_subscription to fix issue 628

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1268,6 +1268,7 @@ class Node:
             raise
         self.__subscriptions.append(subscription)
         callback_group.add_entity(subscription)
+        self._wake_executor()
 
         for event_handler in subscription.event_handlers:
             self.add_waitable(event_handler)


### PR DESCRIPTION
As @ivanpauno suggested, this PR fixes https://github.com/ros2/rclpy/issues/628
