### PR TITLE
Fix segfault by adding __enter__ and __exit__ to Waitable

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -506,9 +506,6 @@ class Executor:
             entity_count = NumberOfEntities(
                 len(subscriptions), len(guards), len(timers), len(clients), len(services))
 
-            for waitable in waitables:
-                entity_count += waitable.get_num_entities()
-
             # Construct a wait set
             wait_set = _rclpy.rclpy_get_zero_initialized_wait_set()
             with ExitStack() as context_stack:
@@ -549,6 +546,13 @@ class Executor:
                         guard_capsules.append(context_stack.enter_context(gc.handle))
                     except InvalidHandle:
                         entity_count.num_guard_conditions -= 1
+
+                for waitable in waitables:
+                    try:
+                        context_stack.enter_context(waitable)
+                        entity_count += waitable.get_num_entities()
+                    except InvalidHandle:
+                        pass
 
                 context_capsule = context_stack.enter_context(self._context.handle)
                 _rclpy.rclpy_wait_set_init(

--- a/rclpy/rclpy/qos_event.py
+++ b/rclpy/rclpy/qos_event.py
@@ -114,6 +114,14 @@ class QoSEventHandler(Waitable):
         with self.__event:
             self._event_index = _rclpy.rclpy_wait_set_add_event(wait_set, self.__event)
 
+    def __enter__(self):
+        """Mark event as in-use to prevent destruction while waiting on it."""
+        self.__event.__enter__()
+
+    def __exit__(self, t, v, tb):
+        """Mark event as not-in-use to allow destruction after waiting on it."""
+        self.__event.__exit__(t, v, tb)
+
     def destroy(self):
         self.__event.destroy_when_not_in_use()
 

--- a/rclpy/rclpy/waitable.py
+++ b/rclpy/rclpy/waitable.py
@@ -65,6 +65,14 @@ class Waitable:
         # List of Futures that have callbacks needing execution
         self._futures = []
 
+    def __enter__(self):
+        """Implement to mark entities as in-use to prevent destruction while waiting on them."""
+        pass
+
+    def __exit__(self, t, v, tb):
+        """Implement to mark entities as not-in-use to allow destruction after waiting on them."""
+        pass
+
     def add_future(self, future):
         self._futures.append(future)
 


### PR DESCRIPTION
Fixes #760

Also make QoS event waitable use it. This fixes a crash when another
thread is spinning on a destroyed subscription using cyclonedds.


I was never able to reproduce the crash with `rqt_console`, but I can confirm it fixes the crash with this MRE https://github.com/ros2/rclpy/issues/760#issuecomment-815287677