### PR TITLE
👩‍🌾 Check that header is not none before accessing it in test

### DIFF
--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -108,6 +108,7 @@ class TestClient(unittest.TestCase):
                     result = srv.handle.service_take_request(srv.srv_type.Request)
                 if result is not None:
                     request, header = result
+                    self.assertTrue(header is not None)
                     self.assertNotEqual(0, header.source_timestamp)
                     return
                 else:


### PR DESCRIPTION
`test_service_timestamps` has started failing lately with:

```
>                   self.assertNotEqual(0, header.source_timestamp)
E                   AttributeError: 'NoneType' object has no attribute 'source_timestamp'
```

See the test history here:

https://build.ros2.org/job/Rci__nightly-connext_ubuntu_focal_amd64/429/testReport/rclpy.rclpy.test.test_client/TestClient/test_service_timestamps/history/

I'm not sure what's the underlying issue that causes the header to be none, but catching that before trying to use the variable should allow the test to fail gracefully instead of throwing an error.

---

https://github.com/osrf/buildfarmer/issues/224