### PR TITLE
Convert subscription functions to pybind11

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -172,6 +172,7 @@ remove_py_debug_definition_on_win32(_rclpy)
 pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/_rclpy_pybind11.cpp
   src/rclpy/context.cpp
+  src/rclpy/subscription.cpp
 )
 target_include_directories(_rclpy_pybind11 PRIVATE
   src/rclpy/

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1009,41 +1009,6 @@ rclpy_get_publisher_logger_name(PyObject * Py_UNUSED(self), PyObject * args)
   return PyUnicode_FromString(node_logger_name);
 }
 
-/// Get the name of the logger associated with the node of the subscription.
-/**
- * Raises ValueError if pysubscription is not a subscription capsule
- *
- * \param[in] pysubscription Capsule pointing to the subscription to get the logger name of
- * \return logger_name, or
- * \return None on failure
- */
-static PyObject *
-rclpy_get_subscription_logger_name(PyObject * module, PyObject * args)
-{
-  rclpy_module_state_t * module_state = (rclpy_module_state_t *)PyModule_GetState(module);
-  if (!module_state) {
-    // exception already raised
-    return NULL;
-  }
-  PyObject * pysubscription;
-  if (!PyArg_ParseTuple(args, "O", &pysubscription)) {
-    return NULL;
-  }
-
-  rclpy_subscription_t * sub =
-    rclpy_handle_get_pointer_from_capsule(pysubscription, "rclpy_subscription_t");
-  if (NULL == sub) {
-    return NULL;
-  }
-
-  const char * node_logger_name = rcl_node_get_logger_name(sub->node);
-  if (NULL == node_logger_name) {
-    Py_RETURN_NONE;
-  }
-
-  return PyUnicode_FromString(node_logger_name);
-}
-
 typedef rcl_ret_t (* count_func)(const rcl_node_t * node, const char * topic_name, size_t * count);
 
 static PyObject *
@@ -1206,43 +1171,6 @@ static PyObject *
 rclpy_get_subscriptions_info_by_topic(PyObject * module, PyObject * args)
 {
   return _get_info_by_topic(module, args, "subscriptions", rcl_get_subscriptions_info_by_topic);
-}
-
-/// Return the resolved topic name of a subscription.
-/**
- * The returned string is the resolved topic name after remappings have be applied.
- *
- * \param[in] pynode Capsule pointing to the node to get the namespace from.
- * \return a string with the topic name
- */
-static PyObject *
-rclpy_get_subscription_topic_name(PyObject * module, PyObject * args)
-{
-  rclpy_module_state_t * module_state = (rclpy_module_state_t *)PyModule_GetState(module);
-  if (!module_state) {
-    // exception already raised
-    return NULL;
-  }
-  PyObject * pysubscription;
-  if (!PyArg_ParseTuple(args, "O", &pysubscription)) {
-    return NULL;
-  }
-
-  rclpy_subscription_t * sub =
-    rclpy_handle_get_pointer_from_capsule(pysubscription, "rclpy_subscription_t");
-  if (NULL == sub) {
-    return NULL;
-  }
-
-  const char * subscription_name = rcl_subscription_get_topic_name(&(sub->subscription));
-  if (NULL == subscription_name) {
-    PyErr_Format(
-      module_state->RCLError, "Failed to get subscription topic name: %s",
-      rcl_get_error_string().str);
-    rcl_reset_error();
-  }
-
-  return PyUnicode_FromString(subscription_name);
 }
 
 /// Validate a topic name and return error message and index of invalidation.
@@ -2519,145 +2447,6 @@ rclpy_time_since_last_call(PyObject * module, PyObject * args)
   }
 
   return PyLong_FromUnsignedLongLong(elapsed_time);
