### PR TITLE
Check the rcl_action return value on cleanup.

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -256,7 +256,7 @@ _rclpy_arg_list_fini(int num_args, char ** argv)
   for (int i = 0; i < num_args; ++i) {
     char * arg = argv[i];
     if (!arg) {
-      // NULL in list means array was partially inititialized when an error occurred
+      // NULL in list means array was partially initialized when an error occurred
       break;
     }
     allocator.deallocate(arg, allocator.state);

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -16,7 +16,6 @@
 
 #include <rcl/error_handling.h>
 #include <rcl_action/rcl_action.h>
-#include <rcutils/strdup.h>
 
 #include "rclpy_common/common.h"
 #include "rclpy_common/handle.h"

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1575,11 +1575,16 @@ rclpy_action_process_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
     action_server, cancel_request, &cancel_response);
   destroy_cancel_request(cancel_request);
   if (RCL_RET_OK != ret) {
+    const char * original_error = rcl_get_error_string().str;
+    const char * extra_error = "";
     ret = rcl_action_cancel_response_fini(&cancel_response);
+    if (RCL_RET_OK != ret) {
+      extra_error = ".  Also failed to cleanup response.";
+    }
     PyErr_Format(
       PyExc_RuntimeError,
-      "Failed to process cancel request: %s",
-      rcl_get_error_string().str);
+      "Failed to process cancel request: %s%s",
+      original_error, extra_error);
     rcl_reset_error();
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -1576,13 +1576,7 @@ rclpy_action_process_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
     action_server, cancel_request, &cancel_response);
   destroy_cancel_request(cancel_request);
   if (RCL_RET_OK != ret) {
-    rcl_allocator_t allocator = rcl_get_default_allocator();
-    bool allocated_error = true;
-    char * original_error = rcutils_strdup(rcl_get_error_string().str, allocator);
-    if (original_error == NULL) {
-      original_error = "Failed to allocate memory for error";
-      allocated_error = false;
-    }
+    rcutils_error_string_t original_error = rcl_get_error_string();
     const char * extra_error = "";
     ret = rcl_action_cancel_response_fini(&cancel_response);
     if (RCL_RET_OK != ret) {
@@ -1591,10 +1585,7 @@ rclpy_action_process_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
     PyErr_Format(
       PyExc_RuntimeError,
       "Failed to process cancel request: %s%s",
-      original_error, extra_error);
-    if (allocated_error) {
-      allocator.deallocate(original_error, allocator.state);
-    }
+      original_error.str, extra_error);
     rcl_reset_error();
     return NULL;
   }

--- a/rclpy/src/rclpy/_rclpy_action.c
+++ b/rclpy/src/rclpy/_rclpy_action.c
@@ -16,6 +16,7 @@
 
 #include <rcl/error_handling.h>
 #include <rcl_action/rcl_action.h>
+#include <rcutils/strdup.h>
 
 #include "rclpy_common/common.h"
 #include "rclpy_common/handle.h"
@@ -1575,7 +1576,13 @@ rclpy_action_process_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
     action_server, cancel_request, &cancel_response);
   destroy_cancel_request(cancel_request);
   if (RCL_RET_OK != ret) {
-    const char * original_error = rcl_get_error_string().str;
+    rcl_allocator_t allocator = rcl_get_default_allocator();
+    bool allocated_error = true;
+    char * original_error = rcutils_strdup(rcl_get_error_string().str, allocator);
+    if (original_error == NULL) {
+      original_error = "Failed to allocate memory for error";
+      allocated_error = false;
+    }
     const char * extra_error = "";
     ret = rcl_action_cancel_response_fini(&cancel_response);
     if (RCL_RET_OK != ret) {
@@ -1585,6 +1592,9 @@ rclpy_action_process_cancel_request(PyObject * Py_UNUSED(self), PyObject * args)
       PyExc_RuntimeError,
       "Failed to process cancel request: %s%s",
       original_error, extra_error);
+    if (allocated_error) {
+      allocator.deallocate(original_error, allocator.state);
+    }
     rcl_reset_error();
     return NULL;
   }


### PR DESCRIPTION
And add an error message as appropriate.  clang static
analysis pointed out that this was a dead store.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>