### PR TITLE
Make sure only non-empty std::vector of arguments are indexed

### DIFF
--- a/rclpy/src/rclpy/init.cpp
+++ b/rclpy/src/rclpy/init.cpp
@@ -91,8 +91,9 @@ init(py::list pyargs, py::capsule pycontext, size_t domain_id)
   if (arg_c_values.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
     throw std::range_error("Too many cli arguments");
   }
-  int arg_count = static_cast<int>(arg_c_values.size());
-  ret = rcl_init(arg_count, &(arg_c_values[0]), &init_options.rcl_options, context);
+  int argc = static_cast<int>(arg_c_values.size());
+  const char ** argv = argc > 0 ? &(arg_c_values[0]) : nullptr;
+  ret = rcl_init(argc, argv, &init_options.rcl_options, context);
   if (RCL_RET_OK != ret) {
     throw RCLError("failed to initialize rcl");
   }

--- a/rclpy/src/rclpy/node.cpp
+++ b/rclpy/src/rclpy/node.cpp
@@ -456,19 +456,21 @@ create_node(
 
   // turn the arguments into an array of C-style strings
   std::vector<const char *> arg_values;
-  const char ** const_arg_values = NULL;
+  const char ** const_arg_values = nullptr;
   py::list pyargs;
   if (!pycli_args.is_none()) {
     pyargs = pycli_args;
-    arg_values.resize(pyargs.size());
-    for (size_t i = 0; i < pyargs.size(); ++i) {
-      // CPython owns const char * memory - no need to free it
-      arg_values[i] = PyUnicode_AsUTF8(pyargs[i].ptr());
-      if (!arg_values[i]) {
-        throw py::error_already_set();
+    if (!pyargs.empty()) {
+      arg_values.resize(pyargs.size());
+      for (size_t i = 0; i < pyargs.size(); ++i) {
+        // CPython owns const char * memory - no need to free it
+        arg_values[i] = PyUnicode_AsUTF8(pyargs[i].ptr());
+        if (!arg_values[i]) {
+          throw py::error_already_set();
+        }
       }
+      const_arg_values = &(arg_values[0]);
     }
-    const_arg_values = &(arg_values[0]);
   }
 
   // call rcl_parse_arguments() so rcl_arguments_t structure is always valid.


### PR DESCRIPTION
Precisely what the title says. This patch addresses a regression introduced in #715 and #735, which is causing debug assertions to fail on Windows. 

CI up to `rclpy`: 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14127)](http://ci.ros2.org/job/ci_linux/14127/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8932)](http://ci.ros2.org/job/ci_linux-aarch64/8932/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11814)](http://ci.ros2.org/job/ci_osx/11814/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14224)](http://ci.ros2.org/job/ci_windows/14224/)
* Windows Debug [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14225)](http://ci.ros2.org/job/ci_windows/14225/)

Somehow, I managed to escape Bill's dungeon far quicker than anticipated :sweat_smile: 