### PR TITLE
Lift LoggingSeverity enum as common dependency to logging and rcutils_logger modules

### DIFF
--- a/rclpy/rclpy/impl/logging_severity.py
+++ b/rclpy/rclpy/impl/logging_severity.py
@@ -1,0 +1,33 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from enum import IntEnum
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+class LoggingSeverity(IntEnum):
+    """
+    Enum for logging severity levels.
+
+    This enum must match the one defined in rcutils/logging.h
+    """
+
+    UNSET = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_UNSET
+    DEBUG = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_DEBUG
+    INFO = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_INFO
+    WARN = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_WARN
+    ERROR = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_ERROR
+    FATAL = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_FATAL

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -20,6 +20,7 @@ import os
 
 from rclpy.clock import Clock
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.logging_severity import LoggingSeverity
 
 # Known filenames from which logging methods can be called (will be ignored in `_find_caller`).
 _internal_callers = []
@@ -225,18 +226,15 @@ class RcutilsLogger:
         return RcutilsLogger(name=name)
 
     def set_level(self, level):
-        from rclpy.logging import LoggingSeverity
         level = LoggingSeverity(level)
         return _rclpy.rclpy_logging_set_logger_level(self.name, level)
 
     def get_effective_level(self):
-        from rclpy.logging import LoggingSeverity
         level = LoggingSeverity(
             _rclpy.rclpy_logging_get_logger_effective_level(self.name))
         return level
 
     def is_enabled_for(self, severity):
-        from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)
         return _rclpy.rclpy_logging_logger_is_enabled_for(self.name, severity)
 
@@ -278,7 +276,6 @@ class RcutilsLogger:
         if not self.is_enabled_for(severity):
             return False
 
-        from rclpy.logging import LoggingSeverity
         severity = LoggingSeverity(severity)
 
         name = kwargs.pop('name', self.name)
@@ -325,17 +322,14 @@ class RcutilsLogger:
 
     def debug(self, message, **kwargs):
         """Log a message with `DEBUG` severity via :py:classmethod:RcutilsLogger.log:."""
-        from rclpy.logging import LoggingSeverity
         return self.log(message, LoggingSeverity.DEBUG, **kwargs)
 
     def info(self, message, **kwargs):
         """Log a message with `INFO` severity via :py:classmethod:RcutilsLogger.log:."""
-        from rclpy.logging import LoggingSeverity
         return self.log(message, LoggingSeverity.INFO, **kwargs)
 
     def warning(self, message, **kwargs):
         """Log a message with `WARN` severity via :py:classmethod:RcutilsLogger.log:."""
-        from rclpy.logging import LoggingSeverity
         return self.log(message, LoggingSeverity.WARN, **kwargs)
 
     def warn(self, message, **kwargs):
@@ -348,10 +342,8 @@ class RcutilsLogger:
 
     def error(self, message, **kwargs):
         """Log a message with `ERROR` severity via :py:classmethod:RcutilsLogger.log:."""
-        from rclpy.logging import LoggingSeverity
         return self.log(message, LoggingSeverity.ERROR, **kwargs)
 
     def fatal(self, message, **kwargs):
         """Log a message with `FATAL` severity via :py:classmethod:RcutilsLogger.log:."""
-        from rclpy.logging import LoggingSeverity
         return self.log(message, LoggingSeverity.FATAL, **kwargs)

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -13,26 +13,11 @@
 # limitations under the License.
 
 
-from enum import IntEnum
 from pathlib import Path
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.logging_severity import LoggingSeverity
 import rclpy.impl.rcutils_logger
-
-
-class LoggingSeverity(IntEnum):
-    """
-    Enum for logging severity levels.
-
-    This enum must match the one defined in rcutils/logging.h
-    """
-
-    UNSET = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_UNSET
-    DEBUG = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_DEBUG
-    INFO = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_INFO
-    WARN = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_WARN
-    ERROR = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_ERROR
-    FATAL = _rclpy.RCUTILS_LOG_SEVERITY.RCUTILS_LOG_SEVERITY_FATAL
 
 
 _root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()


### PR DESCRIPTION
This is a follow up to discussion in https://github.com/ros2/rclpy/pull/776.
LoggingSeverity enum is moved to its own module and it is imported both from logging and rcutils_logger modules.
This change should save a tiny bit of time in doing import for every call inside log method.
