### PR TITLE
Intentionally copy rclpy:: objects instead of having RclPtrs structs

### DIFF
--- a/rclpy/src/rclpy/action_client.cpp
+++ b/rclpy/src/rclpy/action_client.cpp
@@ -34,7 +34,7 @@ void
 ActionClient::destroy()
 {
   rcl_action_client_.reset();
-  node_.reset();
+  node_.destroy();
 }
 
 ActionClient::ActionClient(
@@ -46,7 +46,7 @@ ActionClient::ActionClient(
   const rmw_qos_profile_t & cancel_service_qos,
   const rmw_qos_profile_t & feedback_topic_qos,
   const rmw_qos_profile_t & status_topic_qos)
-: node_(node.shared_from_this())
+: node_(node)
 {
   rosidl_action_type_support_t * ts =
     static_cast<rosidl_action_type_support_t *>(rclpy_common_get_type_support(
@@ -65,9 +65,10 @@ ActionClient::ActionClient(
 
   rcl_action_client_ = std::shared_ptr<rcl_action_client_t>(
     new rcl_action_client_t,
-    [this](rcl_action_client_t * action_client)
+    [node](rcl_action_client_t * action_client)
     {
-      rcl_ret_t ret = rcl_action_client_fini(action_client, node_->rcl_ptr());
+      // Intentionally capture node by value so shared_ptr can be transferred to copies
+      rcl_ret_t ret = rcl_action_client_fini(action_client, node.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -83,7 +84,7 @@ ActionClient::ActionClient(
 
   rcl_ret_t ret = rcl_action_client_init(
     rcl_action_client_.get(),
-    node_->rcl_ptr(),
+    node_.rcl_ptr(),
     ts,
     action_name,
     &action_client_ops);
@@ -220,7 +221,7 @@ ActionClient::is_action_server_available()
 {
   bool is_available = false;
   rcl_ret_t ret = rcl_action_server_is_available(
-    node_->rcl_ptr(), rcl_action_client_.get(), &is_available);
+    node_.rcl_ptr(), rcl_action_client_.get(), &is_available);
   if (RCL_RET_OK != ret) {
     throw rclpy::RCLError("Failed to check if action server is available");
   }

--- a/rclpy/src/rclpy/action_client.hpp
+++ b/rclpy/src/rclpy/action_client.hpp
@@ -214,7 +214,7 @@ public:
   void
   add_to_waitset(WaitSet & wait_set);
 
-  /// Get rcl_client_t pointer
+  /// Get rcl_action_client_t pointer
   rcl_action_client_t *
   rcl_ptr() const
   {
@@ -226,7 +226,7 @@ public:
   destroy() override;
 
 private:
-  std::shared_ptr<Node> node_;
+  Node node_;
   std::shared_ptr<rcl_action_client_t> rcl_action_client_;
 };
 /// Define a pybind11 wrapper for an rcl_time_point_t

--- a/rclpy/src/rclpy/action_goal_handle.cpp
+++ b/rclpy/src/rclpy/action_goal_handle.cpp
@@ -31,6 +31,7 @@ namespace rclpy
 {
 ActionGoalHandle::ActionGoalHandle(
   rclpy::ActionServer & action_server, py::object pygoal_info_msg)
+: action_server_(action_server)
 {
   destroy_ros_message_signature * destroy_ros_message = NULL;
   auto goal_info_msg = static_cast<rcl_action_goal_info_t *>(
@@ -72,6 +73,7 @@ void
 ActionGoalHandle::destroy()
 {
   rcl_action_goal_handle_.reset();
+  action_server_.destroy();
 }
 
 rcl_action_goal_state_t

--- a/rclpy/src/rclpy/action_goal_handle.hpp
+++ b/rclpy/src/rclpy/action_goal_handle.hpp
@@ -75,6 +75,7 @@ public:
   destroy() override;
 
 private:
+  ActionServer action_server_;
   std::shared_ptr<rcl_action_goal_handle_t> rcl_action_goal_handle_;
 };
 

--- a/rclpy/src/rclpy/action_server.hpp
+++ b/rclpy/src/rclpy/action_server.hpp
@@ -233,18 +233,11 @@ public:
   void
   add_to_waitset(WaitSet & wait_set);
 
-  /// Get rcl_client_t pointer
+  /// Get rcl_action_server_t pointer
   rcl_action_server_t *
   rcl_ptr() const
   {
     return rcl_action_server_.get();
-  }
-
-  /// Get rcl_client_t pointer
-  std::shared_ptr<rcl_action_server_t>
-  get_rcl_shared_ptr()
-  {
-    return rcl_action_server_;
   }
 
   /// Force an early destruction of this object
@@ -252,7 +245,7 @@ public:
   destroy() override;
 
 private:
-  std::shared_ptr<Node> node_;
+  Node node_;
   std::shared_ptr<rcl_action_server_t> rcl_action_server_;
 };
 /// Define a pybind11 wrapper for an rcl_time_point_t

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -34,12 +34,12 @@ void
 Client::destroy()
 {
   rcl_client_.reset();
-  node_.reset();
+  node_.destroy_when_not_in_use();
 }
 
 Client::Client(
   Node & node, py::object pysrv_type, const char * service_name, py::object pyqos_profile)
-: node_(node.shared_from_this())
+: node_(node)
 {
   auto srv_type = static_cast<rosidl_service_type_support_t *>(
     rclpy_common_get_type_support(pysrv_type.ptr()));
@@ -59,7 +59,7 @@ Client::Client(
     PythonAllocator<rcl_client_t>().allocate(1),
     [this](rcl_client_t * client)
     {
-      rcl_ret_t ret = rcl_client_fini(client, node_->rcl_ptr());
+      rcl_ret_t ret = rcl_client_fini(client, node_.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -74,7 +74,7 @@ Client::Client(
   *rcl_client_ = rcl_get_zero_initialized_client();
 
   rcl_ret_t ret = rcl_client_init(
-    rcl_client_.get(), node_->rcl_ptr(), srv_type, service_name, &client_ops);
+    rcl_client_.get(), node_.rcl_ptr(), srv_type, service_name, &client_ops);
   if (RCL_RET_OK != ret) {
     if (RCL_RET_SERVICE_NAME_INVALID == ret) {
       std::string error_text{"failed to create client due to invalid service name '"};
@@ -111,8 +111,7 @@ bool
 Client::service_server_is_available()
 {
   bool is_ready;
-  rcl_ret_t ret = rcl_service_server_is_available(
-    node_->rcl_ptr(), rcl_client_.get(), &is_ready);
+  rcl_ret_t ret = rcl_service_server_is_available(node_.rcl_ptr(), rcl_client_.get(), &is_ready);
   if (RCL_RET_OK != ret) {
     throw RCLError("failed to check service availability");
   }

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -34,7 +34,7 @@ void
 Client::destroy()
 {
   rcl_client_.reset();
-  node_.destroy_when_not_in_use();
+  node_.destroy();
 }
 
 Client::Client(
@@ -57,9 +57,10 @@ Client::Client(
   // Create a client
   rcl_client_ = std::shared_ptr<rcl_client_t>(
     PythonAllocator<rcl_client_t>().allocate(1),
-    [this](rcl_client_t * client)
+    [node](rcl_client_t * client)
     {
-      rcl_ret_t ret = rcl_client_fini(client, node_.rcl_ptr());
+      // Intentionally capture node by value so shared_ptr can be transferred to copies
+      rcl_ret_t ret = rcl_client_fini(client, node.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -91,7 +91,7 @@ public:
   destroy() override;
 
 private:
-  std::shared_ptr<Node> node_;
+  Node node_;
   std::shared_ptr<rcl_client_t> rcl_client_;
 };
 

--- a/rclpy/src/rclpy/context.cpp
+++ b/rclpy/src/rclpy/context.cpp
@@ -32,9 +32,7 @@ namespace rclpy
 {
 Context::Context()
 {
-  rcl_ptrs_ = std::make_shared<rclpy::Context::RclPtrs>();
-  // Create a client
-  rcl_ptrs_->rcl_context_ = std::unique_ptr<rcl_context_t, std::function<void(rcl_context_t *)>>(
+  rcl_context_ = std::shared_ptr<rcl_context_t>(
     new rcl_context_t,
     [](rcl_context_t * context)
     {
@@ -66,20 +64,20 @@ Context::Context()
       }
       delete context;
     });
-  *rcl_ptrs_->rcl_context_ = rcl_get_zero_initialized_context();
+  *rcl_context_ = rcl_get_zero_initialized_context();
 }
 
 void
 Context::destroy()
 {
-  rcl_ptrs_.reset();
+  rcl_context_.reset();
 }
 
 size_t
 Context::get_domain_id()
 {
   size_t domain_id;
-  rcl_ret_t ret = rcl_context_get_domain_id(rcl_ptrs_->rcl_context_.get(), &domain_id);
+  rcl_ret_t ret = rcl_context_get_domain_id(rcl_context_.get(), &domain_id);
   if (RCL_RET_OK != ret) {
     throw RCLError("Failed to get domain id");
   }
@@ -90,13 +88,13 @@ Context::get_domain_id()
 bool
 Context::ok()
 {
-  return rcl_context_is_valid(rcl_ptrs_->rcl_context_.get());
+  return rcl_context_is_valid(rcl_context_.get());
 }
 
 void
 Context::shutdown()
 {
-  rcl_ret_t ret = rcl_shutdown(rcl_ptrs_->rcl_context_.get());
+  rcl_ret_t ret = rcl_shutdown(rcl_context_.get());
   if (RCL_RET_OK != ret) {
     throw RCLError("failed to shutdown");
   }

--- a/rclpy/src/rclpy/context.hpp
+++ b/rclpy/src/rclpy/context.hpp
@@ -57,26 +57,14 @@ public:
   /// Get rcl_context_t pointer
   rcl_context_t * rcl_ptr() const
   {
-    return rcl_ptrs_->rcl_context_.get();
+    return rcl_context_.get();
   }
 
   /// Force an early destruction of this object
   void destroy() override;
 
-  struct RclPtrs
-  {
-    std::unique_ptr<rcl_context_t, std::function<void(rcl_context_t *)>> rcl_context_;
-  };
-
-  /// Return RCL pointers so another class can keep the rcl part alive
-  std::shared_ptr<rclpy::Context::RclPtrs>
-  get_rcl_ptrs() const
-  {
-    return rcl_ptrs_;
-  }
-
 private:
-  std::shared_ptr<rclpy::Context::RclPtrs> rcl_ptrs_;
+  std::shared_ptr<rcl_context_t> rcl_context_;
 };
 
 /// Define a pybind11 wrapper for an rclpy::Service

--- a/rclpy/src/rclpy/destroyable.cpp
+++ b/rclpy/src/rclpy/destroyable.cpp
@@ -19,8 +19,17 @@
 #include "destroyable.hpp"
 #include "rclpy_common/exceptions.hpp"
 
+
 namespace rclpy
 {
+Destroyable::Destroyable(const Destroyable &)
+{
+  // When a destroyable is copied, it does not matter if someone asked
+  // to destroy the original. The copy has its own lifetime.
+  use_count = 0;
+  please_destroy_ = false;
+}
+
 void
 Destroyable::enter()
 {

--- a/rclpy/src/rclpy/destroyable.hpp
+++ b/rclpy/src/rclpy/destroyable.hpp
@@ -25,6 +25,12 @@ namespace rclpy
 class Destroyable
 {
 public:
+  /// Default constructor
+  Destroyable() = default;
+
+  /// Copy constructor
+  Destroyable(const Destroyable & other);
+
   /// Context manager __enter__ - block destruction
   void
   enter();

--- a/rclpy/src/rclpy/guard_condition.cpp
+++ b/rclpy/src/rclpy/guard_condition.cpp
@@ -64,7 +64,7 @@ void
 GuardCondition::destroy()
 {
   rcl_guard_condition_.reset();
-  context_.destroy_when_not_in_use();
+  context_.destroy();
 }
 
 void

--- a/rclpy/src/rclpy/guard_condition.cpp
+++ b/rclpy/src/rclpy/guard_condition.cpp
@@ -32,9 +32,8 @@
 namespace rclpy
 {
 GuardCondition::GuardCondition(Context & context)
+: context_(context)
 {
-  rcl_context_ = context.shared_from_this();
-
   rcl_guard_condition_ = std::shared_ptr<rcl_guard_condition_t>(
     new rcl_guard_condition_t,
     [](rcl_guard_condition_t * guard_condition)
@@ -65,7 +64,7 @@ void
 GuardCondition::destroy()
 {
   rcl_guard_condition_.reset();
-  rcl_context_.reset();
+  context_.destroy_when_not_in_use();
 }
 
 void

--- a/rclpy/src/rclpy/guard_condition.hpp
+++ b/rclpy/src/rclpy/guard_condition.hpp
@@ -72,6 +72,7 @@ public:
   void destroy() override;
 
 private:
+  Context context_;
   std::shared_ptr<rcl_guard_condition_t> rcl_guard_condition_;
 
   /// Handle destructor for guard condition
@@ -81,7 +82,6 @@ private:
     (void)p;
     // Empty destructor, the class should take care of the lifecycle.
   }
-  std::shared_ptr<Context> rcl_context_;
 };
 
 /// Define a pybind11 wrapper for an rclpy::Service

--- a/rclpy/src/rclpy/node.cpp
+++ b/rclpy/src/rclpy/node.cpp
@@ -40,7 +40,6 @@
 #include "node.hpp"
 #include "utils.hpp"
 
-
 namespace rclpy
 {
 const char *
@@ -368,7 +367,7 @@ Node::get_parameters(py::object pyparameter_cls)
 void Node::destroy()
 {
   rcl_node_.reset();
-  context_.destroy_when_not_in_use();
+  context_.destroy();
 }
 
 Node::Node(

--- a/rclpy/src/rclpy/node.cpp
+++ b/rclpy/src/rclpy/node.cpp
@@ -46,8 +46,7 @@ namespace rclpy
 const char *
 Node::get_fully_qualified_name()
 {
-  const char * fully_qualified_node_name = rcl_node_get_fully_qualified_name(
-    rcl_ptrs_->rcl_node_.get());
+  const char * fully_qualified_node_name = rcl_node_get_fully_qualified_name(rcl_node_.get());
   if (!fully_qualified_node_name) {
     throw RCLError("Fully qualified name not set");
   }
@@ -58,7 +57,7 @@ Node::get_fully_qualified_name()
 const char *
 Node::logger_name()
 {
-  const char * node_logger_name = rcl_node_get_logger_name(rcl_ptrs_->rcl_node_.get());
+  const char * node_logger_name = rcl_node_get_logger_name(rcl_node_.get());
   if (!node_logger_name) {
     throw RCLError("Logger name not set");
   }
@@ -69,7 +68,7 @@ Node::logger_name()
 const char *
 Node::get_node_name()
 {
-  const char * node_name = rcl_node_get_name(rcl_ptrs_->rcl_node_.get());
+  const char * node_name = rcl_node_get_name(rcl_node_.get());
   if (!node_name) {
     throw RCLError("Node name not set");
   }
@@ -80,7 +79,7 @@ Node::get_node_name()
 const char *
 Node::get_namespace()
 {
-  const char * node_namespace = rcl_node_get_namespace(rcl_ptrs_->rcl_node_.get());
+  const char * node_namespace = rcl_node_get_namespace(rcl_node_.get());
   if (!node_namespace) {
     throw RCLError("Node namespace not set");
   }
@@ -92,7 +91,7 @@ size_t
 Node::get_count_publishers(const char * topic_name)
 {
   size_t count = 0;
-  rcl_ret_t ret = rcl_count_publishers(rcl_ptrs_->rcl_node_.get(), topic_name, &count);
+  rcl_ret_t ret = rcl_count_publishers(rcl_node_.get(), topic_name, &count);
   if (RCL_RET_OK != ret) {
     throw RCLError("Error in rcl_count_publishers");
   }
@@ -104,7 +103,7 @@ size_t
 Node::get_count_subscribers(const char * topic_name)
 {
   size_t count = 0;
-  rcl_ret_t ret = rcl_count_subscribers(rcl_ptrs_->rcl_node_.get(), topic_name, &count);
+  rcl_ret_t ret = rcl_count_subscribers(rcl_node_.get(), topic_name, &count);
   if (RCL_RET_OK != ret) {
     throw RCLError("Error in rcl_count_subscribers");
   }
@@ -123,10 +122,10 @@ Node::get_names_impl(bool get_enclaves)
   rcl_ret_t ret = RCL_RET_OK;
   if (get_enclaves) {
     ret = rcl_get_node_names_with_enclaves(
-      rcl_ptrs_->rcl_node_.get(), allocator, &node_names, &node_namespaces, &enclaves);
+      rcl_node_.get(), allocator, &node_names, &node_namespaces, &enclaves);
   } else {
     ret = rcl_get_node_names(
-      rcl_ptrs_->rcl_node_.get(), allocator, &node_names, &node_namespaces);
+      rcl_node_.get(), allocator, &node_names, &node_namespaces);
   }
   if (RCL_RET_OK != ret) {
     throw RCLError("Failed to get node names");
@@ -330,11 +329,11 @@ Node::get_parameters(py::object pyparameter_cls)
   py::dict params_by_node_name;
   py::object parameter_type_cls = pyparameter_cls.attr("Type");
 
-  const rcl_node_options_t * node_options = rcl_node_get_options(rcl_ptrs_->rcl_node_.get());
+  const rcl_node_options_t * node_options = rcl_node_get_options(rcl_node_.get());
 
   if (node_options->use_global_arguments) {
     _parse_param_overrides(
-      &(rcl_ptrs_->rcl_node_.get()->context->global_arguments), pyparameter_cls,
+      &(rcl_node_.get()->context->global_arguments), pyparameter_cls,
       parameter_type_cls, params_by_node_name);
   }
 
@@ -342,7 +341,7 @@ Node::get_parameters(py::object pyparameter_cls)
     &(node_options->arguments), pyparameter_cls,
     parameter_type_cls, params_by_node_name);
 
-  const char * node_fqn = rcl_node_get_fully_qualified_name(rcl_ptrs_->rcl_node_.get());
+  const char * node_fqn = rcl_node_get_fully_qualified_name(rcl_node_.get());
   if (!node_fqn) {
     throw RCLError("failed to get node fully qualified name");
   }
@@ -368,7 +367,8 @@ Node::get_parameters(py::object pyparameter_cls)
 
 void Node::destroy()
 {
-  rcl_ptrs_.reset();
+  rcl_node_.reset();
+  context_.destroy_when_not_in_use();
 }
 
 Node::Node(
@@ -378,7 +378,7 @@ Node::Node(
   py::object pycli_args,
   bool use_global_arguments,
   bool enable_rosout)
-: rcl_ptrs_(new rclpy::Node::RclPtrs())
+: context_(context)
 {
   rcl_ret_t ret;
   rcl_arguments_t arguments = rcl_get_zero_initialized_arguments();
@@ -432,8 +432,7 @@ Node::Node(
 
   throw_if_unparsed_ros_args(pyargs, arguments);
 
-  rcl_ptrs_->context_ptrs = context.get_rcl_ptrs();
-  rcl_ptrs_->rcl_node_ = std::unique_ptr<rcl_node_t, std::function<void(rcl_node_t *)>>(
+  rcl_node_ = std::shared_ptr<rcl_node_t>(
     new rcl_node_t,
     [](rcl_node_t * node)
     {
@@ -449,7 +448,7 @@ Node::Node(
       delete node;
     });
 
-  *rcl_ptrs_->rcl_node_ = rcl_get_zero_initialized_node();
+  *rcl_node_ = rcl_get_zero_initialized_node();
   rcl_node_options_t options = rcl_node_get_default_options();
   options.use_global_arguments = use_global_arguments;
   options.arguments = arguments;
@@ -458,7 +457,7 @@ Node::Node(
   {
     rclpy::LoggingGuard scoped_logging_guard;
     ret = rcl_node_init(
-      rcl_ptrs_->rcl_node_.get(), node_name, namespace_, context.rcl_ptr(), &options);
+      rcl_node_.get(), node_name, namespace_, context.rcl_ptr(), &options);
   }
 
   if (RCL_RET_BAD_ALLOC == ret) {
@@ -483,7 +482,7 @@ Node::get_action_client_names_and_types_by_node(
   rcl_names_and_types_t names_and_types = rcl_get_zero_initialized_names_and_types();
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_action_get_client_names_and_types_by_node(
-    rcl_ptrs_->rcl_node_.get(),
+    rcl_node_.get(),
     &allocator,
     remote_node_name,
     remote_node_namespace,
@@ -502,7 +501,7 @@ Node::get_action_server_names_and_types_by_node(
   rcl_names_and_types_t names_and_types = rcl_get_zero_initialized_names_and_types();
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_action_get_server_names_and_types_by_node(
-    rcl_ptrs_->rcl_node_.get(),
+    rcl_node_.get(),
     &allocator,
     remote_node_name,
     remote_node_namespace,
@@ -519,8 +518,7 @@ Node::get_action_names_and_types()
 {
   rcl_names_and_types_t names_and_types = rcl_get_zero_initialized_names_and_types();
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  rcl_ret_t ret = rcl_action_get_names_and_types(
-    rcl_ptrs_->rcl_node_.get(), &allocator, &names_and_types);
+  rcl_ret_t ret = rcl_action_get_names_and_types(rcl_node_.get(), &allocator, &names_and_types);
   if (RCL_RET_OK != ret) {
     throw rclpy::RCLError("Failed to get action names and type");
   }

--- a/rclpy/src/rclpy/node.hpp
+++ b/rclpy/src/rclpy/node.hpp
@@ -170,29 +170,16 @@ public:
   py::list
   get_action_names_and_types();
 
-  /// Get rcl_client_t pointer
+  /// Get rcl_node_t pointer
   rcl_node_t *
   rcl_ptr() const
   {
-    return rcl_ptrs_->rcl_node_.get();
+    return rcl_node_.get();
   }
 
   /// Force an early destruction of this object
   void
   destroy() override;
-
-  struct RclPtrs
-  {
-    std::shared_ptr<rclpy::Context::RclPtrs> context_ptrs;
-    std::unique_ptr<rcl_node_t, std::function<void(rcl_node_t *)>> rcl_node_;
-  };
-
-  /// Return RCL pointers so another class can keep the rcl part alive
-  std::shared_ptr<rclpy::Node::RclPtrs>
-  get_rcl_ptrs() const
-  {
-    return rcl_ptrs_;
-  }
 
 private:
   /// Get the list of nodes discovered by the provided node
@@ -208,7 +195,8 @@ private:
   py::list
   get_names_impl(bool get_enclaves);
 
-  std::shared_ptr<rclpy::Node::RclPtrs> rcl_ptrs_;
+  Context context_;
+  std::shared_ptr<rcl_node_t> rcl_node_;
 };
 
 void

--- a/rclpy/src/rclpy/publisher.cpp
+++ b/rclpy/src/rclpy/publisher.cpp
@@ -48,9 +48,10 @@ Publisher::Publisher(
 
   rcl_publisher_ = std::shared_ptr<rcl_publisher_t>(
     new rcl_publisher_t,
-    [this](rcl_publisher_t * publisher)
+    [node](rcl_publisher_t * publisher)
     {
-      rcl_ret_t ret = rcl_publisher_fini(publisher, node_.rcl_ptr());
+      // Intentionally capturing node by value so shared_ptr can be transfered to copies
+      rcl_ret_t ret = rcl_publisher_fini(publisher, node.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -81,7 +82,7 @@ Publisher::Publisher(
 void Publisher::destroy()
 {
   rcl_publisher_.reset();
-  node_.destroy_when_not_in_use();
+  node_.destroy();
 }
 
 const char *

--- a/rclpy/src/rclpy/publisher.cpp
+++ b/rclpy/src/rclpy/publisher.cpp
@@ -32,10 +32,8 @@ namespace rclpy
 Publisher::Publisher(
   Node & node, py::object pymsg_type, std::string topic,
   py::object pyqos_profile)
-: rcl_ptrs_(new rclpy::Publisher::RclPtrs)
+: node_(node)
 {
-  rcl_ptrs_->node_ptrs = node.get_rcl_ptrs();
-
   auto msg_type = static_cast<rosidl_message_type_support_t *>(
     rclpy_common_get_type_support(pymsg_type.ptr()));
   if (!msg_type) {
@@ -48,12 +46,11 @@ Publisher::Publisher(
     publisher_ops.qos = pyqos_profile.cast<rmw_qos_profile_t>();
   }
 
-  rcl_ptrs_->rcl_publisher_ = std::unique_ptr<rcl_publisher_t,
-      std::function<void(rcl_publisher_t *)>>(
+  rcl_publisher_ = std::shared_ptr<rcl_publisher_t>(
     new rcl_publisher_t,
     [this](rcl_publisher_t * publisher)
     {
-      rcl_ret_t ret = rcl_publisher_fini(publisher, rcl_ptrs_->node_ptrs->rcl_node_.get());
+      rcl_ret_t ret = rcl_publisher_fini(publisher, node_.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -65,10 +62,10 @@ Publisher::Publisher(
       delete publisher;
     });
 
-  *rcl_ptrs_->rcl_publisher_ = rcl_get_zero_initialized_publisher();
+  *rcl_publisher_ = rcl_get_zero_initialized_publisher();
 
   rcl_ret_t ret = rcl_publisher_init(
-    rcl_ptrs_->rcl_publisher_.get(), rcl_ptrs_->node_ptrs->rcl_node_.get(), msg_type,
+    rcl_publisher_.get(), node_.rcl_ptr(), msg_type,
     topic.c_str(), &publisher_ops);
   if (RCL_RET_OK != ret) {
     if (RCL_RET_TOPIC_NAME_INVALID == ret) {
@@ -83,14 +80,14 @@ Publisher::Publisher(
 
 void Publisher::destroy()
 {
-  rcl_ptrs_->rcl_publisher_.reset();
-  rcl_ptrs_.reset();
+  rcl_publisher_.reset();
+  node_.destroy_when_not_in_use();
 }
 
 const char *
 Publisher::get_logger_name()
 {
-  const char * node_logger_name = rcl_node_get_logger_name(rcl_ptrs_->node_ptrs->rcl_node_.get());
+  const char * node_logger_name = rcl_node_get_logger_name(node_.rcl_ptr());
   if (!node_logger_name) {
     throw RCLError("Node logger name not set");
   }
@@ -102,7 +99,7 @@ size_t
 Publisher::get_subscription_count()
 {
   size_t count = 0;
-  rcl_ret_t ret = rcl_publisher_get_subscription_count(rcl_ptrs_->rcl_publisher_.get(), &count);
+  rcl_ret_t ret = rcl_publisher_get_subscription_count(rcl_publisher_.get(), &count);
   if (RCL_RET_OK != ret) {
     throw RCLError("failed to get subscription count");
   }
@@ -113,7 +110,7 @@ Publisher::get_subscription_count()
 std::string
 Publisher::get_topic_name()
 {
-  const char * topic_name = rcl_publisher_get_topic_name(rcl_ptrs_->rcl_publisher_.get());
+  const char * topic_name = rcl_publisher_get_topic_name(rcl_publisher_.get());
   if (!topic_name) {
     throw RCLError("failed to get topic name");
   }
@@ -130,7 +127,7 @@ Publisher::publish(py::object pymsg)
     throw py::error_already_set();
   }
 
-  rcl_ret_t ret = rcl_publish(rcl_ptrs_->rcl_publisher_.get(), raw_ros_message, NULL);
+  rcl_ret_t ret = rcl_publish(rcl_publisher_.get(), raw_ros_message, NULL);
   destroy_ros_message(raw_ros_message);
   if (RCL_RET_OK != ret) {
     throw RCLError("Failed to publish");
@@ -145,8 +142,7 @@ Publisher::publish_raw(std::string msg)
   serialized_msg.buffer_length = msg.size();
   serialized_msg.buffer = reinterpret_cast<uint8_t *>(const_cast<char *>(msg.c_str()));
 
-  rcl_ret_t ret = rcl_publish_serialized_message(
-    rcl_ptrs_->rcl_publisher_.get(), &serialized_msg, NULL);
+  rcl_ret_t ret = rcl_publish_serialized_message(rcl_publisher_.get(), &serialized_msg, NULL);
   if (RCL_RET_OK != ret) {
     throw RCLError("Failed to publish");
   }

--- a/rclpy/src/rclpy/publisher.hpp
+++ b/rclpy/src/rclpy/publisher.hpp
@@ -102,29 +102,16 @@ public:
   rcl_publisher_t *
   rcl_ptr() const
   {
-    return rcl_ptrs_->rcl_publisher_.get();
+    return rcl_publisher_.get();
   }
 
   /// Force an early destruction of this object
   void
   destroy() override;
 
-  struct RclPtrs
-  {
-    std::shared_ptr<rclpy::Node::RclPtrs> node_ptrs;
-    // Store node_ptrs in here so rcl_event_t can keep node ptrs alive too
-    std::unique_ptr<rcl_publisher_t, std::function<void(rcl_publisher_t *)>> rcl_publisher_;
-  };
-
-  /// Return RCL pointers so another class can keep the rcl part alive
-  std::shared_ptr<rclpy::Publisher::RclPtrs>
-  get_rcl_ptrs() const
-  {
-    return rcl_ptrs_;
-  }
-
 private:
-  std::shared_ptr<rclpy::Publisher::RclPtrs> rcl_ptrs_;
+  Node node_;
+  std::shared_ptr<rcl_publisher_t> rcl_publisher_;
 };
 /// Define a pybind11 wrapper for an rclpy::Service
 void define_publisher(py::object module);

--- a/rclpy/src/rclpy/qos_event.cpp
+++ b/rclpy/src/rclpy/qos_event.cpp
@@ -58,23 +58,25 @@ create_zero_initialized_event()
 void
 QoSEvent::destroy()
 {
-  rcl_ptrs_->grandparent_sub_handle_.reset();
-  rcl_ptrs_->grandparent_pub_handle_.reset();
-  rcl_ptrs_.reset();
+  rcl_event_.reset();
+  if (Publisher * publisher = std::get_if<Publisher>(&grandparent_)) {
+    publisher->destroy_when_not_in_use();
+  }
+  if (Subscription * subscription = std::get_if<Subscription>(&grandparent_)) {
+    subscription->destroy_when_not_in_use();
+  }
 }
 
 QoSEvent::QoSEvent(
   rclpy::Subscription & subscription, rcl_subscription_event_type_t event_type)
-: event_type_(event_type), rcl_ptrs_(new rclpy::QoSEvent::RclPtrs)
+: event_type_(event_type), grandparent_(subscription)
 {
-  rcl_ptrs_->grandparent_sub_handle_ = subscription.get_rcl_ptrs();
-
   // Create a subscription event
-  rcl_ptrs_->rcl_event_ = std::move(create_zero_initialized_event());
+  rcl_event_ = std::move(create_zero_initialized_event());
 
   rcl_ret_t ret = rcl_subscription_event_init(
-    rcl_ptrs_->rcl_event_.get(),
-    rcl_ptrs_->grandparent_sub_handle_->rcl_subscription_.get(), event_type);
+    rcl_event_.get(),
+    std::get<Subscription>(grandparent_).rcl_ptr(), event_type);
   if (RCL_RET_BAD_ALLOC == ret) {
     rcl_reset_error();
     throw std::bad_alloc();
@@ -89,16 +91,14 @@ QoSEvent::QoSEvent(
 
 QoSEvent::QoSEvent(
   rclpy::Publisher & publisher, rcl_publisher_event_type_t event_type)
-: event_type_(event_type), rcl_ptrs_(new rclpy::QoSEvent::RclPtrs)
+: event_type_(event_type), grandparent_(publisher)
 {
-  rcl_ptrs_->grandparent_pub_handle_ = publisher.get_rcl_ptrs();
-
   // Create a publisher event
-  rcl_ptrs_->rcl_event_ = std::move(create_zero_initialized_event());
+  rcl_event_ = std::move(create_zero_initialized_event());
 
   rcl_ret_t ret = rcl_publisher_event_init(
-    rcl_ptrs_->rcl_event_.get(),
-    rcl_ptrs_->grandparent_pub_handle_->rcl_publisher_.get(), event_type);
+    rcl_event_.get(),
+    std::get<Publisher>(grandparent_).rcl_ptr(), event_type);
   if (RCL_RET_BAD_ALLOC == ret) {
     rcl_reset_error();
     throw std::bad_alloc();
@@ -127,7 +127,7 @@ py::object
 QoSEvent::take_event()
 {
   qos_event_callback_data_t data;
-  rcl_ret_t ret = rcl_take_event(rcl_ptrs_->rcl_event_.get(), &data);
+  rcl_ret_t ret = rcl_take_event(rcl_event_.get(), &data);
   if (RCL_RET_BAD_ALLOC == ret) {
     rcl_reset_error();
     throw std::bad_alloc();

--- a/rclpy/src/rclpy/qos_event.cpp
+++ b/rclpy/src/rclpy/qos_event.cpp
@@ -32,10 +32,10 @@
 namespace rclpy
 {
 static
-std::unique_ptr<rcl_event_t, std::function<void(rcl_event_t *)>>
+std::shared_ptr<rcl_event_t>
 create_zero_initialized_event()
 {
-  auto event = std::unique_ptr<rcl_event_t, std::function<void(rcl_event_t *)>>(
+  auto event = std::shared_ptr<rcl_event_t>(
     new rcl_event_t,
     [](rcl_event_t * event)
     {
@@ -59,12 +59,7 @@ void
 QoSEvent::destroy()
 {
   rcl_event_.reset();
-  if (Publisher * publisher = std::get_if<Publisher>(&grandparent_)) {
-    publisher->destroy_when_not_in_use();
-  }
-  if (Subscription * subscription = std::get_if<Subscription>(&grandparent_)) {
-    subscription->destroy_when_not_in_use();
-  }
+  std::visit([](auto & t) {t.destroy();}, grandparent_);
 }
 
 QoSEvent::QoSEvent(

--- a/rclpy/src/rclpy/qos_event.hpp
+++ b/rclpy/src/rclpy/qos_event.hpp
@@ -91,9 +91,8 @@ public:
   destroy() override;
 
 private:
-
   std::variant<rcl_subscription_event_type_t, rcl_publisher_event_type_t> event_type_;
-  std::variant<Publisher, Subscription>  grandparent_;
+  std::variant<Publisher, Subscription> grandparent_;
   std::shared_ptr<rcl_event_t> rcl_event_;
 };
 

--- a/rclpy/src/rclpy/qos_event.hpp
+++ b/rclpy/src/rclpy/qos_event.hpp
@@ -83,23 +83,18 @@ public:
   rcl_event_t *
   rcl_ptr() const
   {
-    return rcl_ptrs_->rcl_event_.get();
+    return rcl_event_.get();
   }
 
   /// Force an early destruction of this object
   void
   destroy() override;
 
-  struct RclPtrs
-  {
-    std::shared_ptr<rclpy::Publisher::RclPtrs> grandparent_pub_handle_;
-    std::shared_ptr<rclpy::Subscription::RclPtrs> grandparent_sub_handle_;
-    std::unique_ptr<rcl_event_t, std::function<void(rcl_event_t *)>> rcl_event_;
-  };
-
 private:
+
   std::variant<rcl_subscription_event_type_t, rcl_publisher_event_type_t> event_type_;
-  std::shared_ptr<rclpy::QoSEvent::RclPtrs> rcl_ptrs_;
+  std::variant<Publisher, Subscription>  grandparent_;
+  std::shared_ptr<rcl_event_t> rcl_event_;
 };
 
 /// Define a pybind11 wrapper for an rclpy::QoSEvent

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -34,17 +34,15 @@ namespace rclpy
 void
 Service::destroy()
 {
-  rcl_ptrs_->rcl_service_.reset();
-  rcl_ptrs_.reset();
+  rcl_service_.reset();
+  node_.destroy_when_not_in_use();
 }
 
 Service::Service(
   Node & node, py::object pysrv_type, std::string service_name,
   py::object pyqos_profile)
-: rcl_ptrs_(new rclpy::Service::RclPtrs)
+: node_(node)
 {
-  rcl_ptrs_->node_ptrs = node.get_rcl_ptrs();
-
   auto srv_type = static_cast<rosidl_service_type_support_t *>(
     rclpy_common_get_type_support(pysrv_type.ptr()));
   if (!srv_type) {
@@ -58,11 +56,11 @@ Service::Service(
   }
 
   // Create a client
-  rcl_ptrs_->rcl_service_ = std::unique_ptr<rcl_service_t, std::function<void(rcl_service_t *)>>(
+  rcl_service_ = std::unique_ptr<rcl_service_t, std::function<void(rcl_service_t *)>>(
     new rcl_service_t,
     [this](rcl_service_t * service)
     {
-      rcl_ret_t ret = rcl_service_fini(service, rcl_ptrs_->node_ptrs->rcl_node_.get());
+      rcl_ret_t ret = rcl_service_fini(service, node_.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -74,10 +72,10 @@ Service::Service(
       delete service;
     });
 
-  *rcl_ptrs_->rcl_service_ = rcl_get_zero_initialized_service();
+  *rcl_service_ = rcl_get_zero_initialized_service();
 
   rcl_ret_t ret = rcl_service_init(
-    rcl_ptrs_->rcl_service_.get(), rcl_ptrs_->node_ptrs->rcl_node_.get(), srv_type,
+    rcl_service_.get(), node_.rcl_ptr(), srv_type,
     service_name.c_str(), &service_ops);
   if (RCL_RET_OK != ret) {
     if (ret == RCL_RET_SERVICE_NAME_INVALID) {
@@ -104,7 +102,7 @@ Service::service_send_response(py::object pyresponse, rmw_request_id_t * header)
   auto ros_response = std::unique_ptr<void, decltype(message_deleter)>(
     raw_ros_response, message_deleter);
 
-  rcl_ret_t ret = rcl_send_response(rcl_ptrs_->rcl_service_.get(), header, ros_response.get());
+  rcl_ret_t ret = rcl_send_response(rcl_service_.get(), header, ros_response.get());
   if (ret != RCL_RET_OK) {
     throw RCLError("failed to send response");
   }
@@ -118,8 +116,7 @@ Service::service_take_request(py::object pyrequest_type)
   rmw_service_info_t header;
 
   py::tuple result_tuple(2);
-  rcl_ret_t ret = rcl_take_request_with_info(
-    rcl_ptrs_->rcl_service_.get(), &header, taken_request.get());
+  rcl_ret_t ret = rcl_take_request_with_info(rcl_service_.get(), &header, taken_request.get());
   if (ret == RCL_RET_SERVICE_TAKE_FAILED) {
     result_tuple[0] = py::none();
     result_tuple[1] = py::none();

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -35,7 +35,7 @@ void
 Service::destroy()
 {
   rcl_service_.reset();
-  node_.destroy_when_not_in_use();
+  node_.destroy();
 }
 
 Service::Service(
@@ -56,11 +56,12 @@ Service::Service(
   }
 
   // Create a client
-  rcl_service_ = std::unique_ptr<rcl_service_t, std::function<void(rcl_service_t *)>>(
+  rcl_service_ = std::shared_ptr<rcl_service_t>(
     new rcl_service_t,
-    [this](rcl_service_t * service)
+    [node](rcl_service_t * service)
     {
-      rcl_ret_t ret = rcl_service_fini(service, node_.rcl_ptr());
+      // Intentionally capture node by copy so shared_ptr can be transfered to copies
+      rcl_ret_t ret = rcl_service_fini(service, node.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -86,28 +86,16 @@ public:
   rcl_service_t *
   rcl_ptr() const
   {
-    return rcl_ptrs_->rcl_service_.get();
+    return rcl_service_.get();
   }
 
   /// Force an early destruction of this object
   void
   destroy() override;
 
-  struct RclPtrs
-  {
-    std::shared_ptr<rclpy::Node::RclPtrs> node_ptrs;
-    std::unique_ptr<rcl_service_t, std::function<void(rcl_service_t *)>> rcl_service_;
-  };
-
-  /// Return RCL pointers so another class can keep the rcl part alive
-  std::shared_ptr<rclpy::Service::RclPtrs>
-  get_rcl_ptrs() const
-  {
-    return rcl_ptrs_;
-  }
-
 private:
-  std::shared_ptr<rclpy::Service::RclPtrs> rcl_ptrs_;
+  Node node_;
+  std::shared_ptr<rcl_service_t> rcl_service_;
 };
 
 /// Define a pybind11 wrapper for an rclpy::Service

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -51,12 +51,12 @@ Subscription::Subscription(
     subscription_ops.qos = pyqos_profile.cast<rmw_qos_profile_t>();
   }
 
-  rcl_subscription_ = std::unique_ptr<rcl_subscription_t,
-      std::function<void(rcl_subscription_t *)>>(
+  rcl_subscription_ = std::shared_ptr<rcl_subscription_t>(
     new rcl_subscription_t,
-    [this](rcl_subscription_t * subscription)
+    [node](rcl_subscription_t * subscription)
     {
-      rcl_ret_t ret = rcl_subscription_fini(subscription, node_.rcl_ptr());
+      // Intentionally capture node by copy so shared_ptr can be transfered to copies
+      rcl_ret_t ret = rcl_subscription_fini(subscription, node.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -87,7 +87,7 @@ Subscription::Subscription(
 void Subscription::destroy()
 {
   rcl_subscription_.reset();
-  node_.destroy_when_not_in_use();
+  node_.destroy();
 }
 
 py::object

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -37,10 +37,8 @@ namespace rclpy
 Subscription::Subscription(
   Node & node, py::object pymsg_type, std::string topic,
   py::object pyqos_profile)
-: rcl_ptrs_(new rclpy::Subscription::RclPtrs)
+: node_(node)
 {
-  rcl_ptrs_->node_ptrs = node.get_rcl_ptrs();
-
   auto msg_type = static_cast<rosidl_message_type_support_t *>(
     rclpy_common_get_type_support(pymsg_type.ptr()));
   if (!msg_type) {
@@ -53,12 +51,12 @@ Subscription::Subscription(
     subscription_ops.qos = pyqos_profile.cast<rmw_qos_profile_t>();
   }
 
-  rcl_ptrs_->rcl_subscription_ = std::unique_ptr<rcl_subscription_t,
+  rcl_subscription_ = std::unique_ptr<rcl_subscription_t,
       std::function<void(rcl_subscription_t *)>>(
     new rcl_subscription_t,
     [this](rcl_subscription_t * subscription)
     {
-      rcl_ret_t ret = rcl_subscription_fini(subscription, rcl_ptrs_->node_ptrs->rcl_node_.get());
+      rcl_ret_t ret = rcl_subscription_fini(subscription, node_.rcl_ptr());
       if (RCL_RET_OK != ret) {
         // Warning should use line number of the current stack frame
         int stack_level = 1;
@@ -70,10 +68,10 @@ Subscription::Subscription(
       delete subscription;
     });
 
-  *rcl_ptrs_->rcl_subscription_ = rcl_get_zero_initialized_subscription();
+  *rcl_subscription_ = rcl_get_zero_initialized_subscription();
 
   rcl_ret_t ret = rcl_subscription_init(
-    rcl_ptrs_->rcl_subscription_.get(), rcl_ptrs_->node_ptrs->rcl_node_.get(), msg_type,
+    rcl_subscription_.get(), node_.rcl_ptr(), msg_type,
     topic.c_str(), &subscription_ops);
   if (ret != RCL_RET_OK) {
     if (ret == RCL_RET_TOPIC_NAME_INVALID) {
@@ -88,8 +86,8 @@ Subscription::Subscription(
 
 void Subscription::destroy()
 {
-  rcl_ptrs_->rcl_subscription_.reset();
-  rcl_ptrs_.reset();
+  rcl_subscription_.reset();
+  node_.destroy_when_not_in_use();
 }
 
 py::object
@@ -100,7 +98,7 @@ Subscription::take_message(py::object pymsg_type, bool raw)
   if (raw) {
     SerializedMessage taken{rcutils_get_default_allocator()};
     rcl_ret_t ret = rcl_take_serialized_message(
-      rcl_ptrs_->rcl_subscription_.get(), &taken.rcl_msg, &message_info, NULL);
+      rcl_subscription_.get(), &taken.rcl_msg, &message_info, NULL);
     if (RCL_RET_OK != ret) {
       if (RCL_RET_BAD_ALLOC == ret) {
         rcl_reset_error();
@@ -118,7 +116,7 @@ Subscription::take_message(py::object pymsg_type, bool raw)
     auto taken_msg = create_from_py(pymsg_type);
 
     rcl_ret_t ret = rcl_take(
-      rcl_ptrs_->rcl_subscription_.get(), taken_msg.get(), &message_info, NULL);
+      rcl_subscription_.get(), taken_msg.get(), &message_info, NULL);
     if (RCL_RET_OK != ret) {
       if (RCL_RET_BAD_ALLOC == ret) {
         rcl_reset_error();
@@ -142,7 +140,7 @@ Subscription::take_message(py::object pymsg_type, bool raw)
 const char *
 Subscription::get_logger_name()
 {
-  const char * node_logger_name = rcl_node_get_logger_name(rcl_ptrs_->node_ptrs->rcl_node_.get());
+  const char * node_logger_name = rcl_node_get_logger_name(node_.rcl_ptr());
   if (!node_logger_name) {
     throw RCLError("Node logger name not set");
   }
@@ -153,8 +151,7 @@ Subscription::get_logger_name()
 std::string
 Subscription::get_topic_name()
 {
-  const char * subscription_name = rcl_subscription_get_topic_name(
-    rcl_ptrs_->rcl_subscription_.get());
+  const char * subscription_name = rcl_subscription_get_topic_name(rcl_subscription_.get());
   if (nullptr == subscription_name) {
     throw RCLError("failed to get subscription topic name");
   }

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -91,30 +91,16 @@ public:
   rcl_subscription_t *
   rcl_ptr() const
   {
-    return rcl_ptrs_->rcl_subscription_.get();
+    return rcl_subscription_.get();
   }
 
   /// Force an early destruction of this object
   void
   destroy() override;
 
-  struct RclPtrs
-  {
-    std::shared_ptr<rclpy::Node::RclPtrs> node_ptrs;
-    // Store node_ptrs in here so rcl_event_t can keep node ptrs alive too
-    std::unique_ptr<rcl_subscription_t,
-      std::function<void(rcl_subscription_t *)>> rcl_subscription_;
-  };
-
-  /// Return RCL pointers so another class can keep the rcl part alive
-  std::shared_ptr<rclpy::Subscription::RclPtrs>
-  get_rcl_ptrs() const
-  {
-    return rcl_ptrs_;
-  }
-
 private:
-  std::shared_ptr<rclpy::Subscription::RclPtrs> rcl_ptrs_;
+  Node node_;
+  std::shared_ptr<rcl_subscription_t> rcl_subscription_;
 };
 /// Define a pybind11 wrapper for an rclpy::Service
 void define_subscription(py::object module);

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -37,7 +37,7 @@ void
 Timer::destroy()
 {
   rcl_timer_.reset();
-  clock_.destroy_when_not_in_use();
+  clock_.destroy();
   context_.destroy_when_not_in_use();
 }
 

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -37,16 +37,14 @@ void
 Timer::destroy()
 {
   rcl_timer_.reset();
-  clock_handle_.reset();
-  rcl_context_.reset();
+  clock_.destroy_when_not_in_use();
+  context_.destroy_when_not_in_use();
 }
 
 Timer::Timer(
-  Clock & rclcy_clock, Context & context, int64_t period_nsec)
+  Clock & clock, Context & context, int64_t period_nsec)
+: context_(context), clock_(clock)
 {
-  clock_handle_ = rclcy_clock.shared_from_this();
-  rcl_context_ = context.shared_from_this();
-
   // Create a client
   rcl_timer_ = std::shared_ptr<rcl_timer_t>(
     new rcl_timer_t,
@@ -68,7 +66,7 @@ Timer::Timer(
   rcl_allocator_t allocator = rcl_get_default_allocator();
 
   rcl_ret_t ret = rcl_timer_init(
-    rcl_timer_.get(), clock_handle_->rcl_ptr(), context.rcl_ptr(),
+    rcl_timer_.get(), clock_.rcl_ptr(), context.rcl_ptr(),
     period_nsec, NULL, allocator);
 
   if (RCL_RET_OK != ret) {

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -134,9 +134,9 @@ public:
   void destroy() override;
 
 private:
-  std::shared_ptr<Clock> clock_handle_;
+  Context context_;
+  Clock clock_;
   std::shared_ptr<rcl_timer_t> rcl_timer_;
-  std::shared_ptr<Context> rcl_context_;
 };
 
 /// Define a pybind11 wrapper for an rcl_timer_t

--- a/rclpy/src/rclpy/wait_set.cpp
+++ b/rclpy/src/rclpy/wait_set.cpp
@@ -79,7 +79,7 @@ void
 WaitSet::destroy()
 {
   rcl_wait_set_.reset();
-  context_.destroy_when_not_in_use();
+  context_.destroy();
 }
 
 void

--- a/rclpy/src/rclpy/wait_set.hpp
+++ b/rclpy/src/rclpy/wait_set.hpp
@@ -171,8 +171,8 @@ public:
   void destroy() override;
 
 private:
+  Context context_;
   std::shared_ptr<rcl_wait_set_t> rcl_wait_set_;
-  std::shared_ptr<Context> rcl_context_;
 };
 
 /// Define a pybind11 wrapper for an rclpy::Service

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import unittest
 from unittest.mock import Mock
 
@@ -50,6 +51,11 @@ class TestQoSEvent(unittest.TestCase):
         self.is_fastrtps = 'rmw_fastrtps' in get_rmw_implementation_identifier()
 
     def tearDown(self):
+        # These tests create a bunch of events by hand instead of using Node APIs,
+        # so they won't be cleaned up when calling `node.destroy_node()`, but they could still
+        # keep the node alive from one test to the next.
+        # Invoke the garbage collector to destroy them.
+        gc.collect()
         self.node.destroy_node()
         rclpy.shutdown(context=self.context)
 


### PR DESCRIPTION
This is an alternative to https://github.com/ros2/rclpy/compare/ahcorde/pybind11-node...ahcorde/pybind11-node_option2?expand=1

It implementions option2 from this comment: https://github.com/ros2/rclpy/pull/771#discussion_r616961035

part of #665 via part of #771

This PR intentionally copies the `rclpy::Node`, `rclpy::Context`, etc ... classes instead of copying a shared_ptr to an `rclpy::*::RclPtrs` struct.

The interesting things in this PR are:

* Lamdas passed as deleters for `shared_ptr<rcl_*_t>` types must not capture `this`, because that will always be the pointer to the original instance, but the struct might finally be deleted by a copy instead. Capturing the variables they need (`node` in all cases) by value solved this in all cases.
* `test_qos_event` circumvents the node API to create the events it's testing, meaning the Python `Publisher` instance doesn't have a record of the events existing, so it can't destroy it when the Python `Publisher` is destroyed. Now that the QoSEvent properly keeps the publisher and therefore the node alive it was possible for data to leak between tests. calling `gc.collect()` in `TearDown` is a quick fix for this.
* The parent entity must always be higher in the class than the child entity (see `guard_condition.hpp` where `context_` was moved above the `rcl_guard_condition_t` member).
* `rcl_*_t` pointers need to be `shared_ptr` instead of `unique_ptr` so they can be shared with and kept alive by copies in their children.
* I used `std::variant<Publisher, Subscription>` in QoSEvent ... for fun
* `rclpy::WaitSet` doesn't need a default constructor
* action_goal_handle should keep the action_server alive
* a couple typo fixes in comments