-}
-
-/// Handle destructor for subscription
-static void
-_rclpy_destroy_subscription(void * p)
-{
-  rclpy_subscription_t * sub = p;
-  if (!sub) {
-    // Warning should use line number of the current stack frame
-    int stack_level = 1;
-    PyErr_WarnFormat(
-      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_subscrition got NULL pointer");
-    return;
-  }
-
-  rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);
-  if (RCL_RET_OK != ret) {
-    // Warning should use line number of the current stack frame
-    int stack_level = 1;
-    PyErr_WarnFormat(
-      PyExc_RuntimeWarning, stack_level, "Failed to fini subscription: %s",
-      rcl_get_error_string().str);
-  }
-  PyMem_Free(sub);
-}
-
-/// Create a subscription
-/**
- * This function will create a subscription for the given topic name.
- * This subscription will use the typesupport defined in the message module
- * provided as pymsg_type to send messages over the wire.
- *
- * On a successful call a list with two elements is returned:
- *
- * - a Capsule pointing to the pointer of the created rcl_subscription_t * structure
- * - an integer representing the memory address of the created rcl_subscription_t
- *
- * Raises ValueError if the capsules are not the correct types
- * Raises RuntimeError if the subscription could not be created
- *
- * \param[in] pynode Capsule pointing to the node to add the subscriber to
- * \param[in] pymsg_type Message module associated with the subscriber
- * \param[in] pytopic Python object containing the topic name
- * \param[in] pyqos_profile QoSProfile Python object for this subscription
- * \return list with the capsule and memory address, or
- * \return NULL on failure
- */
-static PyObject *
-rclpy_create_subscription(PyObject * module, PyObject * args)
-{
-  rclpy_module_state_t * module_state = (rclpy_module_state_t *)PyModule_GetState(module);
-  if (!module_state) {
-    // exception already raised
-    return NULL;
-  }
-  PyObject * pynode;
-  PyObject * pymsg_type;
-  PyObject * pytopic;
-  PyObject * pyqos_profile;
-
-  if (!PyArg_ParseTuple(args, "OOOO", &pynode, &pymsg_type, &pytopic, &pyqos_profile)) {
-    return NULL;
-  }
-
-  const char * topic = PyUnicode_AsUTF8(pytopic);
-  if (!topic) {
-    return NULL;
-  }
-
-  rclpy_handle_t * node_handle = PyCapsule_GetPointer(pynode, "rcl_node_t");
-  if (!node_handle) {
-    return NULL;
-  }
-  rcl_node_t * node = _rclpy_handle_get_pointer(node_handle);
-  if (!node) {
-    return NULL;
-  }
-
-  rosidl_message_type_support_t * ts = rclpy_common_get_type_support(pymsg_type);
-  if (!ts) {
-    return NULL;
-  }
-
-  rcl_subscription_options_t subscription_ops = rcl_subscription_get_default_options();
-
-  if (PyCapsule_IsValid(pyqos_profile, "rmw_qos_profile_t")) {
-    void * p = PyCapsule_GetPointer(pyqos_profile, "rmw_qos_profile_t");
-    rmw_qos_profile_t * qos_profile = p;
-    subscription_ops.qos = *qos_profile;
-    // TODO(jacobperron): It is not obvious why the capsule reference should be destroyed here.
-    // Instead, a safer pattern would be to destroy the QoS object with its own destructor.
-    PyMem_Free(p);
-    if (PyCapsule_SetPointer(pyqos_profile, Py_None)) {
-      // exception set by PyCapsule_SetPointer
-      return NULL;
-    }
-  }
-
-  rclpy_subscription_t * sub = PyMem_Malloc(sizeof(rclpy_subscription_t));
-  if (!sub) {
-    PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for subscription");
-    return NULL;
-  }
-  sub->subscription = rcl_get_zero_initialized_subscription();
-  sub->node = node;
-
-  rcl_ret_t ret = rcl_subscription_init(&(sub->subscription), node, ts, topic, &subscription_ops);
-  if (ret != RCL_RET_OK) {
-    if (ret == RCL_RET_TOPIC_NAME_INVALID) {
-      PyErr_Format(
-        PyExc_ValueError,
-        "Failed to create subscription due to invalid topic name '%s': %s",
-        topic, rcl_get_error_string().str);
-    } else {
-      PyErr_Format(
-        module_state->RCLError,
-        "Failed to create subscription: %s", rcl_get_error_string().str);
-    }
-    rcl_reset_error();
-    PyMem_Free(sub);
-    return NULL;
-  }
-
-  rclpy_handle_t * sub_handle = _rclpy_create_handle(sub, _rclpy_destroy_subscription);
-  if (!sub_handle) {
-    _rclpy_destroy_subscription(sub);
-    return NULL;
-  }
-  _rclpy_handle_add_dependency(sub_handle, node_handle);
-  if (PyErr_Occurred()) {
-    _rclpy_handle_dec_ref(sub_handle);
-    return NULL;
-  }
-  PyObject * sub_capsule = _rclpy_create_handle_capsule(sub_handle, "rclpy_subscription_t");
-  if (!sub_capsule) {
-    _rclpy_handle_dec_ref(sub_handle);
-    return NULL;
-  }
-  return sub_capsule;
 }
 
 /// Handle destructor for client
@@ -5923,10 +5712,6 @@ static PyMethodDef rclpy_methods[] = {
     "Get the logger name associated with the node of a publisher."
   },
   {
-    "rclpy_get_subscription_logger_name", rclpy_get_subscription_logger_name, METH_VARARGS,
-    "Get the logger name associated with the node of a subscription."
-  },
-  {
     "rclpy_count_publishers", rclpy_count_publishers, METH_VARARGS,
     "Count publishers for a topic."
   },
