### PR TITLE
`InvalidHandle` shouldn't inherit from `Exception`

### DIFF
--- a/rclpy/rclpy/handle.py
+++ b/rclpy/rclpy/handle.py
@@ -18,7 +18,7 @@ from rclpy.impl.implementation_singleton import rclpy_handle_implementation as _
 from rclpy.impl.implementation_singleton import rclpy_pycapsule_implementation as _rclpy_capsule
 
 
-class InvalidHandle(Exception):
+class InvalidHandle(ValueError):
     pass
 
 


### PR DESCRIPTION
See https://github.com/ros2/rclpy/issues/623#issuecomment-942380937.