### PR TITLE
Fix time.py and clock.py circular import

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -15,6 +15,7 @@
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
 from .duration import Duration
+from .time import Time
 
 
 ClockType = _rclpy.ClockType
@@ -119,8 +120,7 @@ class Clock:
     def __repr__(self):
         return 'Clock(clock_type={0})'.format(self.clock_type.name)
 
-    def now(self):
-        from rclpy.time import Time
+    def now(self) -> Time:
         with self.handle:
             rcl_time = self.__clock.get_now()
         return Time(nanoseconds=rcl_time.nanoseconds, clock_type=self.clock_type)
@@ -169,8 +169,7 @@ class ROSClock(Clock):
         with self.handle:
             self.handle.set_ros_time_override_is_enabled(enabled)
 
-    def set_ros_time_override(self, time):
-        from rclpy.time import Time
+    def set_ros_time_override(self, time: Time):
         if not isinstance(time, Time):
             raise TypeError(
                 'Time must be specified as rclpy.time.Time. Received type: {0}'.format(type(time)))

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import builtin_interfaces.msg
-from rclpy.clock import ClockType
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
@@ -23,8 +22,11 @@ CONVERSION_CONSTANT = 10 ** 9
 
 class Time:
 
-    def __init__(self, *, seconds=0, nanoseconds=0, clock_type=ClockType.SYSTEM_TIME):
-        if not isinstance(clock_type, ClockType):
+    def __init__(
+            self, *,
+            seconds=0, nanoseconds=0,
+            clock_type: _rclpy.ClockType = _rclpy.ClockType.SYSTEM_TIME):
+        if not isinstance(clock_type, _rclpy.ClockType):
             raise TypeError('Clock type must be a ClockType enum')
         if seconds < 0:
             raise ValueError('Seconds value must not be negative')
@@ -139,7 +141,7 @@ class Time:
         return builtin_interfaces.msg.Time(sec=seconds, nanosec=nanoseconds)
 
     @classmethod
-    def from_msg(cls, msg, clock_type=ClockType.ROS_TIME):
+    def from_msg(cls, msg, clock_type: _rclpy.ClockType = _rclpy.ClockType.ROS_TIME):
         if not isinstance(msg, builtin_interfaces.msg.Time):
             raise TypeError('Must pass a builtin_interfaces.msg.Time object')
         return cls(seconds=msg.sec, nanoseconds=msg.nanosec, clock_type=clock_type)


### PR DESCRIPTION
Split from #858

This fixes a circular import between `time.py` and `clock.py`. Both need the `ClockType` type, which comes from `_rclpy_pybind11`, but `time.py` was importing it from `clock.py`. That forced `clock.py` to import `Time` inside functions that used it.

I also added type annotations where I touched code.