### PR TITLE
Add convert function from ParameterValue to Python builtin

### DIFF
--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -172,3 +172,39 @@ class Parameter:
 
     def to_parameter_msg(self):
         return ParameterMsg(name=self.name, value=self.get_parameter_value())
+
+
+def parameter_value_to_python(parameter_value: ParameterValue):
+    """
+    Get the Python value from a rcl_interfaces/msg/ParameterValue object.
+
+    Returns the value member of the message based on the ``type`` member.
+    Returns ``None`` if the parameter is "NOT_SET".
+
+    :param parameter_value: The message to get the value from.
+    :raises RuntimeError: if the member ``type`` has an unexpected value.
+    """
+    if parameter_value.type == ParameterType.PARAMETER_BOOL:
+        value = parameter_value.bool_value
+    elif parameter_value.type == ParameterType.PARAMETER_INTEGER:
+        value = parameter_value.integer_value
+    elif parameter_value.type == ParameterType.PARAMETER_DOUBLE:
+        value = parameter_value.double_value
+    elif parameter_value.type == ParameterType.PARAMETER_STRING:
+        value = parameter_value.string_value
+    elif parameter_value.type == ParameterType.PARAMETER_BYTE_ARRAY:
+        value = list(parameter_value.byte_array_value)
+    elif parameter_value.type == ParameterType.PARAMETER_BOOL_ARRAY:
+        value = list(parameter_value.bool_array_value)
+    elif parameter_value.type == ParameterType.PARAMETER_INTEGER_ARRAY:
+        value = list(parameter_value.integer_array_value)
+    elif parameter_value.type == ParameterType.PARAMETER_DOUBLE_ARRAY:
+        value = list(parameter_value.double_array_value)
+    elif parameter_value.type == ParameterType.PARAMETER_STRING_ARRAY:
+        value = list(parameter_value.string_array_value)
+    elif parameter_value.type == ParameterType.PARAMETER_NOT_SET:
+        value = None
+    else:
+        raise RuntimeError(f'unexpected parameter type {parameter_value.type}')
+
+    return value

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -176,7 +176,7 @@ class Parameter:
 
 def parameter_value_to_python(parameter_value: ParameterValue):
     """
-    Get the Python value from a rcl_interfaces/msg/ParameterValue object.
+    Get the value for the Python builtin type from a rcl_interfaces/msg/ParameterValue object.
 
     Returns the value member of the message based on the ``type`` member.
     Returns ``None`` if the parameter is "NOT_SET".

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -15,9 +15,13 @@
 from array import array
 import unittest
 
+import pytest
+
 from rcl_interfaces.msg import Parameter as ParameterMsg
+from rcl_interfaces.msg import ParameterType
 from rcl_interfaces.msg import ParameterValue
 from rclpy.parameter import Parameter
+from rclpy.parameter import parameter_value_to_python
 
 
 class TestParameter(unittest.TestCase):
@@ -160,6 +164,54 @@ class TestParameter(unittest.TestCase):
             name='double_array',
             value=ParameterValue(type=8, double_array_value=[1.0, 2.0, 3.0])
         ))
+
+    def test_parameter_value_to_python(self):
+        """Test the parameter_value_to_python conversion function."""
+        test_cases = [
+            (ParameterValue(type=int(ParameterType.PARAMETER_NOT_SET)), None),
+            (ParameterValue(type=int(ParameterType.PARAMETER_INTEGER), integer_value=42), 42),
+            (ParameterValue(type=int(ParameterType.PARAMETER_DOUBLE), double_value=3.5), 3.5),
+            (ParameterValue(type=int(ParameterType.PARAMETER_STRING), string_value='foo'), 'foo'),
+            (
+                ParameterValue(
+                    type=int(ParameterType.PARAMETER_BYTE_ARRAY),
+                    byte_array_value=[b'J', b'P']
+                ),
+                [b'J', b'P']
+            ),
+            (
+                ParameterValue(
+                    type=int(ParameterType.PARAMETER_INTEGER_ARRAY),
+                    integer_array_value=[1, 2, 3]),
+                [1, 2, 3]
+            ),
+            (
+                ParameterValue(
+                    type=int(ParameterType.PARAMETER_DOUBLE_ARRAY),
+                    double_array_value=[1.0, 2.0, 3.0]),
+                [1.0, 2.0, 3.0]
+            ),
+            (
+                ParameterValue(
+                    type=int(ParameterType.PARAMETER_STRING_ARRAY),
+                    string_array_value=['foo', 'bar']),
+                ['foo', 'bar']
+            ),
+        ]
+
+        for input_value, expected_value in test_cases:
+            result_value = parameter_value_to_python(input_value)
+            if isinstance(expected_value, list):
+                assert len(result_value) == len(expected_value)
+                # element-wise comparison for lists
+                assert all([x == y for x, y in zip(result_value, expected_value)])
+            else:
+                assert result_value == expected_value
+
+        # Test invalid 'type' member
+        parameter_value = ParameterValue(type=42)
+        with pytest.raises(RuntimeError):
+            parameter_value_to_python(parameter_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This function is particular useful when processing a GetParameters service request.
Tools like ros2param implement this function locally, but it would be nice to have a common implementation to avoid duplication.

This function was adapted from the implementation in ros2param: https://github.com/ros2/ros2cli/blob/1f4a3aaf7b930830b3fa04773715bf93ea65693e/ros2param/ros2param/api/__init__.py#L31
