### PR TITLE
Fix two clang static analysis warnings.

### DIFF
--- a/rclpy/src/rclpy/_rclpy_pycapsule.c
+++ b/rclpy/src/rclpy/_rclpy_pycapsule.c
@@ -95,6 +95,7 @@ rclpy_pycapsule_destroy(PyObject * Py_UNUSED(self), PyObject * args)
 
   if (!destructor) {
     PyErr_Format(PyExc_ValueError, "PyCapsule does not have a destructor.");
+    return NULL;
   }
 
   destructor(pycapsule);

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -308,7 +308,8 @@ rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** dest
 
   void * message = create_ros_message();
   if (!message) {
-    return PyErr_NoMemory();
+    PyErr_NoMemory();
+    return NULL;
   }
   return message;
 }


### PR DESCRIPTION
The first one in pycapsule is truly a bug; if destructor
was ever NULL, we would have reported an error and then
immediately dereferenced the NULL pointer, leading to a
crash.

The second one is a false positive.  The documentation for
PyErr_NoMemory() says that it always returns NULL, but
clang static analysis can't tell that just from the function
declaration.  Thus, call PyErr_NoMemory() to set the error,
and return NULL ourselves.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>