### PR TITLE
Improve JumpThreshold documentation and forbid zero durations

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -23,16 +23,28 @@ ClockChange = _rclpy.ClockChange
 
 class JumpThreshold:
 
-    def __init__(self, *, min_forward, min_backward, on_clock_change=True):
+    def __init__(self, *, min_forward: Duration, min_backward: Duration, on_clock_change=True):
         """
         Initialize an instance of JumpThreshold.
-
         :param min_forward: Minimum jump forwards to be considered exceeded, or None.
+            The min_forward threshold is enabled only when given a positive Duration.
+            The duration must be positive, and not zero.
         :param min_backward: Negative duration indicating minimum jump backwards to be considered
                              exceeded, or None.
+            The min_backward threshold enabled only when given a negative Duration.
+            The duration must be negative, and not zero.
         :param on_clock_change: True to make a callback happen when ROS_TIME is activated
                                 or deactivated.
         """
+        if min_forward is not None and min_forward.nanoseconds <= 0:
+            raise ValueError('min_forward must be a positive non-zero duration')
+
+        if min_backward is not None and min_backward.nanoseconds >= 0:
+            raise ValueError('min_backward must be a negative non-zero duration')
+
+        if min_forward is None and min_backward is None and not on_clock_change:
+            raise ValueError('At least one jump threshold must be enabled')
+
         self.min_forward = min_forward
         self.min_backward = min_backward
         self.on_clock_change = on_clock_change

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -26,6 +26,7 @@ class JumpThreshold:
     def __init__(self, *, min_forward: Duration, min_backward: Duration, on_clock_change=True):
         """
         Initialize an instance of JumpThreshold.
+
         :param min_forward: Minimum jump forwards to be considered exceeded, or None.
             The min_forward threshold is enabled only when given a positive Duration.
             The duration must be positive, and not zero.

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -16,6 +16,7 @@ import time
 import unittest
 from unittest.mock import Mock
 
+import pytest
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 from rclpy.clock import JumpThreshold
@@ -24,6 +25,34 @@ from rclpy.duration import Duration
 from rclpy.time import Time
 
 from .mock_compat import __name__ as _  # noqa: ignore=F401
+
+
+def test_invalid_jump_threshold():
+    with pytest.raises(ValueError, match='.*min_forward.*'):
+        JumpThreshold(
+            min_forward=Duration(nanoseconds=0),
+            min_backward=Duration(nanoseconds=-1))
+
+    with pytest.raises(ValueError, match='.*min_forward.*'):
+        JumpThreshold(
+            min_forward=Duration(nanoseconds=-1),
+            min_backward=Duration(nanoseconds=-1))
+
+    with pytest.raises(ValueError, match='.*min_backward.*'):
+        JumpThreshold(
+            min_forward=Duration(nanoseconds=1),
+            min_backward=Duration(nanoseconds=0))
+
+    with pytest.raises(ValueError, match='.*min_backward.*'):
+        JumpThreshold(
+            min_forward=Duration(nanoseconds=1),
+            min_backward=Duration(nanoseconds=1))
+
+    with pytest.raises(ValueError, match='.*must be enabled.*'):
+        JumpThreshold(
+            min_forward=None,
+            min_backward=None,
+            on_clock_change=False)
 
 
 class TestClock(unittest.TestCase):


### PR DESCRIPTION
Split from #858

This documents `JumpThreshold`, and forbids passing zero Durations.

JumpThreshold `min_forward` and `min_backward` are disabled in `rclpy` when `None` is passed. In `rcl` the thresholds are disabled when set to 0. I chose to make `JumpThreshold` forbid zero Durations so that there's only one way to disable them. Otherwise, it's easy to pass a zero duration and think it's requesting the smallest possible time jump.