### PR TITLE
Remove an unnecessary list comprehension in a test.

### DIFF
--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -204,7 +204,7 @@ class TestParameter(unittest.TestCase):
             if isinstance(expected_value, list):
                 assert len(result_value) == len(expected_value)
                 # element-wise comparison for lists
-                assert all([x == y for x, y in zip(result_value, expected_value)])
+                assert all(x == y for x, y in zip(result_value, expected_value))
             else:
                 assert result_value == expected_value
 


### PR DESCRIPTION
This was pointed out by a newer version of flake8 and
flake8-comprehension.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I believe that this should fix the new warnings we are getting on the buildfarm, like https://ci.ros2.org/view/nightly/job/nightly_linux_release/2065/testReport/junit/rclpy/flake8/C407____test_test_parameter_py_207_24_/