### PR TITLE
Explicitly populate tuple with None

### DIFF
--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -203,13 +203,15 @@ client_take_response(py::capsule pyclient, py::object pyresponse_type)
     throw std::bad_alloc();
   }
 
+  py::tuple result_tuple(2);
   rcl_ret_t ret = rcl_take_response_with_info(
     &(client->client), header.get(), taken_response.get());
   if (ret == RCL_RET_CLIENT_TAKE_FAILED) {
-    return py::tuple(2);
+    result_tuple[0] = py::none();
+    result_tuple[1] = py::none();
+    return result_tuple;
   }
 
-  py::tuple result_tuple(2);
   result_tuple[0] = py::capsule(
     header.release(), "rmw_service_info_t", _rclpy_destroy_service_info);
 


### PR DESCRIPTION
I made a false assumption that tuple members which weren't specifically populated would somehow default to 'None'. This change explicitly sets the members to `py::none()`.

Regression caused by #701
Closes #710
Closes ros2/ros2cli#608

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13889)](http://ci.ros2.org/job/ci_linux/13889/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8741)](http://ci.ros2.org/job/ci_linux-aarch64/8741/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11597)](http://ci.ros2.org/job/ci_osx/11597/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13980)](http://ci.ros2.org/job/ci_windows/13980/)