### PR TITLE
Restore exceptions for Connext and message timestamps on Windows

### DIFF
--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import platform
 import time
 import unittest
-import platform
 
 from rcl_interfaces.srv import GetParameters
 import rclpy

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -14,10 +14,12 @@
 
 import time
 import unittest
+import platform
 
 from rcl_interfaces.srv import GetParameters
 import rclpy
 import rclpy.executors
+from rclpy.utilities import get_rmw_implementation_identifier
 
 # TODO(sloretz) Reduce fudge once wait_for_service uses node graph events
 TIME_FUDGE = 0.3
@@ -89,6 +91,9 @@ class TestClient(unittest.TestCase):
             self.node.destroy_client(cli)
             self.node.destroy_service(srv)
 
+    @unittest.skipIf(
+        get_rmw_implementation_identifier() == 'rmw_connextdds' and platform.system() == 'Windows',
+        reason='Source timestamp not implemented for Connext on Windows')
     def test_service_timestamps(self):
         cli = self.node.create_client(GetParameters, 'get/parameters')
         srv = self.node.create_service(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import pathlib
+import platform
 import time
 import unittest
 from unittest.mock import Mock
 import warnings
-import platform
 
 import pytest
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -17,6 +17,7 @@ import time
 import unittest
 from unittest.mock import Mock
 import warnings
+import platform
 
 import pytest
 
@@ -49,6 +50,7 @@ from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time_source import USE_SIM_TIME_NAME
+from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.msg import BasicTypes
 
 TEST_NODE = 'my_node'
@@ -144,6 +146,9 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     def dummy_cb(self, msg):
         pass
 
+    @unittest.skipIf(
+        get_rmw_implementation_identifier() == 'rmw_connextdds' and platform.system() == 'Windows',
+        reason='Source timestamp not implemented for Connext on Windows')
     def test_take(self):
         basic_types_pub = self.node.create_publisher(BasicTypes, 'take_test', 1)
         sub = self.node.create_subscription(


### PR DESCRIPTION
This PR restores some test exceptions in `test_client.py` and `test_node.py` to skip tests which check message timestamps on Windows.

These exceptions were removed in the process of replacing `rmw_connext_cpp` with `rmw_connextdds`, but they should have been kept for Windows, since timestamps are currently not supported on this platform.