### PR TITLE
rclpy_ok and rclpy_create_context to pybind11

### DIFF
--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -34,4 +34,10 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   m.def(
     "rclpy_context_get_domain_id", &rclpy::context_get_domain_id,
     "Retrieves domain ID from init_options of context");
+  m.def(
+    "rclpy_create_context", &rclpy::create_context,
+    "Create a capsule with an rcl_context_t instance");
+  m.def(
+    "rclpy_ok", &rclpy::context_is_valid,
+    "Return true if the context is valid");
 }

--- a/rclpy/src/rclpy/context.cpp
+++ b/rclpy/src/rclpy/context.cpp
@@ -16,6 +16,8 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/context.h>
+#include <rcl/error_handling.h>
+#include <rcl/rcl.h>
 #include <rcl/types.h>
 
 #include <stdexcept>
@@ -44,5 +46,77 @@ context_get_domain_id(py::capsule pycontext)
   }
 
   return domain_id;
+}
+
+void
+_rclpy_context_handle_destructor(void * p)
+{
+  auto context = static_cast<rcl_context_t *>(p);
+  if (!context) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_context_handle_destructor failed to get pointer");
+    return;
+  }
+  if (NULL != context->impl) {
+    rcl_ret_t ret;
+    if (rcl_context_is_valid(context)) {
+      // shutdown first, if still valid
+      ret = rcl_shutdown(context);
+      if (RCL_RET_OK != ret) {
+        fprintf(
+          stderr,
+          "[rclpy|" RCUTILS_STRINGIFY(__FILE__) ":" RCUTILS_STRINGIFY(__LINE__) "]: "
+          "failed to shutdown rcl_context_t (%d) during PyCapsule destructor: %s\n",
+          ret,
+          rcl_get_error_string().str);
+        rcl_reset_error();
+      }
+    }
+    ret = rcl_context_fini(context);
+    if (RCL_RET_OK != ret) {
+      fprintf(
+        stderr,
+        "[rclpy|" RCUTILS_STRINGIFY(__FILE__) ":" RCUTILS_STRINGIFY(__LINE__) "]: "
+        "failed to fini rcl_context_t (%d) during PyCapsule destructor: %s\n",
+        ret,
+        rcl_get_error_string().str);
+      rcl_reset_error();
+    }
+  }
+  PyMem_FREE(context);
+}
+
+py::capsule
+create_context()
+{
+  auto context = static_cast<rcl_context_t *>(PyMem_Malloc(sizeof(rcl_context_t)));
+  if (!context) {
+    throw std::bad_alloc();
+  }
+  *context = rcl_get_zero_initialized_context();
+  PyObject * capsule = rclpy_create_handle_capsule(
+    context, "rcl_context_t", _rclpy_context_handle_destructor);
+  if (!capsule) {
+    throw py::error_already_set();
+  }
+  return py::reinterpret_steal<py::capsule>(capsule);
+}
+
+/// Status of the the client library
+/**
+ * \return True if rcl is running properly, False otherwise
+ */
+bool
+context_is_valid(py::capsule pycontext)
+{
+  auto context = static_cast<rcl_context_t *>(rclpy_handle_get_pointer_from_capsule(
+      pycontext.ptr(), "rcl_context_t"));
+  if (!context) {
+    throw py::error_already_set();
+  }
+
+  return rcl_context_is_valid(context);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/context.hpp
+++ b/rclpy/src/rclpy/context.hpp
@@ -28,6 +28,25 @@ namespace rclpy
  */
 size_t
 context_get_domain_id(py::capsule pycontext);
+
+/// Create a capsule with an rcl_context_t instance.
+/**
+ * The returned context is zero-initialized for use with rclpy_init().
+ *
+ * Raises MemoryError if allocating memory fails.
+ * Raises RuntimeError if creating the context fails.
+ *
+ * \return capsule with the rcl_context_t instance
+ */
+py::capsule
+create_context();
+
+/// Status of the the client library
+/**
+ * \return True if rcl is running properly, False otherwise
+ */
+bool
+context_is_valid(py::capsule context);
 }  // namespace rclpy
 
 #endif  // RCLPY__CONTEXT_HPP_


### PR DESCRIPTION
Converts two `rcl_context_t` functions to pybind11, keeping the C to Python API the same.
part of #665

Make a couple functions use pybind11. These ones didn't benefit too much in the short term, but it brings `rclpy` a little closer to using pybind11 everywhere.