### PR TITLE
Allow declaring uninitialized parameters

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -127,13 +127,13 @@ class ParameterImmutableException(ParameterException):
         Exception.__init__(self, 'Attempted to modify read-only parameter', parameter, *args)
 
 
-class NoParameterOverrideProvidedException(ParameterException):
-    """Raised when no override is provided for a statically typed parameter with no default."""
+class ParameterUninitializedException(ParameterException):
+    """Raised when an uninitialized parameter is accessed."""
 
     def __init__(self, parameter_name, *args):
         Exception.__init__(
             self,
-            f"No parameter override provided for '{parameter_name}' when one was expected",
+            f"The parameter '{parameter_name}' is not initialized",
             *args)
 
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -612,11 +612,8 @@ class Node:
         if not self.has_parameter(name):
             return alternative_value
 
-        # Return alternative for uninitialized static parameters
-        if (
-            not self._descriptors[name].dynamic_typing and
-            self._parameters[name].type_ == Parameter.Type.NOT_SET
-        ):
+        # Return alternative for uninitialized parameters
+        if (self._parameters[name].type_ == Parameter.Type.NOT_SET):
             return alternative_value
 
         return self._parameters[name]

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -603,12 +603,23 @@ class Node:
 
         :param name: Fully-qualified name of the parameter, including its namespace.
         :param alternative_value: Alternative parameter to get if it had not been declared before.
-        :return: Requested parameter, or alternative value if it hadn't been declared before.
+        :return: Requested parameter, or alternative value if it hadn't been declared before or is
+          an uninitialized statically typed parameter.
         """
         if alternative_value is None:
             alternative_value = Parameter(name, Parameter.Type.NOT_SET)
 
-        return self._parameters.get(name, alternative_value)
+        if not self.has_parameter(name):
+            return alternative_value
+
+        # Return alternative for uninitialized static parameters
+        if (
+            not self._descriptors[name].dynamic_typing and
+            self._parameters[name].type_ == Parameter.Type.NOT_SET
+        ):
+            return alternative_value
+
+        return self._parameters[name]
 
     def get_parameters_by_prefix(self, prefix: str) -> Dict[str, Optional[Union[
         bool, int, float, str, bytes,

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -490,8 +490,7 @@ class Node:
             allow_undeclared_parameters=True
         )
         # Don't call get_parameters() to bypass check for NOT_SET parameters
-        parameter_names = [parameter.name for parameter in parameter_list]
-        return [self._parameters[name] for name in parameter_names]
+        return [self._parameters[parameter.name] for parameter in parameter_list]
 
     def undeclare_parameter(self, name: str):
         """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -961,7 +961,7 @@ class Node:
         elif self.has_parameter(parameter.name) and parameter.type_ == Parameter.Type.NOT_SET:
             return SetParametersResult(
                 successful=False,
-                reason=f'Static parameter cannot be undeclared'
+                reason='Static parameter cannot be undeclared'
             )
         elif (
             parameter.type_ != Parameter.Type.NOT_SET and

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -949,6 +949,12 @@ class Node:
 
         if descriptor.dynamic_typing:
             descriptor.type = parameter.type_.value
+        # If this parameter has already been declared, do not allow undeclaring it
+        elif self.has_parameter(parameter.name) and parameter.type_ == Parameter.Type.NOT_SET:
+            return SetParametersResult(
+                successful=False,
+                reason=f'Static parameter cannot be undeclared'
+            )
         elif (
             parameter.type_ != Parameter.Type.NOT_SET and
             parameter.type_.value != descriptor.type

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -859,11 +859,20 @@ class TestNode(unittest.TestCase):
         self.assertEqual(result.value, 152)
 
     def test_node_get_uninitialized_parameter_or(self):
+        # Statically typed parameter
         self.node.declare_parameter('uninitialized_foo', Parameter.Type.INTEGER)
         result = self.node.get_parameter_or(
             'uninitialized_foo', Parameter('foo', Parameter.Type.INTEGER, 152))
         self.assertEqual(result.name, 'foo')
         self.assertEqual(result.value, 152)
+
+        # Dynamically typed parameter
+        self.node.declare_parameter(
+            'uninitialized_bar', None, ParameterDescriptor(dynamic_typing=True))
+        result = self.node.get_parameter_or(
+            'uninitialized_bar', Parameter('foo', Parameter.Type.INTEGER, 153))
+        self.assertEqual(result.name, 'foo')
+        self.assertEqual(result.value, 153)
 
     def test_node_get_parameters_by_prefix(self):
         parameters = [

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1843,7 +1843,7 @@ class TestNode(unittest.TestCase):
         int_param = self.node.get_parameter('int_param')
         self.assertEqual(int_param.type_, Parameter.Type.INTEGER)
         self.assertEqual(int_param.value, 0)
-        with pytest.raises(rclpy.exceptions.ParameterUninitializedException):
+        with pytest.raises(ParameterUninitializedException):
             self.node.get_parameter('int_param_no_default')
         self.assertEqual(self.node.get_parameter('dynamic_param').type_, Parameter.Type.NOT_SET)
 

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1861,6 +1861,10 @@ class TestNode(unittest.TestCase):
             self.node.set_parameters([Parameter('int_param_no_default', value=3)])[0].successful)
         self.assertEqual(self.node.get_parameter('int_param_no_default').value, 3)
 
+        result = self.node.set_parameters([Parameter('int_param_no_default', value=None)])[0]
+        self.assertFalse(result.successful)
+        self.assertTrue(result.reason.startswith('Static parameter cannot be undeclared'))
+
         self.assertTrue(
             self.node.set_parameters([Parameter('dynamic_param', value='asd')])[0].successful)
         self.assertTrue(

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -858,6 +858,13 @@ class TestNode(unittest.TestCase):
         self.assertEqual(result.name, 'foo')
         self.assertEqual(result.value, 152)
 
+    def test_node_get_uninitialized_parameter_or(self):
+        self.node.declare_parameter('uninitialized_foo', Parameter.Type.INTEGER)
+        result = self.node.get_parameter_or(
+            'uninitialized_foo', Parameter('foo', Parameter.Type.INTEGER, 152))
+        self.assertEqual(result.name, 'foo')
+        self.assertEqual(result.value, 152)
+
     def test_node_get_parameters_by_prefix(self):
         parameters = [
             ('foo_prefix.foo', 43),


### PR DESCRIPTION
Parameters can now be declared without a default value and without an override.
Attempting to access a statically typed parameter that does not have value will raise an exception.
Getting dynamically typed parameters will return an unset parameter value.

This change is equivalent to that made in rclcpp: https://github.com/ros2/rclcpp/pull/1673