### PR TITLE
Fix the NULL check for destroy_ros_message.

### DIFF
--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -302,7 +302,7 @@ rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** dest
   *destroy_ros_message = get_capsule_pointer(
     pymetaclass, "_DESTROY_ROS_MESSAGE");
   Py_DECREF(pymetaclass);
-  if (!destroy_ros_message) {
+  if (!(*destroy_ros_message)) {
     return NULL;
   }
 


### PR DESCRIPTION
clang static analysis pointed out that the check for NULL here
was wrong.  We were checking the double pointer for NULL, not
the derefenced one that we just attempted to fill in.  Fix the
check to look at the dereferenced pointer.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>