### PR TITLE
Don't call destroy_node while spinning

### DIFF
--- a/rclpy/test/test_create_while_spinning.py
+++ b/rclpy/test/test_create_while_spinning.py
@@ -48,9 +48,9 @@ class TestCreateWhileSpinning(unittest.TestCase):
 
     def tearDown(self):
         self.executor.shutdown()
-        self.node.destroy_node()
         rclpy.shutdown()
         self.exec_thread.join()
+        self.node.destroy_node()
 
     def test_publish_subscribe(self):
         evt = threading.Event()


### PR DESCRIPTION
This causes a segfault under CycloneDDS, and I don't see an easy way to prevent it from happening. Until we get to the bottom of that, just defer the call to destroy_node until after we know the spin thread has finished.

#663 tracks the issue that this change avoids.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13530)](http://ci.ros2.org/job/ci_linux/13530/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8430)](http://ci.ros2.org/job/ci_linux-aarch64/8430/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11253)](http://ci.ros2.org/job/ci_osx/11253/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13595)](http://ci.ros2.org/job/ci_windows/13595/)