### PR TITLE
Don't throw an exception if timer canceled while sleeping.

### DIFF
--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -131,6 +131,7 @@ class Rate:
                 self._event.clear()
         if self._is_shutdown:
             self.destroy()
+            raise ROSInterruptException()
 
     def sleep(self):
         """

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -131,7 +131,6 @@ class Rate:
                 self._event.clear()
         if self._is_shutdown:
             self.destroy()
-            raise ROSInterruptException()
 
     def sleep(self):
         """

--- a/rclpy/test/test_rate.py
+++ b/rclpy/test/test_rate.py
@@ -17,6 +17,7 @@ import time
 
 import pytest
 import rclpy
+from rclpy.exceptions import ROSInterruptException
 from rclpy.executors import SingleThreadedExecutor
 
 # Hz
@@ -129,7 +130,7 @@ def test_shutdown_wakes_rate():
 
     rate = node.create_rate(0.0000001)
 
-    _thread = threading.Thread(target=sleep_check_exception, args=rate, daemon=True)
+    _thread = threading.Thread(target=sleep_check_exception, args=(rate,), daemon=True)
     _thread.start()
     executor.shutdown()
     node.destroy_node()

--- a/rclpy/test/test_rate.py
+++ b/rclpy/test/test_rate.py
@@ -111,6 +111,15 @@ class TestRate:
         self._thread.join()
 
 
+def sleep_check_exception(rate):
+    try:
+        rate.sleep()
+    except ROSInterruptException:
+        # rate.sleep() can raise ROSInterruptException if the context is
+        # shutdown while it is sleeping.  Just ignore it here.
+        pass
+
+
 def test_shutdown_wakes_rate():
     context = rclpy.context.Context()
     rclpy.init(context=context)
@@ -120,7 +129,7 @@ def test_shutdown_wakes_rate():
 
     rate = node.create_rate(0.0000001)
 
-    _thread = threading.Thread(target=rate.sleep, daemon=True)
+    _thread = threading.Thread(target=sleep_check_exception, args=rate, daemon=True)
     _thread.start()
     executor.shutdown()
     node.destroy_node()


### PR DESCRIPTION
It is a valid situation that may happen sometimes in threading,
so just quietly clean ourselves up and don't throw an
exception.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This resolves the failures we are seeing in the latest CI builds, e.g. https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/1447/testReport/junit/rclpy.rclpy.test/test_rate/test_shutdown_wakes_rate/ .

Here's a build where I ran the tests 10 times with this patch in place: https://ci.ros2.org/job/ci_linux-aarch64/8191/

@sloretz I'd appreciate a look by you, since you put this code in to start with.  I'm not sure if what I'm doing here is OK.