### PR TITLE
Use py::class_ for rmw_service_info_t and rmw_request_id_t

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -347,7 +347,7 @@ class Executor:
         header, response = seq_and_response
         if header is not None:
             try:
-                sequence = _rclpy.rclpy_service_info_get_sequence_number(header)
+                sequence = header.request_id.sequence_number
                 future = client._pending_requests[sequence]
             except KeyError:
                 # The request was cancelled

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -63,7 +63,7 @@ class Service:
         Send a service response.
 
         :param response: The service response.
-        :param header: Capsule pointing to the service header from the original request.
+        :param header: Service header from the original request.
         :raises: TypeError if the type of the passed response isn't an instance
           of the Response type of the provided service when the service was
           constructed.
@@ -71,7 +71,12 @@ class Service:
         if not isinstance(response, self.srv_type.Response):
             raise TypeError()
         with self.handle as capsule:
-            _rclpy.rclpy_send_response(capsule, response, header)
+            if isinstance(header, _rclpy.rmw_service_info_t):
+                _rclpy.rclpy_send_response(capsule, response, header.request_id)
+            elif isinstance(header, _rclpy.rmw_request_id_t):
+                _rclpy.rclpy_send_response(capsule, response, header)
+            else:
+                raise TypeError()
 
     @property
     def handle(self):

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -161,15 +161,7 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     "rclpy_take_request", &rclpy::service_take_request,
     "rclpy_take_request");
 
-  m.def(
-    "rclpy_service_info_get_sequence_number", &rclpy::service_info_get_sequence_number,
-    "Retrieve sequence number from service_info");
-  m.def(
-    "rclpy_service_info_get_source_timestamp", &rclpy::service_info_get_source_timestamp,
-    "Retrieve source timestamp from service_info");
-  m.def(
-    "rclpy_service_info_get_received_timestamp", &rclpy::service_info_get_received_timestamp,
-    "Retrieve received timestamp from service_info");
+  rclpy::define_service_info(m);
 
   m.def(
     "rclpy_qos_check_compatible", &rclpy::qos_check_compatible,

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -122,28 +122,16 @@ Client::service_server_is_available()
   return is_ready;
 }
 
-static void
-_rclpy_destroy_service_info(PyObject * pycapsule)
-{
-  PyMem_Free(PyCapsule_GetPointer(pycapsule, "rmw_service_info_t"));
-}
-
 py::tuple
 Client::take_response(py::object pyresponse_type)
 {
   auto taken_response = create_from_py(pyresponse_type);
 
-  auto deleter = [](rmw_service_info_t * ptr) {PyMem_Free(ptr);};
-  auto header = std::unique_ptr<rmw_service_info_t, decltype(deleter)>(
-    static_cast<rmw_service_info_t *>(PyMem_Malloc(sizeof(rmw_service_info_t))),
-    deleter);
-  if (!header) {
-    throw std::bad_alloc();
-  }
+  rmw_service_info_t header;
 
   py::tuple result_tuple(2);
   rcl_ret_t ret = rcl_take_response_with_info(
-    rcl_client_.get(), header.get(), taken_response.get());
+    rcl_client_.get(), &header, taken_response.get());
   if (ret == RCL_RET_CLIENT_TAKE_FAILED) {
     result_tuple[0] = py::none();
     result_tuple[1] = py::none();
@@ -153,8 +141,7 @@ Client::take_response(py::object pyresponse_type)
     throw RCLError("encountered error when taking client response");
   }
 
-  result_tuple[0] = py::capsule(
-    header.release(), "rmw_service_info_t", _rclpy_destroy_service_info);
+  result_tuple[0] = header;
 
   result_tuple[1] = convert_to_py(taken_response.get(), pyresponse_type);
   // result_tuple now owns the message

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -17,6 +17,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rmw/types.h>
 #include <string>
 
 namespace py = pybind11;
