### PR TITLE
Convert duration to pybind11

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -174,6 +174,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/client.cpp
   src/rclpy/clock.cpp
   src/rclpy/context.cpp
+  src/rclpy/duration.cpp
   src/rclpy/guard_condition.cpp
   src/rclpy/publisher.cpp
   src/rclpy/service.cpp

--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -21,7 +21,7 @@ class Duration:
     def __init__(self, *, seconds=0, nanoseconds=0):
         total_nanoseconds = int(seconds * 1e9)
         total_nanoseconds += int(nanoseconds)
-        if total_nanoseconds >= 2**63:
+        if total_nanoseconds >= 2**63 or total_nanoseconds < -2**63:
             # pybind11 would raise TypeError, but we want OverflowError
             raise OverflowError(
                 'Total nanoseconds value is too large to store in C duration.')

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -2608,73 +2608,6 @@ rclpy_assert_liveliness(PyObject * module, PyObject * args)
   Py_RETURN_NONE;
 }
 
-/// Destructor for a duration
-void
-_rclpy_destroy_duration(PyObject * pycapsule)
-{
-  PyMem_Free(PyCapsule_GetPointer(pycapsule, "rcl_duration_t"));
-}
-
-/// Create a duration
-/**
- * On failure, an exception is raised and NULL is returned if:
- *
- * Raises RuntimeError on initialization failure
- * Raises TypeError if argument of invalid type
- * Raises OverflowError if nanoseconds argument cannot be converted to uint64_t
- *
- * \param[in] nanoseconds unsigned PyLong object storing the nanoseconds value
- *   of the duration in a 64-bit signed integer
- * \return Capsule of the pointer to the created rcl_duration_t * structure, or
- * \return NULL on failure
- */
-static PyObject *
-rclpy_create_duration(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  PY_LONG_LONG nanoseconds;
-
-  if (!PyArg_ParseTuple(args, "L", &nanoseconds)) {
-    return NULL;
-  }
-
-  rcl_duration_t * duration = PyMem_Malloc(sizeof(rcl_duration_t));
-  if (!duration) {
-    PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for duration.");
-    return NULL;
-  }
-
-  duration->nanoseconds = nanoseconds;
-
-  return PyCapsule_New(duration, "rcl_duration_t", _rclpy_destroy_duration);
-}
-
-/// Returns the nanoseconds value of the duration
-/**
- * On failure, an exception is raised and NULL is returned if:
- *
- * Raises ValueError if pyduration is not a duration capsule
- *
- * \param[in] pyduration Capsule pointing to the duration
- * \return NULL on failure:
- *         PyLong integer in nanoseconds on success
- */
-static PyObject *
-rclpy_duration_get_nanoseconds(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  PyObject * pyduration;
-  if (!PyArg_ParseTuple(args, "O", &pyduration)) {
-    return NULL;
-  }
-
-  rcl_duration_t * duration = PyCapsule_GetPointer(
-    pyduration, "rcl_duration_t");
-  if (!duration) {
-    return NULL;
-  }
-
-  return PyLong_FromLongLong(duration->nanoseconds);
-}
-
 /// Create an rclpy.parameter.Parameter from an rcl_variant_t
 /**
  * On failure a Python exception is raised and NULL is returned if:
@@ -3351,16 +3284,6 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_assert_liveliness", rclpy_assert_liveliness, METH_VARARGS,
     "Assert the liveliness of an entity."
-  },
-
-  {
-    "rclpy_create_duration", rclpy_create_duration, METH_VARARGS,
-    "Create a duration."
-  },
-
-  {
-    "rclpy_duration_get_nanoseconds", rclpy_duration_get_nanoseconds, METH_VARARGS,
-    "Get the nanoseconds value of a duration."
   },
 
   {

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -17,6 +17,7 @@
 #include "client.hpp"
 #include "clock.hpp"
 #include "context.hpp"
+#include "duration.hpp"
 #include "guard_condition.hpp"
 #include "publisher.hpp"
 #include "rclpy_common/exceptions.hpp"
@@ -83,6 +84,13 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   m.def(
     "rclpy_ok", &rclpy::context_is_valid,
     "Return true if the context is valid");
+
+  m.def(
+    "rclpy_create_duration", &rclpy::create_duration,
+    "Create a duration");
+  m.def(
+    "rclpy_duration_get_nanoseconds", &rclpy::duration_get_nanoseconds,
+    "Get the nanoseconds value of a duration");
 
   m.def(
     "rclpy_create_publisher", &rclpy::publisher_create,

--- a/rclpy/src/rclpy/duration.cpp
+++ b/rclpy/src/rclpy/duration.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Include pybind11 before rclpy_common/handle.h includes Python.h
+#include <pybind11/pybind11.h>
+
+#include <rcl/time.h>
+
+#include <memory>
+
+#include "duration.hpp"
+
+namespace rclpy
+{
+void
+_rclpy_destroy_duration(PyObject * pycapsule)
+{
+  PyMem_Free(PyCapsule_GetPointer(pycapsule, "rcl_duration_t"));
+}
+
+py::capsule
+create_duration(int64_t nanoseconds)
+{
+  auto duration = static_cast<rcl_duration_t *>(PyMem_Malloc(sizeof(rcl_duration_t)));
+  if (!duration) {
+    throw std::bad_alloc();
+  }
+
+  duration->nanoseconds = nanoseconds;
+
+  return py::capsule(duration, "rcl_duration_t", _rclpy_destroy_duration);
+}
+
+int64_t
+duration_get_nanoseconds(py::capsule pyduration)
+{
+  if (0 != strcmp("rcl_duration_t", pyduration.name())) {
+    throw py::value_error("capsule is not an rcl_duration_t");
+  }
+  auto duration = static_cast<rcl_duration_t *>(pyduration);
+
+  return duration->nanoseconds;
+}
+}  // namespace rclpy

--- a/rclpy/src/rclpy/duration.cpp
+++ b/rclpy/src/rclpy/duration.cpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Include pybind11 before rclpy_common/handle.h includes Python.h
 #include <pybind11/pybind11.h>
-
 #include <rcl/time.h>
 
 #include <memory>

--- a/rclpy/src/rclpy/duration.hpp
+++ b/rclpy/src/rclpy/duration.hpp
@@ -25,9 +25,7 @@ namespace rclpy
 /**
  * On failure, an exception is raised and NULL is returned if:
  *
- * Raises RuntimeError on initialization failure
  * Raises TypeError if argument of invalid type
- * Raises OverflowError if nanoseconds argument cannot be converted to int64_t
  *
  * \param[in] nanoseconds The nanoseconds value of the duration in a 64-bit signed integer
  * \return Capsule of the pointer to the created rcl_duration_t * structure

--- a/rclpy/src/rclpy/duration.hpp
+++ b/rclpy/src/rclpy/duration.hpp
@@ -23,8 +23,6 @@ namespace rclpy
 {
 /// Create a duration
 /**
- * On failure, an exception is raised and NULL is returned if:
- *
  * Raises TypeError if argument of invalid type
  *
  * \param[in] nanoseconds The nanoseconds value of the duration in a 64-bit signed integer

--- a/rclpy/src/rclpy/duration.hpp
+++ b/rclpy/src/rclpy/duration.hpp
@@ -23,7 +23,7 @@ namespace rclpy
 {
 /// Create a duration
 /**
- * Raises TypeError if argument of invalid type
+ * Raises TypeError if argument is of an invalid type
  *
  * \param[in] nanoseconds The nanoseconds value of the duration in a 64-bit signed integer
  * \return Capsule of the pointer to the created rcl_duration_t * structure

--- a/rclpy/src/rclpy/duration.hpp
+++ b/rclpy/src/rclpy/duration.hpp
@@ -1,0 +1,49 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__DURATION_HPP_
+#define RCLPY__DURATION_HPP_
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace rclpy
+{
+/// Create a duration
+/**
+ * On failure, an exception is raised and NULL is returned if:
+ *
+ * Raises RuntimeError on initialization failure
+ * Raises TypeError if argument of invalid type
+ * Raises OverflowError if nanoseconds argument cannot be converted to int64_t
+ *
+ * \param[in] nanoseconds The nanoseconds value of the duration in a 64-bit signed integer
+ * \return Capsule of the pointer to the created rcl_duration_t * structure
+ */
+py::capsule
+create_duration(int64_t nanoseconds);
+
+/// Returns the nanoseconds value of the duration
+/**
+ * Raises ValueError if pyduration is not a duration capsule
+ *
+ * \param[in] pyduration Capsule pointing to the duration
+ * \return integer nanoseconds
+ */
+int64_t
+duration_get_nanoseconds(py::capsule pyduration);
+}  // namespace rclpy
+
+#endif  // RCLPY__DURATION_HPP_


### PR DESCRIPTION
Part of #665

Converts:
* rclpy_create_duration
* rclpy_duration_get_nanoseconds

CI (build: --packages-up-to rclpy test: --packages-select rclpy)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13945)](http://ci.ros2.org/job/ci_linux/13945/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8783)](http://ci.ros2.org/job/ci_linux-aarch64/8783/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11648)](http://ci.ros2.org/job/ci_osx/11648/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14031)](http://ci.ros2.org/job/ci_windows/14031/)