### PR TITLE
Document misuse of parameter callbacks

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -830,6 +830,9 @@ class Node:
 
         Calling this function will add a callback in self._parameter_callbacks list.
 
+        It is considered bad practice to reject changes for "unknown" parameters as this prevents
+        other parts of the node (that may be aware of these parameters) from handling them.
+
         :param callback: The function that is called whenever parameters are set for the node.
         """
         self._parameters_callbacks.insert(0, callback)


### PR DESCRIPTION
Similar to https://github.com/ros2/rclcpp/pull/1590
Related to https://github.com/ros2/rclcpp/issues/1587