### PR TITLE
Use py::class_ for rcl_time_point_t

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -123,11 +123,8 @@ class Clock:
     def now(self):
         from rclpy.time import Time
         with self.handle as clock_capsule:
-            time_handle = _rclpy.rclpy_clock_get_now(clock_capsule)
-        # TODO(dhood): Return a python object from the C extension
-        return Time(
-            nanoseconds=_rclpy.rclpy_time_point_get_nanoseconds(time_handle),
-            clock_type=self.clock_type)
+            rcl_time = _rclpy.rclpy_clock_get_now(clock_capsule)
+        return Time(nanoseconds=rcl_time.nanoseconds, clock_type=self.clock_type)
 
     def create_jump_callback(self, threshold, *, pre_callback=None, post_callback=None):
         """

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -36,12 +36,11 @@ class Time:
             # pybind11 would raise TypeError, but we want OverflowError
             raise OverflowError(
                 'Total nanoseconds value is too large to store in C time point.')
-        self._time_handle = _rclpy.rclpy_create_time_point(total_nanoseconds, clock_type)
-        self._clock_type = clock_type
+        self._time_handle = _rclpy.rcl_time_point_t(total_nanoseconds, clock_type)
 
     @property
     def nanoseconds(self):
-        return _rclpy.rclpy_time_point_get_nanoseconds(self._time_handle)
+        return self._time_handle.nanoseconds
 
     def seconds_nanoseconds(self):
         """
@@ -55,7 +54,7 @@ class Time:
 
     @property
     def clock_type(self):
-        return self._clock_type
+        return self._time_handle.clock_type
 
     def __repr__(self):
         return 'Time(nanoseconds={0}, clock_type={1})'.format(

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -209,12 +209,7 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     "rclpy_take", &rclpy::subscription_take_message,
     "Take a message and its metadata from a subscription");
 
