### PR TITLE
Enforce static parameter types when dynamic typing is not specified

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -95,6 +95,19 @@ class InvalidParameterException(ParameterException):
         Exception.__init__(self, 'Invalid parameter name', parameter, *args)
 
 
+class InvalidParameterTypeException(ParameterException):
+    """Raised when rejected when applying a descriptor for being of an invalid type."""
+
+    def __init__(self, desired_parameter, expected_type, *args):
+        Exception.__init__(
+            self,
+            f"Trying to set parameter '{desired_parameter._name}' to '{desired_parameter._value}'"
+            f" of type '{type(desired_parameter._value)}', expecting type {expected_type}",
+            *args)
+        self._actual_type = desired_parameter.type_
+        self._param_name = desired_parameter.name
+
+
 class InvalidParameterValueException(ParameterException):
     """Raised when a parameter is rejected by a user callback or when applying a descriptor."""
 
@@ -110,6 +123,16 @@ class ParameterImmutableException(ParameterException):
 
     def __init__(self, parameter, *args):
         Exception.__init__(self, 'Attempted to modify read-only parameter', parameter, *args)
+
+
+class NoParameterOverrideProvidedException(ParameterException):
+    """Raised when no override is provided for a statically typed parameter with no default."""
+
+    def __init__(self, parameter_name, *args):
+        Exception.__init__(
+            self,
+            f"No parameter override provided for '{parameter_name}' when one was expected",
+            *args)
 
 
 class ROSInterruptException(Exception):

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -99,10 +99,12 @@ class InvalidParameterTypeException(ParameterException):
     """Raised when rejected when applying a descriptor for being of an invalid type."""
 
     def __init__(self, desired_parameter, expected_type, *args):
+        from rclpy.parameter import Parameter
         Exception.__init__(
             self,
             f"Trying to set parameter '{desired_parameter._name}' to '{desired_parameter._value}'"
-            f" of type '{type(desired_parameter._value)}', expecting type {expected_type}",
+            f" of type '{Parameter.Type.from_parameter_value(desired_parameter._value).name}'"
+            f", expecting type '{expected_type}'",
             *args)
         self._actual_type = desired_parameter.type_
         self._param_name = desired_parameter.name

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -96,7 +96,7 @@ class InvalidParameterException(ParameterException):
 
 
 class InvalidParameterTypeException(ParameterException):
-    """Raised when rejected when applying a descriptor for being of an invalid type."""
+    """Raised when a parameter is rejected for having an invalid type."""
 
     def __init__(self, desired_parameter, expected_type, *args):
         from rclpy.parameter import Parameter

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -25,6 +25,7 @@ from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
+import warnings
 import weakref
 
 from rcl_interfaces.msg import FloatingPointRange
@@ -43,8 +44,10 @@ from rclpy.clock import Clock
 from rclpy.clock import ROSClock
 from rclpy.constants import S_TO_NS
 from rclpy.context import Context
+from rclpy.exceptions import InvalidParameterTypeException
 from rclpy.exceptions import InvalidParameterValueException
 from rclpy.exceptions import InvalidTopicNameException
+from rclpy.exceptions import NoParameterOverrideProvidedException
 from rclpy.exceptions import NotInitializedException
 from rclpy.exceptions import ParameterAlreadyDeclaredException
 from rclpy.exceptions import ParameterImmutableException
@@ -328,7 +331,7 @@ class Node:
         self,
         name: str,
         value: Any = None,
-        descriptor: ParameterDescriptor = ParameterDescriptor(),
+        descriptor: Optional[ParameterDescriptor] = None,
         ignore_override: bool = False
     ) -> Parameter:
         """
@@ -346,13 +349,20 @@ class Node:
         :raises: InvalidParameterException if the parameter name is invalid.
         :raises: InvalidParameterValueException if the registered callback rejects the parameter.
         """
-        return self.declare_parameters('', [(name, value, descriptor)], ignore_override)[0]
+        if value is None and descriptor is None:
+            # Temporal patch so we get deprecation warning if only a name is provided.
+            args = (name, )
+        else:
+            descriptor = ParameterDescriptor() if descriptor is None else descriptor
+            args = (name, value, descriptor)
+        return self.declare_parameters('', [args], ignore_override)[0]
 
     def declare_parameters(
         self,
         namespace: str,
         parameters: List[Union[
             Tuple[str],
+            Tuple[str, Parameter.Type],
             Tuple[str, Any],
             Tuple[str, Any, ParameterDescriptor],
         ]],
@@ -401,42 +411,57 @@ class Node:
                 )
 
             value = None
