### PR TITLE
Add history and depth to topic endpoint string

### DIFF
--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -164,6 +164,8 @@ class TopicEndpointInfo:
         result += 'Endpoint type: %s\n' % self.endpoint_type.name
         result += 'GID: %s\n' % '.'.join(format(x, '02x') for x in self.endpoint_gid)
         result += 'QoS profile:\n'
+        result += '  History: %s\n' % self.qos_profile.history.name
+        result += '  Depth: %s\n' % self.qos_profile.depth
         result += '  Reliability: %s\n' % self.qos_profile.reliability.name
         result += '  Durability: %s\n' % self.qos_profile.durability.name
         result += '  Lifespan: %d nanoseconds\n' % self.qos_profile.lifespan.nanoseconds

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -95,6 +95,8 @@ class TestQosProfile(unittest.TestCase):
             'Endpoint type: INVALID\n' \
             'GID: \n' \
             'QoS profile:\n' \
+            '  History: UNKNOWN\n' \
+            '  Depth: 0\n' \
             '  Reliability: UNKNOWN\n' \
             '  Durability: UNKNOWN\n' \
             '  Lifespan: 0 nanoseconds\n' \


### PR DESCRIPTION
I'm not sure why history and depth were left out originally. Maybe @jaisontj or @mm318 can answer?

AFAICT, we seem to be able to get this info from the endpoints just fine.