-  m.def(
-    "rclpy_create_time_point", &rclpy::create_time_point,
-    "Create a time point.");
-  m.def(
-    "rclpy_time_point_get_nanoseconds", &rclpy::time_point_get_nanoseconds,
-    "Get the nanoseconds value of a time point.");
+  rclpy::define_time_point(m);
 
   m.def(
     "rclpy_create_clock", &rclpy::create_clock,

--- a/rclpy/src/rclpy/clock.hpp
+++ b/rclpy/src/rclpy/clock.hpp
@@ -43,7 +43,7 @@ create_clock(rcl_clock_type_t clock_type);
  * \param[in] pyclock Capsule pointing to the clock
  * \return capsule to a time point with the current time
  */
-py::capsule
+rcl_time_point_t
 clock_get_now(py::capsule pyclock);
 
 /// Returns if a clock using ROS time has the ROS time override enabled.
@@ -70,15 +70,14 @@ clock_set_ros_time_override_is_enabled(py::capsule pyclock, bool enabled);
 
 /// Set the ROS time override for a clock using ROS time.
 /**
- * Raises ValueError if pyclock is not a clock capsule, or
- * pytime_point is not a time point capsule
+ * Raises ValueError if pyclock is not a clock capsule
  * Raises RRCLError if the clock's ROS time override cannot be set
  *
  * \param[in] pyclock Capsule pointing to the clock to set
- * \param[in] pytime_point Capsule pointing to the time point
+ * \param[in] time_point a time point instance
  */
 void
-clock_set_ros_time_override(py::capsule py_clock, py::capsule pytime_point);
+clock_set_ros_time_override(py::capsule py_clock, rcl_time_point_t time_point);
 
 /// Add a time jump callback to a clock.
 /**

--- a/rclpy/src/rclpy/time_point.cpp
+++ b/rclpy/src/rclpy/time_point.cpp
@@ -15,10 +15,7 @@
 // Include pybind11 before rclpy_common/handle.h includes Python.h
 #include <pybind11/pybind11.h>
 
-#include <rcl/rcl.h>
-
-#include <cstring>
-#include <memory>
+#include <rcl/time.h>
 
 #include "time_point.hpp"
 

--- a/rclpy/src/rclpy/time_point.cpp
+++ b/rclpy/src/rclpy/time_point.cpp
@@ -24,58 +24,22 @@
 
 namespace rclpy
 {
-/// Destructor for a time point
-void
-_rclpy_destroy_time_point(PyObject * pycapsule)
-{
-  PyMem_Free(PyCapsule_GetPointer(pycapsule, "rcl_time_point_t"));
-}
-
 /// Create a time point
-/**
- * On failure, an exception is raised and NULL is returned if:
- *
- * Raises RuntimeError on initialization failure
- * Raises TypeError if argument of invalid type
- * Raises OverflowError if nanoseconds argument cannot be converted to uint64_t
- *
- * \param[in] nanoseconds unsigned PyLong object storing the nanoseconds value
- *   of the time point in a 64-bit unsigned integer
- * \param[in] clock_type enum of type ClockType
- * \return Capsule of the pointer to the created rcl_time_point_t * structure, or
- * \return NULL on failure
- */
-py::capsule
+rcl_time_point_t
 create_time_point(int64_t nanoseconds, rcl_clock_type_t clock_type)
 {
-  auto deleter = [](rcl_time_point_t * ptr) {PyMem_FREE(ptr);};
-  auto time_point = std::unique_ptr<rcl_time_point_t, decltype(deleter)>(
-    static_cast<rcl_time_point_t *>(PyMem_Malloc(sizeof(rcl_time_point_t))),
-    deleter);
-
-  time_point->nanoseconds = nanoseconds;
-  time_point->clock_type = clock_type;
-
-  return py::capsule(time_point.release(), "rcl_time_point_t", _rclpy_destroy_time_point);
+  rcl_time_point_t time_point;
+  time_point.nanoseconds = nanoseconds;
+  time_point.clock_type = clock_type;
+  return time_point;
 }
 
-/// Returns the nanoseconds value of the time point
-/**
- * On failure, an exception is raised and NULL is returned if:
- *
- * Raises ValueError if pytime_point is not a time point capsule
- *
- * \param[in] pytime_point Capsule pointing to the time point
- * \return NULL on failure:
- *         PyLong integer in nanoseconds on success
- */
-int64_t
-time_point_get_nanoseconds(py::capsule pytime_point)
+void
+define_time_point(py::object module)
 {
-  if (0 != std::strcmp("rcl_time_point_t", pytime_point.name())) {
-    throw py::value_error("capsule is not an rcl_time_point_t");
-  }
-  auto time_point = static_cast<rcl_time_point_t *>(pytime_point);
-  return time_point->nanoseconds;
+  py::class_<rcl_time_point_t>(module, "rcl_time_point_t")
+  .def(py::init<>(&create_time_point))
+  .def_readonly("nanoseconds", &rcl_time_point_t::nanoseconds)
+  .def_readonly("clock_type", &rcl_time_point_t::clock_type);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/time_point.hpp
+++ b/rclpy/src/rclpy/time_point.hpp
@@ -21,27 +21,11 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-/// Create a time point
+/// Define a pybind11 wrapper for an rcl_time_point_t
 /**
- * Raises TypeError if argument of invalid type
- * Raises OverflowError if nanoseconds argument cannot be converted to uint64_t
- *
- * \param[in] nanoseconds the nanoseconds to store in the time point
- * \param[in] clock_type enum of type ClockType
- * \return Capsule of the pointer to the created rcl_time_point_t
+ * \param[in] module a pybind11 module to add the definition to
  */
-py::capsule
-create_time_point(int64_t nanoseconds, rcl_clock_type_t clock_type);
-
-/// Returns the nanoseconds value of the time point
-/**
- * Raises ValueError if pytime_point is not a time point capsule
- *
- * \param[in] pytime_point Capsule pointing to the time point
- * \return nanoseconds on the time time point
- */
-int64_t
-time_point_get_nanoseconds(py::capsule pytime_point);
+void define_time_point(py::object module);
 }  // namespace rclpy
 
 #endif  // RCLPY__TIME_POINT_HPP_


### PR DESCRIPTION
Part of #665

This is a PR that refactors the code using `rcl_time_point_t` to use a `py::class_` definition. This is an example of what moving away from PyCapsules looks like for C structs that aren't being wrapped with `rclpy_handle_t` currently.