-            descriptor = ParameterDescriptor()
+            param_type = None
 
             # Get the values from the tuple, checking its types.
             # Use defaults if the tuple doesn't contain value and / or descriptor.
-            try:
-                name = parameter_tuple[0]
-                assert \
-                    isinstance(name, str), \
-                    (
-                        'First element {name} at index {index} in parameters list '
-                        'is not a str.'.format_map(locals())
-                    )
+            name = parameter_tuple[0]
+            second_arg = parameter_tuple[1] if 1 < len(parameter_tuple) else None
+            descriptor = parameter_tuple[2] if 2 < len(parameter_tuple) else ParameterDescriptor()
 
-                # Get value from parameter overrides, of from tuple if it doesn't exist.
-                if not ignore_override and name in self._parameter_overrides:
-                    value = self._parameter_overrides[name].value
+            if not isinstance(name, str):
+                raise TypeError(
+                        f'First element {name} at index {index} in parameters list '
+                        'is not a str.')
+            if not isinstance(descriptor, ParameterDescriptor):
+                raise TypeError(
+                    f'Third element {descriptor} at index {index} in parameters list '
+                    'is not a ParameterDescriptor.'
+                )
+
+            if len(parameter_tuple) == 1:
+                warnings.warn(
+                    f"when declaring parmater named '{name}', "
+                    'declaring a parameter only providing its name is deprecated. '
+                    'You have to either:\n'
+                    '\t- Pass a name and a default value different to "PARAMETER NOT SET"'
+                    ' (and optionally a descriptor).\n'
+                    '\t- Pass a name and a parameter type.\n'
+                    '\t- Pass a name and a descriptor with `dynamic_typing=True',
+                    DeprecationWarning)
+                descriptor.dynamic_typing = True
+
+            if isinstance(second_arg, Parameter.Type):
+                param_type = second_arg
+            else:
+                value = second_arg
+
+            if not descriptor.dynamic_typing and value is not None:
+                # infer type from default value
+                if not isinstance(value, ParameterValue):
+                    descriptor.type = Parameter.Type.from_parameter_value(value).value
                 else:
-                    # This raises a TypeError if it's not possible to get a type from the tuple.
-                    value = parameter_tuple[1]
+                    descriptor.type = value.type
 
-                # Get descriptor from tuple.
-                descriptor = parameter_tuple[2]
-                assert \
-                    isinstance(descriptor, ParameterDescriptor), \
-                    (
-                        'Third element {descriptor} at index {index} in parameters list '
-                        'is not a ParameterDescriptor.'.format_map(locals())
-                    )
-            except AssertionError as assertion_error:
-                raise TypeError(assertion_error)
-            except IndexError:
-                # This means either value or descriptor were not defined which is fine.
-                pass
+            # Get value from parameter overrides, of from tuple if it doesn't exist.
+            if not ignore_override and name in self._parameter_overrides:
+                value = self._parameter_overrides[name].value
+
+            if value is None and not descriptor.dynamic_typing:
+                raise NoParameterOverrideProvidedException(name)
 
             if namespace:
-                name = '{namespace}.{name}'.format_map(locals())
+                name = f'{namespace}.{name}'
 
             # Note(jubeira): declare_parameters verifies the name, but set_parameters doesn't.
             validate_parameter_name(name)
@@ -643,6 +668,8 @@ class Node:
                 allow_not_set_type=allow_undeclared_parameters
             )
             if raise_on_failure and not result.successful:
+                if result.reason.startswith('Wrong parameter type'):
+                    raise InvalidParameterTypeException(param, descriptors[param._name])
                 raise InvalidParameterValueException(param.name, param.value, result.reason)
             results.append(result)
         return results
@@ -871,6 +898,15 @@ class Node:
 
         if parameter.type_ == Parameter.Type.DOUBLE and descriptor.floating_point_range:
             return self._apply_floating_point_range(parameter, descriptor.floating_point_range[0])
+
+        if not descriptor.dynamic_typing and descriptor.type != parameter.type_.value:
+            return SetParametersResult(
+                successful=False,
+                reason=(
+                    'Wrong parameter type, expected '
+                    f"'{Parameter.Type.from_parameter_msg(descriptor.type)}'"
+                    f" got '{parameter.type_}'")
+            )
 
         return SetParametersResult(successful=True)
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -438,8 +438,7 @@ class Node:
                     '\t- Pass a name and a default value different to "PARAMETER NOT SET"'
                     ' (and optionally a descriptor).\n'
                     '\t- Pass a name and a parameter type.\n'
