### PR TITLE
Include pybind11 first to fix windows debug warning

### DIFF
--- a/rclpy/src/rclpy/qos_events.cpp
+++ b/rclpy/src/rclpy/qos_events.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Include pybind11 before rclpy_common/handle.h includes Python.h
+#include <pybind11/pybind11.h>
+
 #include <rcl/error_handling.h>
 #include <rcl/event.h>
 #include <rcl/types.h>


### PR DESCRIPTION
I think this will fix the warning on Windows Debug https://ci.ros2.org/job/ci_windows/14100/

Part of #665