### PR TITLE
check if publisher's rmw handle is NULL

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1761,6 +1761,17 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
+  rmw_publisher_t * publisher_rmw_handle = rcl_publisher_get_rmw_handle(
+      &(pub->publisher));
+  if (!publisher_rmw_handle) {
+    PyErr_Format(
+      RCLError,
+      "Failed to get publisher rmw handle: %s", rcl_get_error_string().str);
+    rcl_reset_error();
+    PyMem_Free(pub);
+    return NULL;
+  }
+
   rclpy_handle_t * pub_handle = _rclpy_create_handle(pub, _rclpy_destroy_publisher);
   if (!pub_handle) {
     _rclpy_destroy_publisher(pub);

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1761,8 +1761,7 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rmw_publisher_t * publisher_rmw_handle = rcl_publisher_get_rmw_handle(
-      &(pub->publisher));
+  rmw_publisher_t * publisher_rmw_handle = rcl_publisher_get_rmw_handle(&(pub->publisher));
   if (!publisher_rmw_handle) {
     PyErr_Format(
       RCLError,


### PR DESCRIPTION
Add a NULL check for the rmw handle of the created publisher in `rclpy_create_publisher`.

This pr fixes issue #826 : rclpy now aborts if the rmw handle becomes NULL before returning from `rclpy_create_publisher`:
```
$ ros2 run demo_nodes_py talker
Traceback (most recent call last):                                    
  File "/home/seulbae/workspace/ros2_foxy/install/demo_nodes_py/lib/demo_nodes_py/talker", line 11, in <module>
    load_entry_point('demo-nodes-py', 'console_scripts', 'talker')()                                                                         
  File "/home/seulbae/workspace/ros2_foxy/build/demo_nodes_py/demo_nodes_py/topics/talker.py", line 41, in main                              
    node = Talker()                                                   
  File "/home/seulbae/workspace/ros2_foxy/build/demo_nodes_py/demo_nodes_py/topics/talker.py", line 26, in __init__                          
    self.pub = self.create_publisher(String, 'chatter', 10)                                                                                  
  File "/home/seulbae/workspace/ros2_foxy/install/rclpy/lib/python3.8/site-packages/rclpy/node.py", line 1144, in create_publisher
    publisher_capsule = _rclpy.rclpy_create_publisher(                                                                                       
_rclpy.RCLError: Failed to get publisher rmw handle: publisher's rmw handle is invalid, at /home/seulbae/workspace/ros2_foxy/src/ros2/rcl/rcl/src/rcl/publisher.c:442
```

Signed-off-by: Seulbae Kim <squizz617@gmail.com>