### PR TITLE
Use Pybind11's CMake functions for pycapsule lib

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -25,6 +25,8 @@ find_package(rmw_implementation_cmake REQUIRED)
 
 find_package(python_cmake_module REQUIRED)
 find_package(PythonExtra MODULE REQUIRED)
+find_package(pybind11_vendor REQUIRED)
+find_package(pybind11 REQUIRED)
 
 set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
 
@@ -159,11 +161,18 @@ ament_target_dependencies(rclpy_signal_handler
 )
 
 # Pycapsule handling library
-add_library(
-  rclpy_pycapsule
-  SHARED src/rclpy/_rclpy_pycapsule.c
+pybind11_add_module(_rclpy_pycapsule SHARED
+  src/rclpy/_rclpy_pycapsule.c
 )
-configure_python_c_extension_library(rclpy_pycapsule)
+# Install into test_rclpy folder in build space for unit tests to import
+set_target_properties(_rclpy_pycapsule PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_rclpy"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_rclpy")
+# Install library for actual use
+install(
+  TARGETS _rclpy_pycapsule
+  DESTINATION "${PYTHON_INSTALL_DIR}/rclpy"
+)
 
 # Handle library, used to keep dependencies between C objects.
 add_library(

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -166,8 +166,9 @@ pybind11_add_module(_rclpy_pycapsule SHARED
 )
 # Install into test_rclpy folder in build space for unit tests to import
 set_target_properties(_rclpy_pycapsule PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_rclpy"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_rclpy")
+  # Use generator expression to avoid prepending a build type specific directory on Windows
+  LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/test_rclpy>
+  RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/test_rclpy>)
 # Install library for actual use
 install(
   TARGETS _rclpy_pycapsule

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>pybind11_vendor</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
-  <build_depend>pybind11</build_depend>
+  <build_depend>pybind11-dev</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
 

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -15,8 +15,10 @@
   <author email="william@openrobotics.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pybind11_vendor</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
+  <build_depend>pybind11</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
 


### PR DESCRIPTION
This is a small check to see if Pybind11's CMake function works on all
platforms. It works fine locally on ~~Linux~~ Ubuntu Focal using `CMAKE_BUILD_TYPE=Debug`.

@cottsay @IanTheEngineer FYI