### PR TITLE
Use `std::shared_ptr` holder type for Destroyable subsclasses to keep grandparent wrapper instances alive

### DIFF
--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -155,7 +155,7 @@ Client::take_response(py::object pyresponse_type)
 void
 define_client(py::object module)
 {
-  py::class_<Client, Destroyable>(module, "Client")
+  py::class_<Client, Destroyable, std::shared_ptr<Client>>(module, "Client")
   .def(py::init<py::capsule, py::object, const char *, py::object>())
   .def_property_readonly(
     "pointer", [](const Client & client) {

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -28,7 +28,7 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-class Client : public Destroyable
+class Client : public Destroyable, public std::enable_shared_from_this<Client>
 {
 public:
   /// Create a client

--- a/rclpy/src/rclpy/clock.cpp
+++ b/rclpy/src/rclpy/clock.cpp
@@ -181,7 +181,7 @@ void Clock::remove_clock_callback(py::object pyjump_handle)
 
 void define_clock(py::object module)
 {
-  py::class_<Clock, Destroyable>(module, "Clock")
+  py::class_<Clock, Destroyable, std::shared_ptr<Clock>>(module, "Clock")
   .def(py::init<rcl_clock_type_t>())
   .def_property_readonly(
     "pointer", [](const Clock & clock) {

--- a/rclpy/src/rclpy/clock.hpp
+++ b/rclpy/src/rclpy/clock.hpp
@@ -31,7 +31,7 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-class Clock : public Destroyable
+class Clock : public Destroyable, public std::enable_shared_from_this<Clock>
 {
 public:
   /// Create a clock

--- a/rclpy/src/rclpy/clock.hpp
+++ b/rclpy/src/rclpy/clock.hpp
@@ -106,12 +106,6 @@ public:
   remove_clock_callback(py::object pyjump_handle);
 
   /// Get rcl_client_t pointer
-  std::shared_ptr<rcl_clock_t> get_shared_ptr()
-  {
-    return rcl_clock_;
-  }
-
-  /// Get rcl_client_t pointer
   rcl_clock_t * rcl_ptr() const
   {
     return rcl_clock_.get();

--- a/rclpy/src/rclpy/destroyable.cpp
+++ b/rclpy/src/rclpy/destroyable.cpp
@@ -62,7 +62,7 @@ Destroyable::destroy_when_not_in_use()
 void
 define_destroyable(py::object module)
 {
-  py::class_<Destroyable>(module, "Destroyable")
+  py::class_<Destroyable, std::shared_ptr<Destroyable>>(module, "Destroyable")
   .def("__enter__", &Destroyable::enter)
   .def("__exit__", &Destroyable::exit)
   .def(

--- a/rclpy/src/rclpy/qos_event.cpp
+++ b/rclpy/src/rclpy/qos_event.cpp
@@ -168,7 +168,7 @@ QoSEvent::take_event()
 void
 define_qos_event(py::module module)
 {
-  py::class_<QoSEvent, Destroyable>(module, "QoSEvent")
+  py::class_<QoSEvent, Destroyable, std::shared_ptr<QoSEvent>>(module, "QoSEvent")
   .def(py::init<py::capsule, rcl_subscription_event_type_t>())
   .def(py::init<py::capsule, rcl_publisher_event_type_t>())
   .def_property_readonly(

--- a/rclpy/src/rclpy/qos_event.hpp
+++ b/rclpy/src/rclpy/qos_event.hpp
@@ -29,7 +29,7 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-class QoSEvent : public Destroyable
+class QoSEvent : public Destroyable, public std::enable_shared_from_this<QoSEvent>
 {
 public:
   /// Create a subscription event

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -139,7 +139,7 @@ Service::service_take_request(py::object pyrequest_type)
 void
 define_service(py::object module)
 {
-  py::class_<Service, Destroyable>(module, "Service")
+  py::class_<Service, Destroyable, std::shared_ptr<Service>>(module, "Service")
   .def(py::init<py::capsule, py::object, std::string, py::object>())
   .def_property_readonly(
     "pointer", [](const Service & service) {

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -33,7 +33,7 @@ namespace py = pybind11;
 namespace rclpy
 {
 
-class Service : public Destroyable
+class Service : public Destroyable, public std::enable_shared_from_this<Service>
 {
 public:
   /// Create a service server

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -168,7 +168,7 @@ bool Timer::is_timer_canceled()
 void
 define_timer(py::object module)
 {
-  py::class_<Timer, Destroyable>(module, "Timer")
+  py::class_<Timer, Destroyable, std::shared_ptr<Timer>>(module, "Timer")
   .def(py::init<Clock &, py::capsule, int64_t>())
   .def_property_readonly(
     "pointer", [](const Timer & timer) {

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -43,7 +43,7 @@ Timer::destroy()
 Timer::Timer(
   Clock & rclcy_clock, py::capsule pycontext, int64_t period_nsec)
 {
-  clock_handle_ = rclcy_clock.get_shared_ptr();
+  clock_handle_ = rclcy_clock.shared_from_this();
 
   auto context = static_cast<rcl_context_t *>(
     rclpy_handle_get_pointer_from_capsule(pycontext.ptr(), "rcl_context_t"));
@@ -72,7 +72,7 @@ Timer::Timer(
   rcl_allocator_t allocator = rcl_get_default_allocator();
 
   rcl_ret_t ret = rcl_timer_init(
-    rcl_timer_.get(), clock_handle_.get(), context,
+    rcl_timer_.get(), clock_handle_->rcl_ptr(), context,
     period_nsec, NULL, allocator);
 
   if (RCL_RET_OK != ret) {

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -30,7 +30,7 @@ namespace py = pybind11;
 namespace rclpy
 {
 
-class Timer : public Destroyable
+class Timer : public Destroyable, public std::enable_shared_from_this<Timer>
 {
 public:
   /// Create a timer

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -133,8 +133,7 @@ public:
   void destroy() override;
 
 private:
-  // TODO(ahcorde) replace with std::shared_ptr<rcl_clock_t> when rclpy::Clock exists
-  std::shared_ptr<rcl_clock_t> clock_handle_;
+  std::shared_ptr<Clock> clock_handle_;
   std::shared_ptr<rcl_timer_t> rcl_timer_;
 };
 


### PR DESCRIPTION
Part of #665 - alternative to #757


This makes `Destroyable` subclasses use the `std::shared_ptr` holder type and use `shared_from this`. This allows classes to keep the parent wrapper instance alive so that grandparent's are kept alive too.

Since `clock` has no grandparent types, there isn't actually an issue in `master` - it's not until #756 adds Publisher and Subscription that it becomes an issue.. Maybe it's fine to leave this as is, and include this fix via #757 to #756?