### PR TITLE
Replace rmw_connext_cpp with rmw_connextdds

### DIFF
--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -19,8 +19,6 @@ from rcl_interfaces.srv import GetParameters
 import rclpy
 import rclpy.executors
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-from rclpy.utilities import get_rmw_implementation_identifier
-
 
 # TODO(sloretz) Reduce fudge once wait_for_service uses node graph events
 TIME_FUDGE = 0.3
@@ -92,10 +90,6 @@ class TestClient(unittest.TestCase):
             self.node.destroy_client(cli)
             self.node.destroy_service(srv)
 
-    # https://github.com/ros2/rmw_connext/issues/405
-    @unittest.skipIf(
-        get_rmw_implementation_identifier() == 'rmw_connext_cpp',
-        reason='Source timestamp not implemented for Connext')
     def test_service_timestamps(self):
         cli = self.node.create_client(GetParameters, 'get/parameters')
         srv = self.node.create_service(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -49,7 +49,6 @@ from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time_source import USE_SIM_TIME_NAME
-from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'
@@ -145,10 +144,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     def dummy_cb(self, msg):
         pass
 
-    # https://github.com/ros2/rmw_connext/issues/405
-    @unittest.skipIf(
-        get_rmw_implementation_identifier() == 'rmw_connext_cpp',
-        reason='Source timestamp not implemented for Connext')
     def test_take(self):
         basic_types_pub = self.node.create_publisher(BasicTypes, 'take_test', 1)
         sub = self.node.create_subscription(


### PR DESCRIPTION
This PR removes all references to `rmw_connext_cpp`, so that it may be replaced by `rmw_connextdds`.

The PR re-enables two tests which were previously disabled for Connext.

See [rticommunity/rmw_connextdds #9](https://github.com/rticommunity/rmw_connextdds/issues/9) for a list of related PRs, and an overview of all the changes required to replace [ros2/rmw_connext](https://github.com/ros2/rmw_connext) (`rmw_connext_cpp`) with [rticommunity/rmw_connextdds](https://github.com/rticommunity/rmw_connextdds) in the ROS2 source tree.