### PR TITLE
Fix windows warning by using consistent types

### DIFF
--- a/rclpy/test/test_python_allocator.cpp
+++ b/rclpy/test/test_python_allocator.cpp
@@ -30,7 +30,7 @@ TEST(test_allocator, vector) {
   EXPECT_EQ(42u, container.capacity());
   ASSERT_EQ(42u, container.size());
 
-  for (size_t i = 0; i < 42u; ++i) {
+  for (int i = 0; i < 42; ++i) {
     container[i] = i;
   }
 }


### PR DESCRIPTION
Should fix https://ci.ros2.org/view/nightly/job/nightly_win_rel/1891/msbuild/new/

Part of #665