### PR TITLE
Don't override `rclpy._rclpy_pybind11` docs

### DIFF
--- a/rclpy/src/rclpy/_rclpy_logging.cpp
+++ b/rclpy/src/rclpy/_rclpy_logging.cpp
@@ -177,8 +177,6 @@ namespace rclpy
 void
 define_logging_api(py::module m)
 {
-  m.doc() = "RCLPY module for logging.";
-
   py::enum_<RCUTILS_LOG_SEVERITY>(m, "RCUTILS_LOG_SEVERITY")
   .value("RCUTILS_LOG_SEVERITY_UNSET", RCUTILS_LOG_SEVERITY_UNSET)
   .value("RCUTILS_LOG_SEVERITY_DEBUG", RCUTILS_LOG_SEVERITY_DEBUG)


### PR DESCRIPTION
There's no `rclpy._rclpy_logging_pybind11` module, the deleted line was just overriding the original docs.