### PR TITLE
Check if shutdown callback weak method is valid before calling it

### DIFF
--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -87,7 +87,8 @@ class Context:
         with self._callbacks_lock:
             for weak_method in self._callbacks:
                 callback = weak_method()
-                callback()
+                if callback is not None:
+                    callback()
             self._callbacks = []
 
     def shutdown(self):


### PR DESCRIPTION
Fixes https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_repeated/1555/testReport/junit/(root)/projectroot/test_client/.

The issue might also be related to some of the pybind11 migration changes, but checking if the weak method is valid before calling it seems reasonable to do.