### PR TITLE
Change index.ros.org -> docs.ros.org.

### DIFF
--- a/rclpy/docs/source/about.rst
+++ b/rclpy/docs/source/about.rst
@@ -1,7 +1,7 @@
 About
 =====
 
-The canonical Python API for `ROS 2 <https://index.ros.org/doc/ros2>`_.
+The canonical Python API for `ROS 2 <https://docs.ros.org/en/rolling>`_.
 
 *rclpy* is built on the common C-API provided by `rcl <https://github.com/ros2/rcl>`_.
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>