-                    '\t- Pass a name and a descriptor with `dynamic_typing=True',
-                    DeprecationWarning)
+                    '\t- Pass a name and a descriptor with `dynamic_typing=True')
                 descriptor.dynamic_typing = True
 
             if isinstance(second_arg, Parameter.Type):

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -444,7 +444,11 @@ class Node:
             if isinstance(second_arg, Parameter.Type):
                 if second_arg.value == Parameter.Type.NOT_SET:
                     raise ValueError(
-                        'Cannot declare a statically typed parameter of type NOT_SET')
+                        f'Cannot declare parameter {{{name}}} as statically typed of type NOT_SET')
+                if descriptor.dynamic_typing is True:
+                    raise ValueError(
+                        f'When declaring parameter {{{name}}} passing a descriptor with'
+                        '`dynamic_typing=True` is not allowed when the parameter type is provided')
                 descriptor.type = second_arg.value
             else:
                 value = second_arg

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -456,8 +456,8 @@ class Node:
                     else:
                         if value.type == ParameterType.PARAMETER_NOT_SET:
                             raise ValueError(
-                                'Cannot declare a statically typed parameter with default value of '
-                                'type PARAMETER_NOT_SET')
+                                'Cannot declare a statically typed parameter with default value '
+                                'of type PARAMETER_NOT_SET')
                         descriptor.type = value.type
 
             # Get value from parameter overrides, of from tuple if it doesn't exist.
@@ -676,7 +676,8 @@ class Node:
             )
             if raise_on_failure and not result.successful:
                 if result.reason.startswith('Wrong parameter type'):
-                    raise InvalidParameterTypeException(param, Parameter.Type(descriptors[param._name].type).name)
+                    raise InvalidParameterTypeException(
+                        param, Parameter.Type(descriptors[param._name].type).name)
                 raise InvalidParameterValueException(param.name, param.value, result.reason)
             results.append(result)
         return results

--- a/rclpy/test/resources/test_node/test_parameters.yaml
+++ b/rclpy/test/resources/test_node/test_parameters.yaml
@@ -5,4 +5,4 @@
     initial_foobar: False
 /my_ns/my_node:
   ros__parameters:
-    initial_fizz: 23
+    initial_fizz: param_file_override

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -544,7 +544,8 @@ class TestNode(unittest.TestCase):
         # initial_foo and initial_fizz get override values; initial_bar does not.
         self.assertEqual(result_initial_foo.value, 4321)
         self.assertEqual(result_initial_bar.value, 'ignoring_override')
-        self.assertEqual(result_initial_fizz.value, 'param_file_override')  # provided by CLI, overridden by file
+        # provided by CLI, overridden by file
+        self.assertEqual(result_initial_fizz.value, 'param_file_override')
         self.assertEqual(result_initial_baz.value, 3.14)  # provided by file, overridden manually
         self.assertEqual(result_initial_buzz.value, 1.)  # provided by CLI
         self.assertEqual(result_initial_foobar.value, False)  # provided by file
@@ -1450,7 +1451,8 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_parameter('baz').value, 2.41)
 
         # Now undeclare one of them implicitly.
-        result = self.node.set_parameters_atomically([Parameter('bar', Parameter.Type.NOT_SET, None)])
+        result = self.node.set_parameters_atomically([
+            Parameter('bar', Parameter.Type.NOT_SET, None)])
         self.assertEqual(result.successful, True)
         self.assertEqual(self.node.get_parameter('foo').value, 42)
         self.assertFalse(self.node.has_parameter('bar'))
@@ -1574,7 +1576,7 @@ class TestNode(unittest.TestCase):
                 additional_constraints='some constraints',
                 read_only=False,
                 integer_range=[IntegerRange(from_value=-10, to_value=10, step=2)],
-                dynamic_typing = True
+                dynamic_typing=True
             )
         )
         self.assertEqual(value.type, Parameter.Type.STRING.value)
@@ -1819,8 +1821,10 @@ class TestNode(unittest.TestCase):
 
         self.assertTrue(self.node.set_parameters([Parameter('int_param', value=3)])[0].successful)
 
