### PR TITLE
Use Py_XDECREF for pyresult_list.

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -516,7 +516,7 @@ cleanup:
   if (RCL_RET_OK != ret) {
     PyErr_Format(RCLError, "Failed to init: %s", rcl_get_error_string().str);
     rcl_reset_error();
-    Py_DECREF(pyresult_list);
+    Py_XDECREF(pyresult_list);
     return NULL;
   }
 


### PR DESCRIPTION
As pointed out by clang static analysis, 'pyresult_list' could
be NULL during cleanup, so make sure to use Py_XDECREF to check
for that possibility.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>