### PR TITLE
Removed some functions in common.c and replaced them in utils.cpp

### DIFF
--- a/rclpy/src/rclpy/action_client.cpp
+++ b/rclpy/src/rclpy/action_client.cpp
@@ -49,8 +49,7 @@ ActionClient::ActionClient(
 : node_(node)
 {
   rosidl_action_type_support_t * ts =
-    static_cast<rosidl_action_type_support_t *>(rclpy_common_get_type_support(
-      pyaction_type.ptr()));
+    static_cast<rosidl_action_type_support_t *>(common_get_type_support(pyaction_type));
   if (!ts) {
     throw py::error_already_set();
   }

--- a/rclpy/src/rclpy/action_goal_handle.cpp
+++ b/rclpy/src/rclpy/action_goal_handle.cpp
@@ -33,19 +33,16 @@ ActionGoalHandle::ActionGoalHandle(
   rclpy::ActionServer & action_server, py::object pygoal_info_msg)
 : action_server_(action_server)
 {
-  destroy_ros_message_signature * destroy_ros_message = NULL;
-  auto goal_info_msg = static_cast<rcl_action_goal_info_t *>(
-    rclpy_convert_from_py(pygoal_info_msg.ptr(), &destroy_ros_message));
+  auto goal_info_msg = convert_from_py(pygoal_info_msg);
+  rcl_action_goal_info_t * goal_info_msg_ptr =
+    static_cast<rcl_action_goal_info_t *>(goal_info_msg.get());
 
   if (!goal_info_msg) {
     throw py::error_already_set();
   }
 
-  auto goal_info_msg_ptr = std::unique_ptr<rcl_action_goal_info_t, decltype(destroy_ros_message)>(
-    goal_info_msg, destroy_ros_message);
-
   auto rcl_handle = rcl_action_accept_new_goal(
-    action_server.rcl_ptr(), goal_info_msg);
+    action_server.rcl_ptr(), goal_info_msg_ptr);
   if (!rcl_handle) {
     throw rclpy::RCLError("Failed to accept new goal");
   }

--- a/rclpy/src/rclpy/action_server.cpp
+++ b/rclpy/src/rclpy/action_server.cpp
@@ -53,7 +53,7 @@ ActionServer::ActionServer(
   rcl_clock_t * clock = rclpy_clock.rcl_ptr();
 
   rosidl_action_type_support_t * ts = static_cast<rosidl_action_type_support_t *>(
-    rclpy_common_get_type_support(pyaction_type.ptr()));
+    common_get_type_support(pyaction_type));
   if (!ts) {
     throw py::error_already_set();
   }

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -42,7 +42,7 @@ Client::Client(
 : node_(node)
 {
   auto srv_type = static_cast<rosidl_service_type_support_t *>(
-    rclpy_common_get_type_support(pysrv_type.ptr()));
+    common_get_type_support(pysrv_type));
   if (!srv_type) {
     throw py::error_already_set();
   }
@@ -92,15 +92,13 @@ Client::Client(
 int64_t
 Client::send_request(py::object pyrequest)
 {
-  destroy_ros_message_signature * destroy_ros_message = nullptr;
-  void * raw_ros_request = rclpy_convert_from_py(pyrequest.ptr(), &destroy_ros_message);
+  auto raw_ros_request = convert_from_py(pyrequest);
   if (!raw_ros_request) {
     throw py::error_already_set();
   }
 
   int64_t sequence_number;
-  rcl_ret_t ret = rcl_send_request(rcl_client_.get(), raw_ros_request, &sequence_number);
-  destroy_ros_message(raw_ros_request);
+  rcl_ret_t ret = rcl_send_request(rcl_client_.get(), raw_ros_request.get(), &sequence_number);
   if (RCL_RET_OK != ret) {
     throw RCLError("failed to send request");
   }

--- a/rclpy/src/rclpy/publisher.cpp
+++ b/rclpy/src/rclpy/publisher.cpp
@@ -25,6 +25,7 @@
 #include "rclpy_common/exceptions.hpp"
 
 #include "publisher.hpp"
+#include "utils.hpp"
 
 namespace rclpy
 {
@@ -34,7 +35,7 @@ Publisher::Publisher(
 : node_(node)
 {
   auto msg_type = static_cast<rosidl_message_type_support_t *>(
-    rclpy_common_get_type_support(pymsg_type.ptr()));
+    common_get_type_support(pymsg_type));
   if (!msg_type) {
     throw py::error_already_set();
   }
@@ -121,14 +122,12 @@ Publisher::get_topic_name()
 void
 Publisher::publish(py::object pymsg)
 {
-  destroy_ros_message_signature * destroy_ros_message = NULL;
-  void * raw_ros_message = rclpy_convert_from_py(pymsg.ptr(), &destroy_ros_message);
+  auto raw_ros_message = convert_from_py(pymsg);
   if (!raw_ros_message) {
     throw py::error_already_set();
   }
 
-  rcl_ret_t ret = rcl_publish(rcl_publisher_.get(), raw_ros_message, NULL);
-  destroy_ros_message(raw_ros_message);
+  rcl_ret_t ret = rcl_publish(rcl_publisher_.get(), raw_ros_message.get(), NULL);
   if (RCL_RET_OK != ret) {
     throw RCLError("Failed to publish");
   }

--- a/rclpy/src/rclpy/serialization.cpp
+++ b/rclpy/src/rclpy/serialization.cpp
@@ -30,6 +30,7 @@
 #include "rclpy_common/exceptions.hpp"
 
 #include "serialization.hpp"
+#include "utils.hpp"
 
 namespace rclpy
 {
@@ -60,14 +61,12 @@ serialize(py::object pymsg, py::object pymsg_type)
 {
   // Get type support
   auto ts = static_cast<rosidl_message_type_support_t *>(
-    rclpy_common_get_type_support(pymsg_type.ptr()));
+    common_get_type_support(pymsg_type));
   if (!ts) {
     throw py::error_already_set();
   }
 
-  destroy_ros_message_signature * destroy_ros_message = nullptr;
-  auto ros_msg = std::unique_ptr<void, decltype(destroy_ros_message)>(
-    rclpy_convert_from_py(pymsg.ptr(), &destroy_ros_message), destroy_ros_message);
+  auto ros_msg = convert_from_py(pymsg);
   if (!ros_msg) {
     throw py::error_already_set();
   }
@@ -92,7 +91,7 @@ deserialize(py::bytes pybuffer, py::object pymsg_type)
 {
   // Get type support
   auto ts = static_cast<rosidl_message_type_support_t *>(
-    rclpy_common_get_type_support(pymsg_type.ptr()));
+    common_get_type_support(pymsg_type));
   if (!ts) {
     throw py::error_already_set();
   }
@@ -112,13 +111,10 @@ deserialize(py::bytes pybuffer, py::object pymsg_type)
   serialized_msg.buffer_length = length;
   serialized_msg.buffer = reinterpret_cast<uint8_t *>(serialized_buffer);
 
-  destroy_ros_message_signature * destroy_ros_message = nullptr;
-  void * deserialized_ros_msg_c = rclpy_create_from_py(pymsg_type.ptr(), &destroy_ros_message);
-  if (!deserialized_ros_msg_c) {
+  auto deserialized_ros_msg = create_from_py(pymsg_type);
+  if (!deserialized_ros_msg) {
     throw py::error_already_set();
   }
-  auto deserialized_ros_msg = std::unique_ptr<void, decltype(destroy_ros_message)>(
-    deserialized_ros_msg_c, destroy_ros_message);
 
   // Deserialize
   rmw_ret_t rmw_ret = rmw_deserialize(&serialized_msg, ts, deserialized_ros_msg.get());
@@ -127,8 +123,6 @@ deserialize(py::bytes pybuffer, py::object pymsg_type)
     throw RMWError("failed to deserialize ROS message");
   }
 
-  PyObject * pydeserialized_ros_msg_c =
-    rclpy_convert_to_py(deserialized_ros_msg.get(), pymsg_type.ptr());
-  return py::reinterpret_steal<py::object>(pydeserialized_ros_msg_c);
+  return convert_to_py(deserialized_ros_msg.get(), pymsg_type);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -44,7 +44,7 @@ Service::Service(
 : node_(node)
 {
   auto srv_type = static_cast<rosidl_service_type_support_t *>(
-    rclpy_common_get_type_support(pysrv_type.ptr()));
+    common_get_type_support(pysrv_type));
   if (!srv_type) {
     throw py::error_already_set();
   }
@@ -94,17 +94,13 @@ Service::Service(
 void
 Service::service_send_response(py::object pyresponse, rmw_request_id_t * header)
 {
-  destroy_ros_message_signature * destroy_ros_message = nullptr;
-  void * raw_ros_response = rclpy_convert_from_py(pyresponse.ptr(), &destroy_ros_message);
+  auto raw_ros_response = convert_from_py(pyresponse);
   if (!raw_ros_response) {
     throw py::error_already_set();
   }
-  auto message_deleter = [destroy_ros_message](void * ptr) {destroy_ros_message(ptr);};
-  auto ros_response = std::unique_ptr<void, decltype(message_deleter)>(
-    raw_ros_response, message_deleter);
 
-  rcl_ret_t ret = rcl_send_response(rcl_service_.get(), header, ros_response.get());
-  if (ret != RCL_RET_OK) {
+  rcl_ret_t ret = rcl_send_response(rcl_service_.get(), header, raw_ros_response.get());
+  if (RCL_RET_OK != ret) {
     throw RCLError("failed to send response");
   }
 }

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -40,7 +40,7 @@ Subscription::Subscription(
 : node_(node)
 {
   auto msg_type = static_cast<rosidl_message_type_support_t *>(
-    rclpy_common_get_type_support(pymsg_type.ptr()));
+    common_get_type_support(pymsg_type));
   if (!msg_type) {
     throw py::error_already_set();
   }

--- a/rclpy/src/rclpy/utils.cpp
+++ b/rclpy/src/rclpy/utils.cpp
@@ -51,6 +51,17 @@ convert_to_py_names_and_types(const rcl_names_and_types_t * names_and_types)
   return py_names_and_types;
 }
 
+void *
+common_get_type_support(py::object pymessage)
+{
+  py::object pymetaclass = pymessage.attr("__class__");
+
+  py::object value = pymetaclass.attr("_TYPE_SUPPORT");
+  auto capsule_ptr = static_cast<void *>(value.cast<py::capsule>());
+
+  return capsule_ptr;
+}
+
 std::unique_ptr<void, destroy_ros_message_function *>
 create_from_py(py::object pymessage)
 {

--- a/rclpy/src/rclpy/utils.hpp
+++ b/rclpy/src/rclpy/utils.hpp
@@ -40,6 +40,14 @@ typedef void destroy_ros_message_function (void *);
 py::list
 convert_to_py_names_and_types(const rcl_names_and_types_t * topic_names_and_types);
 
+/// Get the type support structure for a Python ROS message type.
+/**
+ * \param[in] pymsg_type The Python ROS message type.
+ * \return The type support structure or NULL if an error occurred.
+ */
+void *
+common_get_type_support(py::object pymessage);
+
 /// Create the equivalent ROS message C type instance for a given Python type.
 /**
 * Raises AttributeError if \p pyclass is missing a required attribute.

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -27,20 +27,6 @@ extern "C"
 
 #include "rclpy_common/visibility_control.h"
 
-typedef void * create_ros_message_signature (void);
-typedef void destroy_ros_message_signature (void *);
-typedef bool convert_from_py_signature (PyObject *, void *);
-typedef PyObject * convert_to_py_signature (void *);
-
-/// Get the type support structure for a Python ROS message type.
-/**
- * \param[in] pymsg_type The Python ROS message type.
- * \return The type support structure or NULL if an error occurred.
- */
-RCLPY_COMMON_PUBLIC
-void *
-rclpy_common_get_type_support(PyObject * pymsg_type);
-
 /// Convert a C rmw_qos_profile_t into a Python dictionary with qos profile args.
 /**
  * \param[in] profile Pointer to a rmw_qos_profile_t to convert
@@ -49,39 +35,6 @@ rclpy_common_get_type_support(PyObject * pymsg_type);
 RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_common_convert_to_qos_dict(const rmw_qos_profile_t * profile);
-
-RCLPY_COMMON_PUBLIC
-void *
-get_capsule_pointer(PyObject * pymetaclass, const char * attr);
-
-RCLPY_COMMON_PUBLIC
-void *
-rclpy_create_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message);
-
-/// Convert a ROS message from a Python type to a C type.
-/**
- * Raises AttributeError if the Python message type is missing a required attribute.
- * Raises MemoryError on a memory allocation failure.
- *
- * \param[in] pymessage The Python message to convert from.
- * \param[out] destroy_ros_message The destructor function for finalizing the returned message.
- * \return The C version of the input ROS message.
- */
-RCLPY_COMMON_PUBLIC
-void *
-rclpy_convert_from_py(PyObject * pymessage, destroy_ros_message_signature ** destroy_ros_message);
-
-/// Convert a ROS message from a C type to a Python type.
-/**
- * Raises AttributeError if the Python type is missing a required attribute.
- *
- * \param[in] message The C message to convert to a Python type
- * \param[in] pyclass An instance of the Python type to convert to.
- * \return The Python version of the input ROS message.
- */
-RCLPY_COMMON_PUBLIC
-PyObject *
-rclpy_convert_to_py(void * message, PyObject * pyclass);
 
 /// Convert a C rmw_topic_endpoint_info_array_t into a Python list.
 /**


### PR DESCRIPTION
Removed some functions in `common.c` and created an analog method in utils.cpp if doesn't exist:
 - rclpy_convert_from_py
 - rclpy_convert_to_py
 - rclpy_create_from_py
 - get_capsule_pointer
 - rclpy_common_get_type_support

This PR could be backported to galactic

Signed-off-by: ahcorde <ahcorde@gmail.com>