### PR TITLE
Change the time jump time type to just rcl_time_jump_t.

### DIFF
--- a/rclpy/src/rclpy/clock.cpp
+++ b/rclpy/src/rclpy/clock.cpp
@@ -170,7 +170,7 @@ clock_set_ros_time_override(py::capsule pyclock, py::capsule pytime_point)
 /// Called when a time jump occurs.
 void
 _rclpy_on_time_jump(
-  const struct rcl_time_jump_t * time_jump,
+  const rcl_time_jump_t * time_jump,
   bool before_jump,
   void * user_data)
 {


### PR DESCRIPTION
The struct is redundant.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>