### PR TITLE
Convert Client to use C++ Class

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -166,9 +166,11 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/client.cpp
   src/rclpy/clock.cpp
   src/rclpy/context.cpp
+  src/rclpy/destroyable.cpp
   src/rclpy/duration.cpp
   src/rclpy/graph.cpp
   src/rclpy/guard_condition.cpp
+  src/rclpy/handle.cpp
   src/rclpy/init.cpp
   src/rclpy/logging.cpp
   src/rclpy/names.cpp

--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -15,11 +15,11 @@
 from threading import Lock
 
 from rclpy.impl.implementation_singleton import rclpy_handle_implementation as _rclpy_handle
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.impl.implementation_singleton import rclpy_pycapsule_implementation as _rclpy_capsule
 
 
-class InvalidHandle(Exception):
-    pass
+InvalidHandle = _rclpy.InvalidHandle
 
 
 class Handle:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1383,7 +1383,7 @@ class Node:
         failed = False
         try:
             with self.handle as node_capsule:
-                client_capsule = _rclpy.rclpy_create_client(
+                client_impl = _rclpy.Client(
                     node_capsule,
                     srv_type,
                     srv_name,
@@ -1393,11 +1393,9 @@ class Node:
         if failed:
             self._validate_topic_or_service_name(srv_name, is_service=True)
 
-        client_handle = Handle(client_capsule)
-
         client = Client(
             self.context,
-            client_handle, srv_type, srv_name, qos_profile,
+            client_impl, srv_type, srv_name, qos_profile,
             callback_group)
         self.__clients.append(client)
         callback_group.add_entity(client)

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -19,6 +19,7 @@
 #include "client.hpp"
 #include "clock.hpp"
 #include "context.hpp"
+#include "destroyable.hpp"
 #include "duration.hpp"
 #include "graph.hpp"
 #include "guard_condition.hpp"
@@ -42,6 +43,8 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(_rclpy_pybind11, m) {
   m.doc() = "ROS 2 Python client library.";
+
+  rclpy::define_destroyable(m);
 
   py::enum_<rcl_clock_type_t>(m, "ClockType")
   .value("UNINITIALIZED", RCL_CLOCK_UNINITIALIZED)
@@ -100,6 +103,8 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     m, "UnsupportedEventTypeError", rclerror.ptr());
   py::register_exception<rclpy::NotImplementedError>(
     m, "NotImplementedError", PyExc_NotImplementedError);
+  py::register_exception<rclpy::InvalidHandle>(
+    m, "InvalidHandle", PyExc_RuntimeError);
 
   m.def(
     "rclpy_init", &rclpy::init,
@@ -108,18 +113,7 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     "rclpy_shutdown", &rclpy::shutdown,
     "rclpy_shutdown.");
 
-  m.def(
-    "rclpy_create_client", &rclpy::client_create,
-    "Create a Client");
-  m.def(
-    "rclpy_send_request", &rclpy::client_send_request,
-    "Send a request");
-  m.def(
-    "rclpy_service_server_is_available", &rclpy::client_service_server_is_available,
-    "Return true if the service server is available");
-  m.def(
-    "rclpy_take_response", &rclpy::client_take_response,
-    "rclpy_take_response");
+  rclpy::define_client(m);
 
   m.def(
     "rclpy_context_get_domain_id", &rclpy::context_get_domain_id,
@@ -268,6 +262,9 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   m.def(
     "rclpy_wait_set_add_entity", &rclpy::wait_set_add_entity,
     "rclpy_wait_set_add_entity.");
+  m.def(
+    "rclpy_wait_set_add_client", &rclpy::wait_set_add_client,
+    "Add a client to the wait set.");
   m.def(
     "rclpy_wait_set_is_ready", &rclpy::wait_set_is_ready,
     "rclpy_wait_set_is_ready.");

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -17,67 +17,91 @@
 
 #include <pybind11/pybind11.h>
 
-#include <string>
+#include <rcl/client.h>
+
+#include <memory>
+
+#include "destroyable.hpp"
+#include "handle.hpp"
 
 namespace py = pybind11;
 
 namespace rclpy
 {
-/// Create a client
-/**
- * This function will create a client for the given service name.
- * This client will use the typesupport defined in the service module
- * provided as pysrv_type to send messages over the wire.
- *
- * On a successful call a Capsule pointing to the pointer of the created
- * rclpy_client_t * is returned.
- *
- * Raises ValueError if the capsules are not the correct types
- * Raises RuntimeError if the client could not be created
- *
- * \param[in] pynode Capsule pointing to the node to add the client to
- * \param[in] pysrv_type Service module associated with the client
- * \param[in] service_name Python object containing the service name
- * \param[in] pyqos_profile QoSProfile Python object for this client
- * \return capsule containing the rclpy_client_t
- */
-py::capsule
-client_create(
-  py::capsule pynode, py::object pysrv_type, std::string service_name,
-  py::capsule pyqos_profile);
+class Client : public Destroyable
+{
+public:
+  /// Create a client
+  /**
+   * This function will create a client for the given service name.
+   * This client will use the typesupport defined in the service module
+   * provided as pysrv_type to send messages over the wire.
+   *
+   * Raises ValueError if the capsules are not the correct types
+   * Raises RuntimeError if the client could not be created
+   *
+   * \param[in] pynode Capsule pointing to the node to add the client to
+   * \param[in] pysrv_type Service module associated with the client
+   * \param[in] service_name Python object containing the service name
+   * \param[in] pyqos_profile QoSProfile Python object for this client
+   */
+  Client(py::capsule pynode, py::object pysrv_type, const char * service_name, py::capsule pyqos);
 
-/// Publish a request message
-/**
- * Raises ValueError if pyclient is not a client capsule
- * Raises RuntimeError if the request could not be sent
- *
- * \param[in] pyclient Capsule pointing to the client
- * \param[in] pyrequest request message to send
- * \return sequence_number Index of the sent request
- */
-int64_t
-client_send_request(py::capsule pyclient, py::object pyrequest);
+  ~Client() = default;
 
-/// Check if a service server is available
-/**
- * Raises ValueError if the arguments are not capsules
- *
- * \param[in] pyclient Capsule pointing to the client
- * \return True if the service server is available
- */
-bool
-client_service_server_is_available(py::capsule pyclient);
+  /// Publish a request message
+  /**
+   * Raises ValueError if pyclient is not a client capsule
+   * Raises RuntimeError if the request could not be sent
+   *
+   * \param[in] pyrequest request message to send
+   * \return sequence_number Index of the sent request
+   */
+  int64_t
+  send_request(py::object pyrequest);
 
-/// Take a response from a given client
+  /// Check if a service server is available
+  /**
+   * Raises ValueError if the arguments are not capsules
+   *
+   * \return True if the service server is available
+   */
+  bool
+  service_server_is_available();
+
+  /// Take a response from a given client
+  /**
+   * Raises ValueError if pyclient is not a client capsule
+   *
+   * \param[in] pyresponse_type Instance of the message type to take
+   * \return 2-tuple sequence number and received response, or None if there is no response
+   */
+  py::tuple
+  take_response(py::object pyresponse_type);
+
+  /// Get rcl_client_t pointer
+  rcl_client_t *
+  rcl_ptr() const
+  {
+    return rcl_client_.get();
+  }
+
+  /// Force an early destruction of this object
+  void
+  destroy() override;
+
+private:
+  // TODO(sloretz) replace with std::shared_ptr<rcl_node_t> when rclpy::Node exists
+  std::shared_ptr<Handle> node_handle_;
+  std::shared_ptr<rcl_client_t> rcl_client_;
+};
+
+/// Define a pybind11 wrapper for an rclpy::Client
 /**
- * Raises ValueError if pyclient is not a client capsule
- *
- * \param[in] pyclient Capsule pointing to the client to process the response
- * \param[in] pyresponse_type Instance of the message type to take
- * \return 2-tuple sequence number and received response or None, None if there is no response
+ * \param[in] module a pybind11 module to add the definition to
  */
-py::tuple
-client_take_response(py::capsule pyclient, py::object pyresponse_type);
+void
+define_client(py::object module);
 }  // namespace rclpy
 
 #endif  // RCLPY__CLIENT_HPP_

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -35,7 +35,7 @@ public:
   /**
    * This function will create a client for the given service name.
    * This client will use the typesupport defined in the service module
-   * provided as pysrv_type to send messages over the wire.
+   * provided as pysrv_type to send messages.
    *
    * Raises ValueError if the capsules are not the correct types
    * Raises RuntimeError if the client could not be created

--- a/rclpy/src/rclpy/destroyable.cpp
+++ b/rclpy/src/rclpy/destroyable.cpp
@@ -21,14 +21,13 @@
 
 namespace rclpy
 {
-Destroyable &
+void
 Destroyable::enter()
 {
   if (please_destroy_) {
     throw InvalidHandle("cannot use Destroyable because destruction was requested");
   }
   ++use_count;
-  return *this;
 }
 
 void

--- a/rclpy/src/rclpy/destroyable.cpp
+++ b/rclpy/src/rclpy/destroyable.cpp
@@ -1,0 +1,73 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include <memory>
+
+#include "destroyable.hpp"
+#include "rclpy_common/exceptions.hpp"
+
+namespace rclpy
+{
+Destroyable &
+Destroyable::enter()
+{
+  if (please_destroy_) {
+    throw InvalidHandle("cannot use Destroyable because destruction was requested");
+  }
+  ++use_count;
+  return *this;
+}
+
+void
+Destroyable::exit(py::object, py::object, py::object)
+{
+  if (0u == use_count) {
+    throw std::runtime_error("Internal error: Destroyable use_count would be negative");
+  }
+
+  --use_count;
+  if (please_destroy_ && 0u == use_count) {
+    destroy();
+  }
+}
+
+void
+Destroyable::destroy()
+{
+  // Normally would be pure virtual, but then pybind11 can't create bindings for this class
+  throw NotImplementedError("Internal error: Destroyable subclass didn't override destroy()");
+}
+
+void
+Destroyable::destroy_when_not_in_use()
+{
+  please_destroy_ = true;
+  if (0u == use_count) {
+    destroy();
+  }
+}
+
+void
+define_destroyable(py::object module)
+{
+  py::class_<Destroyable>(module, "Destroyable")
+  .def("__enter__", &Destroyable::enter)
+  .def("__exit__", &Destroyable::exit)
+  .def(
+    "destroy_when_not_in_use", &Destroyable::destroy_when_not_in_use,
+    "Forcefully destroy the rcl object as soon as it's not actively being used");
+}
+}  // namespace rclpy

--- a/rclpy/src/rclpy/destroyable.hpp
+++ b/rclpy/src/rclpy/destroyable.hpp
@@ -42,6 +42,9 @@ public:
   void
   destroy();
 
+  virtual
+  ~Destroyable() = default;
+
 private:
   size_t use_count = 0u;
   bool please_destroy_ = false;

--- a/rclpy/src/rclpy/destroyable.hpp
+++ b/rclpy/src/rclpy/destroyable.hpp
@@ -26,7 +26,7 @@ class Destroyable
 {
 public:
   /// Context manager __enter__ - block destruction
-  Destroyable &
+  void
   enter();
 
   /// Context manager __exit__ - unblock destruction

--- a/rclpy/src/rclpy/destroyable.hpp
+++ b/rclpy/src/rclpy/destroyable.hpp
@@ -1,0 +1,57 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__DESTROYABLE_HPP_
+#define RCLPY__DESTROYABLE_HPP_
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace rclpy
+{
+/// This class blocks destruction when in use
+class Destroyable
+{
+public:
+  /// Context manager __enter__ - block destruction
+  Destroyable &
+  enter();
+
+  /// Context manager __exit__ - unblock destruction
+  void
+  exit(py::object pytype, py::object pyvalue, py::object pytraceback);
+
+  /// Signal that the object should be destroyed as soon as it's not in use
+  void
+  destroy_when_not_in_use();
+
+  /// Override this to destroy an object
+  virtual
+  void
+  destroy();
+
+private:
+  size_t use_count = 0u;
+  bool please_destroy_ = false;
+};
+
+/// Define a pybind11 wrapper for an rclpy::Destroyable
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void define_destroyable(py::object module);
+}  // namespace rclpy
+
+#endif  // RCLPY__DESTROYABLE_HPP_

--- a/rclpy/src/rclpy/handle.cpp
+++ b/rclpy/src/rclpy/handle.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include "rclpy_common/handle.h"
+
+#include "handle.hpp"
+
+namespace rclpy
+{
+Handle::Handle(py::capsule pyhandle)
+: pyhandle_(pyhandle)
+{
+  inc_ref();
+}
+
+Handle::~Handle()
+{
+  dec_ref();
+}
+
+Handle &
+Handle::operator=(const Handle & other)
+{
+  dec_ref();
+
+  pyhandle_ = other.pyhandle_;
+
+  inc_ref();
+
+  return *this;
+}
+
+void Handle::inc_ref()
+{
+  if (pyhandle_.ptr()) {
+    // Forced to assume this uses rclpy_handle_t because pycapsule name gives no clues
+    auto c_handle = static_cast<rclpy_handle_t *>(pyhandle_);
+    // Increment the reference count
+    _rclpy_handle_inc_ref(c_handle);
+  }
+}
+
+void Handle::dec_ref()
+{
+  if (pyhandle_.ptr()) {
+    // Forced to assume this uses rclpy_handle_t because pycapsule name gives no clues
+    auto c_handle = static_cast<rclpy_handle_t *>(pyhandle_);
+    // Decrement the reference count
+    _rclpy_handle_dec_ref(c_handle);
+  }
+}
+
+void *
+Handle::rcl_ptr(const char * capsule_name) noexcept
+{
+  return rclpy_handle_get_pointer_from_capsule(pyhandle_.ptr(), capsule_name);
+}
+}  // namespace rclpy

--- a/rclpy/src/rclpy/handle.hpp
+++ b/rclpy/src/rclpy/handle.hpp
@@ -1,0 +1,75 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__HANDLE_HPP_
+#define RCLPY__HANDLE_HPP_
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace rclpy
+{
+/// RAII wrapper around rclpy_handle_t that keeps it alive
+class Handle
+{
+public:
+  Handle() = default;
+
+  /// Create a handle instance wrapping a pycapsule to a type that uses rclpy_handle_t
+  explicit Handle(py::capsule pyhandle);
+
+  ~Handle();
+
+  /// assignment operator
+  Handle & operator=(const Handle & other);
+
+  /// Get the rcl pointer belonging to the handle or throw an exception
+  template<typename T>
+  T
+  cast(const char * capsule_name)
+  {
+    void * ptr = rcl_ptr(capsule_name);
+    if (!ptr) {
+      throw py::error_already_set();
+    }
+    return static_cast<T>(ptr);
+  }
+
+  /// Get the rcl pointer belonging to the handle or print a warning
+  template<typename T>
+  T
+  cast_or_warn(const char * capsule_name) noexcept
+  {
+    void * ptr = rcl_ptr(capsule_name);
+    if (!ptr) {
+      PyErr_Clear();
+      int stack_level = 1;
+      PyErr_WarnFormat(PyExc_RuntimeWarning, stack_level, "Failed to get rclpy_handle_t pointer");
+    }
+    return static_cast<T>(ptr);
+  }
+
+private:
+  py::capsule pyhandle_;
+
+  void inc_ref();
+  void dec_ref();
+
+  void *
+  rcl_ptr(const char * capsule_name) noexcept;
+};
+}  // namespace rclpy
+
+#endif  // RCLPY__HANDLE_HPP_

--- a/rclpy/src/rclpy/wait_set.cpp
+++ b/rclpy/src/rclpy/wait_set.cpp
@@ -135,13 +135,6 @@ wait_set_add_entity(const std::string & entity_type, py::capsule pywait_set, py:
       throw py::error_already_set();
     }
     ret = rcl_wait_set_add_subscription(wait_set, &(sub->subscription), &index);
-  } else if ("client" == entity_type) {
-    auto client = static_cast<rclpy_client_t *>(
-      rclpy_handle_get_pointer_from_capsule(pyentity.ptr(), "rclpy_client_t"));
-    if (!client) {
-      throw py::error_already_set();
-    }
-    ret = rcl_wait_set_add_client(wait_set, &(client->client), &index);
   } else if ("service" == entity_type) {
     auto srv = static_cast<rclpy_service_t *>(
       rclpy_handle_get_pointer_from_capsule(pyentity.ptr(), "rclpy_service_t"));
@@ -181,6 +174,22 @@ wait_set_add_entity(const std::string & entity_type, py::capsule pywait_set, py:
     error_text += entity_type;
     error_text += "' to waitset";
     throw RCLError(error_text);
+  }
+  return index;
+}
+
+size_t
+wait_set_add_client(const py::capsule pywait_set, const Client & client)
+{
+  if (0 != std::strcmp("rcl_wait_set_t", pywait_set.name())) {
+    throw py::value_error("capsule is not an rcl_wait_set_t");
+  }
+  auto wait_set = static_cast<rcl_wait_set_t *>(pywait_set);
+
+  size_t index;
+  rcl_ret_t ret = rcl_wait_set_add_client(wait_set, client.rcl_ptr(), &index);
+  if (RCL_RET_OK != ret) {
+    throw RCLError("failed to add client to wait set");
   }
   return index;
 }

--- a/rclpy/src/rclpy/wait_set.hpp
+++ b/rclpy/src/rclpy/wait_set.hpp
@@ -17,7 +17,10 @@
 
 #include <pybind11/pybind11.h>
 
+#include <memory>
 #include <string>
+
+#include "client.hpp"
 
 namespace py = pybind11;
 
@@ -72,6 +75,17 @@ wait_set_clear_entities(py::capsule pywait_set);
  */
 size_t
 wait_set_add_entity(const std::string & entity_type, py::capsule pywait_set, py::capsule pyentity);
+
+/// Add a client to the wait set structure
+/**
+ * Raises RCLError if any lower level error occurs
+ *
+ * \param[in] pywait_set Capsule pointing to the wait set structure
+ * \param[in] client a client to add to the wait set
+ * \return Index in waitset entity was added at
+ */
+size_t
+wait_set_add_client(const py::capsule pywait_set, const Client & client);
 
 /// Check if an entity in the wait set is ready by its index
 /**

--- a/rclpy/src/rclpy_common/include/rclpy_common/exceptions.hpp
+++ b/rclpy/src/rclpy_common/include/rclpy_common/exceptions.hpp
@@ -86,6 +86,11 @@ class NotImplementedError : public RCLError
   using RCLError::RCLError;
 };
 
+class InvalidHandle : public std::runtime_error
+{
+  using std::runtime_error::runtime_error;
+};
+
 }  // namespace rclpy
 
 #endif  // RCLPY_COMMON__EXCEPTIONS_HPP_

--- a/rclpy/src/rclpy_common/include/rclpy_common/handle.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/handle.h
@@ -112,6 +112,14 @@ RCLPY_COMMON_PUBLIC
 void
 _rclpy_handle_add_dependency(rclpy_handle_t * dependent, rclpy_handle_t * dependency);
 
+/// Increments the reference count of a handle.
+/**
+ * If a reference count is manually incremented, then it must later be manually decremented.
+ */
+RCLPY_COMMON_PUBLIC
+void
+_rclpy_handle_inc_ref(rclpy_handle_t * handle);
+
 /// Decrements the reference count of a handle.
 /**
  * The reference count of `handle` is decremented.

--- a/rclpy/src/rclpy_common/src/handle.c
+++ b/rclpy/src/rclpy_common/src/handle.c
@@ -76,6 +76,16 @@ _rclpy_handle_add_dependency(rclpy_handle_t * dependent, rclpy_handle_t * depend
   dependency->ref_count++;
 }
 
+/// Increments the reference count of a handle.
+void
+_rclpy_handle_inc_ref(rclpy_handle_t * handle)
+{
+  if (!handle) {
+    return;
+  }
+  ++handle->ref_count;
+}
+
 /// Decrements the reference count of a handle.
 /**
  * The reference count of `handle` is decremented.

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -189,14 +189,10 @@ def test_destroy_client_asap():
             with client.handle:
                 pass
 
-            with client.handle:
-                node.destroy_client(client)
-                # handle valid because it's still being used
-                with client.handle:
-                    pass
+            node.destroy_client(client)
 
             with pytest.raises(InvalidHandle):
-                # handle invalid because it was destroyed when no one was using it
+                # handle invalid because it was destroyed
                 with client.handle:
                     pass
         finally:


### PR DESCRIPTION
This converts the Client functions to a C++ class. It includes a couple infrastructure things needed for the conversion

## `class Handle`
This is an RAII wrapper around the `rclpy_handle_t` type. This class can be deleted as soon as all types are no longer using `rclpy_handle_t`. When constructed it increments the handle's reference to block destruction, and when destructed it decrements the reference. This allows the `Client` to keep a node alive, so a `Client` won't be destructed after a node.

## `class Destroyable`
While refactoring I found while `std::shared_ptr<>` solves the destruction order issue, there's still a need to block destruction of an object while it's in use. This class implements that very similarly to how it's done for `rclpy_handle_t` types - though I did choose to make a design change.

When destruction is requested on an `rclpy_handle_t`, new threads are allowed to use it as long as there is another thread using it. I didn't like that it meant two very fast threads using it back and forth (with overlap in their use) could block destruction forever. I chose to make `Destroyable` block new use of itself after destruction is requested, so it gets destroyed as soon as the current uses of it finish.

## `class Client`

This is the conversion to a `Client` class. It inherits from Destroyable and overrides `destroy()` to allow early destruction. It keeps a `Handle` instance to the node to prevent it from being destructed before the client. Once a `Node` class is created, that type will become `std::shared_ptr<rcl_node_t>` instead.

When `~Client()` is called, the destruction order between `rcl_node_t` and `rclpy_client_t` is guaranteed by the `std::shared_ptr<rcl_client_t>` being after `node_handle_` in the class definition. When `Client::destroy()` is called, the destruction order is guaranteed by releasing the `std::shared_ptr<rcl_client_t>` before releasing the `std::shared_ptr<Handle> node_handle_`.