### PR TITLE
Use correct type when creating test publisher

### DIFF
--- a/rclpy/test/test_messages.py
+++ b/rclpy/test/test_messages.py
@@ -65,6 +65,6 @@ class TestMessages(unittest.TestCase):
     def test_serialized_publish(self):
         msg = Strings()
         msg.string_value = 'ñu'
-        pub = self.node.create_publisher(BasicTypes, 'chatter', 1)
+        pub = self.node.create_publisher(Strings, 'chatter', 1)
         pub.publish(serialize_message(msg))
         self.node.destroy_publisher(pub)


### PR DESCRIPTION
This PR fixes `test_serialized_publish` from `test_messages.py`. The test creates a publisher for type `BasicTypes` but then tries to publish a message of type `Strings`.