@@ -5941,10 +5726,6 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_get_subscriptions_info_by_topic", rclpy_get_subscriptions_info_by_topic, METH_VARARGS,
     "Get subscriptions info for a topic."
-  },
-  {
-    "rclpy_get_subscription_topic_name", rclpy_get_subscription_topic_name, METH_VARARGS,
-    "Get the topic name of a subscription."
   },
   {
     "rclpy_expand_topic_name", rclpy_expand_topic_name, METH_VARARGS,
@@ -5981,10 +5762,6 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_create_publisher", rclpy_create_publisher, METH_VARARGS,
     "Create a Publisher."
-  },
-  {
-    "rclpy_create_subscription", rclpy_create_subscription, METH_VARARGS,
-    "Create a Subscription."
   },
   {
     "rclpy_create_service", rclpy_create_service, METH_VARARGS,

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -16,6 +16,7 @@
 
 #include "context.hpp"
 #include "rclpy_common/exceptions.hpp"
+#include "subscription.hpp"
 
 namespace py = pybind11;
 
@@ -40,4 +41,14 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   m.def(
     "rclpy_ok", &rclpy::context_is_valid,
     "Return true if the context is valid");
+
+  m.def(
+    "rclpy_create_subscription", &rclpy::subscription_create,
+    "Create a Subscription");
+  m.def(
+    "rclpy_get_subscription_logger_name", &rclpy::subscription_get_logger_name,
+    "Get the logger name associated with the node of a subscription");
+  m.def(
+    "rclpy_get_subscription_topic_name", &rclpy::subscription_get_topic_name,
+    "Get the topic name of a subscription");
 }

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -1,0 +1,162 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Include pybind11 before rclpy_common/handle.h includes Python.h
+#include <pybind11/pybind11.h>
+
+#include <rcl/error_handling.h>
+
+#include <memory>
+#include <string>
+
+extern "C"
+{
+#include "rclpy_common/common.h"
+}
+#include "rclpy_common/handle.h"
+
+#include "rclpy_common/exceptions.hpp"
+
+#include "subscription.hpp"
+
+namespace rclpy
+{
+static void
+_rclpy_destroy_subscription(void * p)
+{
+  auto sub = static_cast<rclpy_subscription_t *>(p);
+  if (!sub) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_subscription got NULL pointer");
+    return;
+  }
+
+  rcl_ret_t ret = rcl_subscription_fini(&(sub->subscription), sub->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini subscription: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(sub);
+}
+
+py::capsule
+subscription_create(
+  py::capsule pynode, py::object pymsg_type, std::string topic,
+  py::capsule pyqos_profile)
+{
+  auto node = static_cast<rcl_node_t *>(
+    rclpy_handle_get_pointer_from_capsule(pynode.ptr(), "rcl_node_t"));
+  if (!node) {
+    throw py::error_already_set();
+  }
+
+  auto msg_type = static_cast<rosidl_message_type_support_t *>(
+    rclpy_common_get_type_support(pymsg_type.ptr()));
+  if (!msg_type) {
+    throw py::error_already_set();
+  }
+
+  rcl_subscription_options_t subscription_ops = rcl_subscription_get_default_options();
+
+  if (!pyqos_profile.is(py::none())) {
+    if (0 != strcmp("rmw_qos_profile_t", pyqos_profile.name())) {
+      throw py::value_error("capsule is not an rmw_qos_profile_t");
+    }
+    auto qos_profile = static_cast<rmw_qos_profile_t *>(pyqos_profile);
+    subscription_ops.qos = *qos_profile;
+  }
+
+  // Use smart pointer to make sure memory is free'd on error
+  auto deleter = [](rclpy_subscription_t * ptr) {_rclpy_destroy_subscription(ptr);};
+  auto sub = std::unique_ptr<rclpy_subscription_t, decltype(deleter)>(
+    static_cast<rclpy_subscription_t *>(PyMem_Malloc(sizeof(rclpy_subscription_t))),
+    deleter);
+  if (!sub) {
+    throw std::bad_alloc();
+  }
+  sub->subscription = rcl_get_zero_initialized_subscription();
+  sub->node = node;
+
+  rcl_ret_t ret = rcl_subscription_init(
+    &(sub->subscription), node, msg_type,
+    topic.c_str(), &subscription_ops);
+  if (ret != RCL_RET_OK) {
+    if (ret == RCL_RET_TOPIC_NAME_INVALID) {
+      std::string error_text{"Failed to create subscription due to invalid topic name '"};
+      error_text += topic;
+      error_text += "'";
+      throw RCLError(error_text);
+    }
+    throw RCLError("Failed to create subscription");
+  }
+
+  PyObject * pysub_c =
+    rclpy_create_handle_capsule(sub.get(), "rclpy_subscription_t", _rclpy_destroy_subscription);
+  if (!pysub_c) {
+    throw py::error_already_set();
+  }
+  auto pysub = py::reinterpret_steal<py::capsule>(pysub_c);
+  // pysub now owns the rclpy_subscription_t
+  sub.release();
+
+  auto sub_handle = static_cast<rclpy_handle_t *>(pysub);
+  auto node_handle = static_cast<rclpy_handle_t *>(pynode);
+  _rclpy_handle_add_dependency(sub_handle, node_handle);
+  if (PyErr_Occurred()) {
+    _rclpy_handle_dec_ref(node_handle);
+    throw py::error_already_set();
+  }
+
+  return pysub;
+}
+
+py::object
+subscription_get_logger_name(py::capsule pysubscription)
+{
+  auto sub = static_cast<rclpy_subscription_t *>(
+    rclpy_handle_get_pointer_from_capsule(pysubscription.ptr(), "rclpy_subscription_t"));
+  if (!sub) {
+    throw py::error_already_set();
+  }
+
+  const char * node_logger_name = rcl_node_get_logger_name(sub->node);
+  if (NULL == node_logger_name) {
+    return py::none();
+  }
+
+  return py::str(node_logger_name);
+}
+
+std::string
+subscription_get_topic_name(py::capsule pysubscription)
+{
+  auto sub = static_cast<rclpy_subscription_t *>(
+    rclpy_handle_get_pointer_from_capsule(pysubscription.ptr(), "rclpy_subscription_t"));
+  if (!sub) {
+    throw py::error_already_set();
+  }
+
+  const char * subscription_name = rcl_subscription_get_topic_name(&(sub->subscription));
+  if (NULL == subscription_name) {
+    throw RCLError("failed to get subscription topic name");
+  }
+
+  return std::string(subscription_name);
+}
+}  // namespace rclpy

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -1,0 +1,74 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__SUBSCRIPTION_HPP_
+#define RCLPY__SUBSCRIPTION_HPP_
+
+#include <pybind11/pybind11.h>
+
+#include <string>
+
+namespace py = pybind11;
+
+namespace rclpy
+{
+/// Create a subscription
+/**
+ * This function will create a subscription for the given topic name.
+ * This subscription will use the typesupport defined in the message module
+ * provided as pymsg_type to send messages over the wire.
+ *
+ * On a successful call a list with two elements is returned:
+ *
+ * - a Capsule pointing to the pointer of the created rcl_subscription_t * structure
+ * - an integer representing the memory address of the created rcl_subscription_t
+ *
+ * Raises ValueError if the capsules are not the correct types
+ * Raises RuntimeError if the subscription could not be created
+ *
+ * \param[in] pynode Capsule pointing to the node to add the subscriber to
+ * \param[in] pymsg_type Message module associated with the subscriber
+ * \param[in] topic The topic name
+ * \param[in] pyqos_profile QoSProfile Python object for this subscription
+ * \return list with the capsule and memory address, or
+ * \return NULL on failure
+ */
+py::capsule
+subscription_create(
+  py::capsule pynode, py::object pymsg_type, std::string topic,
+  py::capsule pyqos_profile);
+
+/// Get the name of the logger associated with the node of the subscription.
+/**
+ * Raises ValueError if pysubscription is not a subscription capsule
+ *
+ * \param[in] pysubscription Capsule pointing to the subscription to get the logger name of
+ * \return logger_name, or
+ * \return None on failure
+ */
+py::object
+subscription_get_logger_name(py::capsule pysubscription);
+
+/// Return the resolved topic name of a subscription.
+/**
+ * The returned string is the resolved topic name after remappings have be applied.
+ *
+ * \param[in] pynode Capsule pointing to the node to get the namespace from.
+ * \return a string with the topic name
+ */
+std::string
+subscription_get_topic_name(py::capsule pysubscription);
+}  // namespace rclpy
+
+#endif  // RCLPY__SUBSCRIPTION_HPP_


### PR DESCRIPTION
Part of #665

Converts:
* rclpy_get_subscription_logger_name
* rclpy_get_subscription_topic_name
* rclpy_create_subscription

CI (build: --packages-up-to rclpy test: --packages-select rclpy)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13800)](http://ci.ros2.org/job/ci_linux/13800/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8670)](http://ci.ros2.org/job/ci_linux-aarch64/8670/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11511)](http://ci.ros2.org/job/ci_osx/11511/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13883)](http://ci.ros2.org/job/ci_windows/13883/)