### PR TITLE
Make context.on_shutdown allow free functions as shutdown callbacks

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -185,6 +185,7 @@ if(BUILD_TESTING)
       test/test_callback_group.py
       test/test_client.py
       test/test_clock.py
+      test/test_context.py
       test/test_create_node.py
       test/test_create_while_spinning.py
       test/test_destruction.py

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from inspect import ismethod
 import sys
 import threading
 from typing import Callable
@@ -123,7 +124,10 @@ class Context:
             if not self.__context.ok():
                 callback()
             else:
-                self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
+                if ismethod(callback):
+                    self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
+                else:
+                    self._callbacks.append(weakref.ref(callback, self._remove_callback))
 
     def _logging_fini(self):
         # This function must be called with self._lock held.

--- a/rclpy/test/test_context.py
+++ b/rclpy/test/test_context.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.context import Context
+
+
+def test_on_shutdown_method():
+    context = Context()
+    context.init()
+
+    callback_called = False
+
+    class SomeClass:
+
+        def on_shutdown(self):
+            nonlocal callback_called
+            callback_called = True
+
+    instance = SomeClass()
+    context.on_shutdown(instance.on_shutdown)
+
+    context.shutdown()
+
+    assert callback_called
+
+
+def test_on_shutdown_function():
+    context = Context()
+    context.init()
+
+    callback_called = False
+
+    def on_shutdown():
+        nonlocal callback_called
+        callback_called = True
+
+    context.on_shutdown(on_shutdown)
+
+    context.shutdown()
+
+    assert callback_called


### PR DESCRIPTION
Split from #858 

`WeakMethod` throws an exception if the callable is not a bound method, which prevented using free functions as a shutdown callback. This allows free functions by storing them with `weakref.ref`. 

Example exception before this PR

```python
9: >           raise TypeError("argument should be a bound method, not {}"
9:                             .format(type(meth))) from None
9: E           TypeError: argument should be a bound method, not <class 'function'>
```