### PR TITLE
Include Pybind11 before Python.h

### DIFF
--- a/rclpy/src/rclpy/context.cpp
+++ b/rclpy/src/rclpy/context.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Include pybind11 before rclpy_common/handle.h includes Python.h
+#include <pybind11/pybind11.h>
+
 #include <rcl/context.h>
 #include <rcl/types.h>
 


### PR DESCRIPTION
Fixes #689

`handle.h` is including `Python.h`. Including `pybind11/pybind11.h` first makes sure the `Py_DEBUG` macro is handled in a way that avoids a warning on Windows.