### PR TITLE
Add __enter__ and __exit__ to JumpHandle

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -95,6 +95,12 @@ class JumpHandle:
                 self._clock.handle.remove_clock_callback(self)
             self._clock = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, t, v, tb):
+        self.unregister()
+
 
 class Clock:
 

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
+from rclpy.clock import JumpHandle
 from rclpy.clock import JumpThreshold
 from rclpy.clock import ROSClock
 from rclpy.duration import Duration
@@ -179,3 +180,20 @@ class TestClock(unittest.TestCase):
         handler1.unregister()
         handler2.unregister()
         handler3.unregister()
+
+
+def test_with_jump_handle():
+    clock = ROSClock()
+    clock._set_ros_time_is_active(False)
+
+    post_callback = Mock()
+    threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
+
+    with clock.create_jump_callback(threshold, post_callback=post_callback) as jump_handler:
+        assert isinstance(jump_handler, JumpHandle)
+        clock._set_ros_time_is_active(True)
+        post_callback.assert_called_once()
+
+    post_callback.reset_mock()
+    clock._set_ros_time_is_active(False)
+    post_callback.assert_not_called()


### PR DESCRIPTION
Split from #858

This allows `JumpHandle` to be used with Python's `with` keyword, guaranteeing the time jump callback is unregestered even if an exception is thrown.