### PR TITLE
Fix static typing when allow undeclared

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -801,7 +801,9 @@ class Node:
                     if descriptors is not None:
                         self._descriptors[param.name] = descriptors[param.name]
                     elif param.name not in self._descriptors:
-                        self._descriptors[param.name] = ParameterDescriptor()
+                        descriptor = ParameterDescriptor()
+                        descriptor.dynamic_typing = True
+                        self._descriptors[param.name] = descriptor
 
                     if Parameter.Type.NOT_SET == self.get_parameter_or(param.name).type_:
                         #  Parameter is new. (Parameter had no value and new value is set)
@@ -901,7 +903,7 @@ class Node:
                 successful=False,
                 reason='Trying to set a read-only parameter: {}.'.format(parameter.name))
 
-        if descriptor.dynamic_typing or self._allow_undeclared_parameters:
+        if descriptor.dynamic_typing:
             descriptor.type = parameter.type_.value
         elif descriptor.type != parameter.type_.value:
             return SetParametersResult(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -443,6 +443,26 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertIsInstance(self.node.get_parameter('unset'), Parameter)
         self.assertEqual(self.node.get_parameter('unset').type_, Parameter.Type.NOT_SET)
 
+    def test_node_declare_static_parameter(self):
+        value = self.node.declare_parameter('an_integer', 5)
+        self.assertEqual(value.value, 5)
+        self.assertFalse(
+            self.node.set_parameters([Parameter('an_integer', value='asd')])[0].successful)
+        self.assertEqual(self.node.get_parameter('an_integer').value, 5)
+
+    def test_node_undeclared_parameters_are_dynamically_typed(self):
+        self.assertTrue(self.node.set_parameters([Parameter('my_param', value=5)])[0].successful)
+        self.assertEqual(self.node.get_parameter('my_param').value, 5)
+        self.assertTrue(
+            self.node.set_parameters([Parameter('my_param', value='asd')])[0].successful)
+        self.assertEqual(self.node.get_parameter('my_param').value, 'asd')
+
+    def test_node_cannot_declare_after_set(self):
+        self.assertTrue(self.node.set_parameters([Parameter('my_param', value=5)])[0].successful)
+        self.assertEqual(self.node.get_parameter('my_param').value, 5)
+        with pytest.raises(rclpy.exceptions.ParameterAlreadyDeclaredException):
+            self.node.declare_parameter('my_param', 5)
+
     def test_node_has_parameter_services(self):
         service_names_and_types = self.node.get_service_names_and_types()
         self.assertIn(


### PR DESCRIPTION
Add tests checking that declaring an statically typed parameter when undeclared parameters are allowed works as described in #1568 (comment).

See also https://github.com/ros2/rclcpp/pull/1575.

Pending: tests.