-        self.assertTrue(self.node.set_parameters([Parameter('dynamic_param', value='asd')])[0].successful)
-        self.assertTrue(self.node.set_parameters([Parameter('dynamic_param', value=3)])[0].successful)
+        self.assertTrue(
+            self.node.set_parameters([Parameter('dynamic_param', value='asd')])[0].successful)
+        self.assertTrue(
+            self.node.set_parameters([Parameter('dynamic_param', value=3)])[0].successful)
 
         result = self.node.set_parameters_atomically([
             Parameter('dynamic_param', value=3), Parameter('int_param', value='asd')])

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -528,9 +528,11 @@ class TestNode(unittest.TestCase):
             'bar', 'hello', ParameterDescriptor())
         result_baz = self.node.declare_parameter(
             'baz', 2.41, ParameterDescriptor())
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=UserWarning)
             result_value_not_set = self.node.declare_parameter('value_not_set')
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
 
         # OK cases.
         self.assertIsInstance(result_initial_foo, Parameter)
@@ -616,9 +618,11 @@ class TestNode(unittest.TestCase):
             self.node.declare_parameter('initial_decl_with_type', Parameter.Type.DOUBLE).value,
             3.14)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=UserWarning)
             result = self.node.declare_parameters('', parameters)
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
 
         # OK cases - using overrides.
         self.assertIsInstance(result, list)
@@ -640,9 +644,10 @@ class TestNode(unittest.TestCase):
         self.assertIsNone(self.node.get_parameter('value_not_set').value)
         self.assertTrue(self.node.has_parameter('value_not_set'))
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=UserWarning)
             result = self.node.declare_parameters('namespace', parameters)
+            assert len(w) == 1
 
         # OK cases.
         self.assertIsInstance(result, list)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -599,6 +599,12 @@ class TestNode(unittest.TestCase):
             self.node.declare_parameter(
                 'wrong_parameter_descriptor_type', 1, ParameterValue())
 
+        descriptor = ParameterDescriptor()
+        descriptor.dynamic_typing = True
+        with self.assertRaises(ValueError):
+            self.node.declare_parameter(
+                'dynamic_typing_and_static_type', Parameter.Type.DOUBLE, descriptor=descriptor)
+
     def test_declare_parameters(self):
         parameters = [
             ('initial_foo', 0, ParameterDescriptor()),

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -529,7 +529,7 @@ class TestNode(unittest.TestCase):
         result_baz = self.node.declare_parameter(
             'baz', 2.41, ParameterDescriptor())
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            warnings.filterwarnings('ignore', category=UserWarning)
             result_value_not_set = self.node.declare_parameter('value_not_set')
 
         # OK cases.
@@ -617,7 +617,7 @@ class TestNode(unittest.TestCase):
             3.14)
 
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            warnings.filterwarnings('ignore', category=UserWarning)
             result = self.node.declare_parameters('', parameters)
 
         # OK cases - using overrides.
@@ -641,7 +641,7 @@ class TestNode(unittest.TestCase):
         self.assertTrue(self.node.has_parameter('value_not_set'))
 
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            warnings.filterwarnings('ignore', category=UserWarning)
             result = self.node.declare_parameters('namespace', parameters)
 
         # OK cases.

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -16,6 +16,7 @@ import pathlib
 import time
 import unittest
 from unittest.mock import Mock
+import warnings
 
 from rcl_interfaces.msg import FloatingPointRange
 from rcl_interfaces.msg import IntegerRange
@@ -516,7 +517,9 @@ class TestNode(unittest.TestCase):
             'bar', 'hello', ParameterDescriptor())
         result_baz = self.node.declare_parameter(
             'baz', 2.41, ParameterDescriptor())
-        result_value_not_set = self.node.declare_parameter('value_not_set')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            result_value_not_set = self.node.declare_parameter('value_not_set')
 
         # OK cases.
         self.assertIsInstance(result_initial_foo, Parameter)
@@ -591,7 +594,9 @@ class TestNode(unittest.TestCase):
             ('value_not_set',)
         ]
 
-        result = self.node.declare_parameters('', parameters)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            result = self.node.declare_parameters('', parameters)
 
         # OK cases - using overrides.
         self.assertIsInstance(result, list)
@@ -613,7 +618,9 @@ class TestNode(unittest.TestCase):
         self.assertIsNone(self.node.get_parameter('value_not_set').value)
         self.assertTrue(self.node.has_parameter('value_not_set'))
 
-        result = self.node.declare_parameters('namespace', parameters)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            result = self.node.declare_parameters('namespace', parameters)
 
         # OK cases.
         self.assertIsInstance(result, list)


### PR DESCRIPTION
Equivalent to https://github.com/ros2/rclcpp/pull/1522.