@@ -53,10 +54,10 @@ service_create(
  *
  * \param[in] pyservice Capsule pointing to the service
  * \param[in] pyresponse reply message to send
- * \param[in] pyheader Capsule pointing to the rmw_request_id_t header of the request we respond to
+ * \param[in] header Pointer to the rmw_request_id_t header of the request we respond to
  */
 void
-service_send_response(py::capsule pyservice, py::object pyresponse, py::capsule pyheader);
+service_send_response(py::capsule pyservice, py::object pyresponse, rmw_request_id_t * header);
 
 /// Take a request from a given service
 /**
@@ -68,7 +69,7 @@ service_send_response(py::capsule pyservice, py::object pyresponse, py::capsule 
  * \return None if there was nothing to take, or
  * \return List with 2 elements:
  *            first element: a Python request message with all fields populated with received request
- *            second element: a Capsule pointing to the header (rmw_request_id) of the processed request
+ *            second element: The rmw_request_id header of the processed request
  */
 py::object
 service_take_request(py::capsule pyservice, py::object pyrequest_type);

--- a/rclpy/src/rclpy/service_info.cpp
+++ b/rclpy/src/rclpy/service_info.cpp
@@ -21,33 +21,17 @@
 
 namespace rclpy
 {
-int64_t
-service_info_get_sequence_number(py::capsule pyservice_info)
-{
-  if (0 != strcmp("rmw_service_info_t", pyservice_info.name())) {
-    throw py::value_error("capsule is not an rmw_service_info_t");
-  }
-  auto service_info = static_cast<rmw_service_info_t *>(pyservice_info);
-  return service_info->request_id.sequence_number;
-}
 
-int64_t
-service_info_get_source_timestamp(py::capsule pyservice_info)
+void
+define_service_info(py::object module)
 {
-  if (0 != strcmp("rmw_service_info_t", pyservice_info.name())) {
-    throw py::value_error("capsule is not an rmw_service_info_t");
-  }
-  auto service_info = static_cast<rmw_service_info_t *>(pyservice_info);
-  return service_info->source_timestamp;
-}
+  py::class_<rmw_service_info_t>(module, "rmw_service_info_t")
+  .def_readonly("source_timestamp", &rmw_service_info_t::source_timestamp)
+  .def_readonly("received_timestamp", &rmw_service_info_t::received_timestamp)
+  .def_readonly("request_id", &rmw_service_info_t::request_id);
 
-int64_t
-service_info_get_received_timestamp(py::capsule pyservice_info)
-{
-  if (0 != strcmp("rmw_service_info_t", pyservice_info.name())) {
-    throw py::value_error("capsule is not an rmw_service_info_t");
-  }
-  auto service_info = static_cast<rmw_service_info_t *>(pyservice_info);
-  return service_info->received_timestamp;
+  py::class_<rmw_request_id_t>(module, "rmw_request_id_t")
+  .def_readonly("sequence_number", &rmw_request_id_t::sequence_number);
+  // "writer_guid" is not included because it's not used by rclpy
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/service_info.hpp
+++ b/rclpy/src/rclpy/service_info.hpp
@@ -21,35 +21,11 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-/// Retrieves the sequence number from a rmw_service_info_t capsule
+/// Define a pybind11 wrapper for an rmw_service_info_t and rmw_request_id_t
 /**
- * Raises ValueError if pyservice_info is not a service info capsule
- *
- * \param[in] pyservice_info Capsule pointing to the rmw_service_info_t
- * \return the sequence number as a long
+ * \param[in] module a pybind11 module to add the definition to
  */
-int64_t
-service_info_get_sequence_number(py::capsule pyservice_info);
-
-/// Retrieves the source timestamp number from a rmw_service_info_t capsule
-/**
- * Raises ValueError if pyservice_info is not a service info capsule
- *
- * \param[in] pyservice_info Capsule pointing to the rmw_service_info_t
- * \return the source timestamps as a long
- */
-int64_t
-service_info_get_source_timestamp(py::capsule pyservice_info);
-
-/// Retrieves the received timestsamp number from a rmw_service_info_t capsule
-/**
- * Raises ValueError if pyservice_info is not a service info capsule
- *
- * \param[in] pyservice_info Capsule pointing to the rmw_service_info_t
- * \return the receive timestamp as a long
- */
-int64_t
-service_info_get_received_timestamp(py::capsule pyservice_info);
+void define_service_info(py::object module);
 }  // namespace rclpy
 
 #endif  // RCLPY__SERVICE_INFO_HPP_

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -104,8 +104,7 @@ class TestClient(unittest.TestCase):
                     result = _rclpy.rclpy_take_request(capsule, srv.srv_type.Request)
                 if result is not None:
                     request, header = result
-                    source_timestamp = _rclpy.rclpy_service_info_get_source_timestamp(header)
-                    self.assertNotEqual(0, source_timestamp)
+                    self.assertNotEqual(0, header.source_timestamp)
                     return
                 else:
                     time.sleep(0.1)


### PR DESCRIPTION
Part of #665

This refactors the code using `rmw_service_info_t` and `rmw_request_id_t` to use a py::class_ definition.