### PR TITLE
Use py::class_ for rcl_duration_t

### DIFF
--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -25,11 +25,11 @@ class Duration:
             # pybind11 would raise TypeError, but we want OverflowError
             raise OverflowError(
                 'Total nanoseconds value is too large to store in C duration.')
-        self._duration_handle = _rclpy.rclpy_create_duration(total_nanoseconds)
+        self._duration_handle = _rclpy.rcl_duration_t(total_nanoseconds)
 
     @property
     def nanoseconds(self):
-        return _rclpy.rclpy_duration_get_nanoseconds(self._duration_handle)
+        return self._duration_handle.nanoseconds
 
     def __repr__(self):
         return 'Duration(nanoseconds={0})'.format(self.nanoseconds)

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -126,12 +126,7 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     "rclpy_ok", &rclpy::context_is_valid,
     "Return true if the context is valid");
 
-  m.def(
-    "rclpy_create_duration", &rclpy::create_duration,
-    "Create a duration");
-  m.def(
-    "rclpy_duration_get_nanoseconds", &rclpy::duration_get_nanoseconds,
-    "Get the nanoseconds value of a duration");
+  rclpy::define_duration(m);
 
   m.def(
     "rclpy_create_publisher", &rclpy::publisher_create,

--- a/rclpy/src/rclpy/duration.cpp
+++ b/rclpy/src/rclpy/duration.cpp
@@ -15,39 +15,22 @@
 #include <pybind11/pybind11.h>
 #include <rcl/time.h>
 
-#include <memory>
-
 #include "duration.hpp"
 
 namespace rclpy
 {
-void
-_rclpy_destroy_duration(PyObject * pycapsule)
-{
-  PyMem_Free(PyCapsule_GetPointer(pycapsule, "rcl_duration_t"));
-}
-
-py::capsule
+rcl_duration_t
 create_duration(int64_t nanoseconds)
 {
-  auto duration = static_cast<rcl_duration_t *>(PyMem_Malloc(sizeof(rcl_duration_t)));
-  if (!duration) {
-    throw std::bad_alloc();
-  }
-
-  duration->nanoseconds = nanoseconds;
-
-  return py::capsule(duration, "rcl_duration_t", _rclpy_destroy_duration);
+  rcl_duration_t duration;
+  duration.nanoseconds = nanoseconds;
+  return duration;
 }
-
-int64_t
-duration_get_nanoseconds(py::capsule pyduration)
+void
+define_duration(py::object module)
 {
-  if (0 != strcmp("rcl_duration_t", pyduration.name())) {
-    throw py::value_error("capsule is not an rcl_duration_t");
-  }
-  auto duration = static_cast<rcl_duration_t *>(pyduration);
-
-  return duration->nanoseconds;
+  py::class_<rcl_duration_t>(module, "rcl_duration_t")
+  .def(py::init<>(&create_duration))
+  .def_readonly("nanoseconds", &rcl_duration_t::nanoseconds);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/duration.hpp
+++ b/rclpy/src/rclpy/duration.hpp
@@ -21,25 +21,11 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-/// Create a duration
+/// Define a pybind11 wrapper for an rcl_duration_t
 /**
- * Raises TypeError if argument is of an invalid type
- *
- * \param[in] nanoseconds The nanoseconds value of the duration in a 64-bit signed integer
- * \return Capsule of the pointer to the created rcl_duration_t * structure
+ * \param[in] module a pybind11 module to add the definition to
  */
-py::capsule
-create_duration(int64_t nanoseconds);
-
-/// Returns the nanoseconds value of the duration
-/**
- * Raises ValueError if pyduration is not a duration capsule
- *
- * \param[in] pyduration Capsule pointing to the duration
- * \return integer nanoseconds
- */
-int64_t
-duration_get_nanoseconds(py::capsule pyduration);
+void define_duration(py::object module);
 }  // namespace rclpy
 
 #endif  // RCLPY__DURATION_HPP_

--- a/rclpy/src/rclpy/qos.cpp
+++ b/rclpy/src/rclpy/qos.cpp
@@ -72,7 +72,7 @@ namespace
 
 // Fill a given rmw_time_t from an rclpy.duration.Duration instance.
 void
-_convert_py_duration_to_rmw_time(const rcl_duration_t duration, rmw_time_t * out_time)
+_convert_py_duration_to_rmw_time(const rcl_duration_t & duration, rmw_time_t * out_time)
 {
   out_time->sec = RCL_NS_TO_S(duration.nanoseconds);
   out_time->nsec = duration.nanoseconds % (1000LL * 1000LL * 1000LL);
@@ -86,10 +86,10 @@ convert_from_py_qos_policy(
   int qos_depth,
   int qos_reliability,
   int qos_durability,
-  const rcl_duration_t pyqos_lifespan,
-  const rcl_duration_t pyqos_deadline,
+  const rcl_duration_t & pyqos_lifespan,
+  const rcl_duration_t & pyqos_deadline,
   int qos_liveliness,
-  const rcl_duration_t pyqos_liveliness_lease_duration,
+  const rcl_duration_t & pyqos_liveliness_lease_duration,
   bool avoid_ros_namespace_conventions)
 {
   auto qos_profile =

--- a/rclpy/src/rclpy/qos.cpp
+++ b/rclpy/src/rclpy/qos.cpp
@@ -72,15 +72,10 @@ namespace
 
 // Fill a given rmw_time_t from an rclpy.duration.Duration instance.
 void
-_convert_py_duration_to_rmw_time(py::capsule pyduration, rmw_time_t * out_time)
+_convert_py_duration_to_rmw_time(rcl_duration_t duration, rmw_time_t * out_time)
 {
-  assert(out_time != nullptr);
-  if (0 != strcmp("rcl_duration_t", pyduration.name())) {
-    throw py::value_error("capsule is not an rcl_duration_t");
-  }
-  auto duration = static_cast<rcl_duration_t *>(pyduration);
-  out_time->sec = RCL_NS_TO_S(duration->nanoseconds);
-  out_time->nsec = duration->nanoseconds % (1000LL * 1000LL * 1000LL);
+  out_time->sec = RCL_NS_TO_S(duration.nanoseconds);
+  out_time->nsec = duration.nanoseconds % (1000LL * 1000LL * 1000LL);
 }
 
 }  // namespace
@@ -91,10 +86,10 @@ convert_from_py_qos_policy(
   int qos_depth,
   int qos_reliability,
   int qos_durability,
-  py::capsule pyqos_lifespan,
-  py::capsule pyqos_deadline,
+  rcl_duration_t pyqos_lifespan,
+  rcl_duration_t pyqos_deadline,
   int qos_liveliness,
-  py::capsule pyqos_liveliness_lease_duration,
+  rcl_duration_t pyqos_liveliness_lease_duration,
   bool avoid_ros_namespace_conventions)
 {
   auto qos_profile =

--- a/rclpy/src/rclpy/qos.cpp
+++ b/rclpy/src/rclpy/qos.cpp
@@ -72,7 +72,7 @@ namespace
 
 // Fill a given rmw_time_t from an rclpy.duration.Duration instance.
 void
-_convert_py_duration_to_rmw_time(rcl_duration_t duration, rmw_time_t * out_time)
+_convert_py_duration_to_rmw_time(const rcl_duration_t duration, rmw_time_t * out_time)
 {
   out_time->sec = RCL_NS_TO_S(duration.nanoseconds);
   out_time->nsec = duration.nanoseconds % (1000LL * 1000LL * 1000LL);
@@ -86,10 +86,10 @@ convert_from_py_qos_policy(
   int qos_depth,
   int qos_reliability,
   int qos_durability,
-  rcl_duration_t pyqos_lifespan,
-  rcl_duration_t pyqos_deadline,
+  const rcl_duration_t pyqos_lifespan,
+  const rcl_duration_t pyqos_deadline,
   int qos_liveliness,
-  rcl_duration_t pyqos_liveliness_lease_duration,
+  const rcl_duration_t pyqos_liveliness_lease_duration,
   bool avoid_ros_namespace_conventions)
 {
   auto qos_profile =

--- a/rclpy/src/rclpy/qos.hpp
+++ b/rclpy/src/rclpy/qos.hpp
@@ -94,10 +94,10 @@ convert_from_py_qos_policy(
   int qos_depth,
   int qos_reliability,
   int qos_durability,
-  rcl_duration_t pyqos_lifespan,
-  rcl_duration_t pyqos_deadline,
+  const rcl_duration_t pyqos_lifespan,
+  const rcl_duration_t pyqos_deadline,
   int qos_liveliness,
-  rcl_duration_t pyqos_liveliness_lease_duration,
+  const rcl_duration_t pyqos_liveliness_lease_duration,
   bool avoid_ros_namespace_conventions);
 
 /// Convert a C rmw_qos_profile_t capsule to a dictionary.

--- a/rclpy/src/rclpy/qos.hpp
+++ b/rclpy/src/rclpy/qos.hpp
@@ -94,10 +94,10 @@ convert_from_py_qos_policy(
   int qos_depth,
   int qos_reliability,
   int qos_durability,
-  const rcl_duration_t pyqos_lifespan,
-  const rcl_duration_t pyqos_deadline,
+  const rcl_duration_t & pyqos_lifespan,
+  const rcl_duration_t & pyqos_deadline,
   int qos_liveliness,
-  const rcl_duration_t pyqos_liveliness_lease_duration,
+  const rcl_duration_t & pyqos_liveliness_lease_duration,
   bool avoid_ros_namespace_conventions);
 
 /// Convert a C rmw_qos_profile_t capsule to a dictionary.

--- a/rclpy/src/rclpy/qos.hpp
+++ b/rclpy/src/rclpy/qos.hpp
@@ -94,10 +94,10 @@ convert_from_py_qos_policy(
   int qos_depth,
   int qos_reliability,
   int qos_durability,
-  py::capsule pyqos_lifespan,
-  py::capsule pyqos_deadline,
+  rcl_duration_t pyqos_lifespan,
+  rcl_duration_t pyqos_deadline,
   int qos_liveliness,
-  py::capsule pyqos_liveliness_lease_duration,
+  rcl_duration_t pyqos_liveliness_lease_duration,
   bool avoid_ros_namespace_conventions);
 
 /// Convert a C rmw_qos_profile_t capsule to a dictionary.


### PR DESCRIPTION
Part of #665

This is a PR that refactors the code using `rcl_duration_t` to use a `py::class_` definition. 

Signed-off-by: ahcorde <ahcorde@gmail.com>