### PR TITLE
Implement managed nodes

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -16,9 +16,11 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(rcl REQUIRED)
-find_package(rcl_logging_interface REQUIRED)
 find_package(rcl_action REQUIRED)
+find_package(rcl_lifecycle REQUIRED)
+find_package(rcl_logging_interface REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
@@ -113,6 +115,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/exceptions.cpp
   src/rclpy/graph.cpp
   src/rclpy/guard_condition.cpp
+  src/rclpy/lifecycle.cpp
   src/rclpy/logging.cpp
   src/rclpy/names.cpp
   src/rclpy/node.cpp
@@ -132,9 +135,12 @@ pybind11_add_module(_rclpy_pybind11 SHARED
 target_include_directories(_rclpy_pybind11 PRIVATE
   src/rclpy/
 )
-target_link_libraries(_rclpy_pybind11 PRIVATE
+target_link_libraries(_rclpy_pybind11 PRIVATE  
+  lifecycle_msgs::lifecycle_msgs__rosidl_generator_c
+  lifecycle_msgs::lifecycle_msgs__rosidl_typesupport_c
   rcl::rcl
   rcl_action::rcl_action
+  rcl_lifecycle::rcl_lifecycle
   rcl_logging_interface::rcl_logging_interface
   rcpputils::rcpputils
   rcutils::rcutils

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -135,7 +135,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
 target_include_directories(_rclpy_pybind11 PRIVATE
   src/rclpy/
 )
-target_link_libraries(_rclpy_pybind11 PRIVATE  
+target_link_libraries(_rclpy_pybind11 PRIVATE
   lifecycle_msgs::lifecycle_msgs__rosidl_generator_c
   lifecycle_msgs::lifecycle_msgs__rosidl_typesupport_c
   rcl::rcl

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -25,6 +25,7 @@
 
   <depend>rmw_implementation</depend>
   <depend>rcl</depend>
+  <depend>rcl_lifecycle</depend>
   <depend>rcl_logging_interface</depend>
   <depend>rcl_action</depend>
   <depend>rcl_yaml_param_parser</depend>

--- a/rclpy/rclpy/lifecycle.py
+++ b/rclpy/rclpy/lifecycle.py
@@ -12,32 +12,229 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import Callable
+from typing import Dict
+from typing import Optional
+
+import lifecycle_msgs.srv
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
+from rclpy.qos import QoSProfile
 from rclpy.service import Service
+from rclpy.type_support import check_is_valid_msg_type
+from rclpy.type_support import check_is_valid_srv_type
 
+
+TransitionCallbackReturn = _rclpy.TransitionCallbackReturnType
 
 class LifecycleMixin:
-    def __init__(self, *, enable_communication_interface: bool = True):
-        self.create_state_machine(enable_communication_interface)
 
+    # TODO(ivanpauno): We could make this a bit nicer by adding State, Transition, StateMachine abstractions
+    # in this module.
+    # Anyways those are not directly useful to the user and the implementation is not too bad without them.
+    def __init__(
+        self,
+        *,
+        enable_communication_interface: bool = True,
+        callback_group: Optional[CallbackGroup] = None,
+    ):
+        if callback_group is None:
+            callback_group = self.default_callback_group
+        self._callbacks : Dict[int, Callable[[int], TransitionCallbackReturn]] = {}
+        for srv_type in (
+            lifecycle_msgs.srv.ChangeState,
+            lifecycle_msgs.srv.GetState,
+            lifecycle_msgs.srv.GetAvailableStates,
+            lifecycle_msgs.srv.GetAvailableTransitions,
+        ):
+            # this doesn't only checks, but also imports some stuff we need later
+            check_is_valid_srv_type(srv_type)
 
-    def create_state_machine(self, enable_communication_interface: bool):
         with self.handle:
-            # self._state_machine = StateMachine(
-            #     _rclpy.LifecycleStateMachine(self.handle, enable_communication_interface))
             self._state_machine = _rclpy.LifecycleStateMachine(self.handle, enable_communication_interface)
-        self._Node__services.extend(
-            [
-                self._state_machine.service_change_state,
-                self._state_machine.service_get_state,
-                self._state_machine.service_get_available_states,
-                self._state_machine.service_get_available_transitions,
-                self._state_machine.service_get_transition_graph,
-            ]
-        )
+        self._service_change_state = Service(
+            self._state_machine.service_change_state,
+            lifecycle_msgs.srv.ChangeState,
+            self._state_machine.service_change_state.name,
+            self.__on_change_state,
+            callback_group,
+            QoSProfile(**self._state_machine.service_change_state.qos))
+        self._service_get_state = Service(
+            self._state_machine.service_get_state,
+            lifecycle_msgs.srv.GetState,
+            self._state_machine.service_get_state.name,
+            self._on_get_state,
+            callback_group,
+            QoSProfile(**self._state_machine.service_get_state.qos))
+        self._service_get_available_states = Service(
+            self._state_machine.service_get_available_states,
+            lifecycle_msgs.srv.GetAvailableStates,
+            self._state_machine.service_get_available_states.name,
+            self._on_get_available_states,
+            callback_group,
+            QoSProfile(**self._state_machine.service_get_available_states.qos))
+        self._service_get_available_transitions = Service(
+            self._state_machine.service_get_available_transitions,
+            lifecycle_msgs.srv.GetAvailableTransitions,
+            self._state_machine.service_get_available_transitions.name,
+            self._on_get_available_transitions,
+            callback_group,
+            QoSProfile(**self._state_machine.service_get_available_transitions.qos))
+        self._service_get_transition_graph = Service(
+            self._state_machine.service_get_transition_graph,
+            lifecycle_msgs.srv.GetAvailableTransitions,
+            self._state_machine.service_get_transition_graph.name,
+            self._on_get_transition_graph,
+            callback_group,
+            QoSProfile(**self._state_machine.service_get_transition_graph.qos))
+
+        lifecycle_services = [
+            self._service_change_state,
+            self._service_get_state,
+            self._service_get_available_states,
+            self._service_get_available_transitions,
+            self._service_get_transition_graph,
+        ]
+        for s in lifecycle_services:
+            callback_group.add_entity(s)
+        # TODO(ivanpauno): Modify attribute in Node to be "protected" instead of "private".
+        # i.e. Node.__services -> Node._services
+        # Maybe the same with similar attributes (__publishers, etc).
+        # Maybe have some interface to add a service/etc instead (?).
+        self._Node__services.extend(lifecycle_services)
+
+    def register_callback(
+        self, state_id: int, callback: Callable[[int], TransitionCallbackReturn]
+    ) -> bool:
+        self._callbacks[state_id] = callback
+        # TODO(ivanpauno): Copying rclcpp style.
+        # Maybe having a return value doesn't make sense (?).
+        # Should we error/warn if overridding an existing callback?
+        return True
+
+    def __execute_callback(self, current_state: int, previous_state: int) -> TransitionCallbackReturn:
+        cb = self._callbacks.get(current_state, None)
+        if not cb:
+            return TransitionCallbackReturn.SUCCESS
+        try:
+            return cb(previous_state)
+        except Exception:
+            # TODO(ivanpauno): log sth here
+            return TransitionCallbackReturn.ERROR
+
+    def __change_state(self, transition_id: int):
+        self.__check_is_initialized()
+        initial_state_id = self._state_machine.current_state[0]
+        self._state_machine.trigger_transition_by_id(transition_id, True)
+
+        cb_return_code = self.__execute_callback(self._state_machine.current_state[0], initial_state_id)
+        self._state_machine.trigger_transition_by_label(cb_return_code.to_label(), True)
+
+
+        if cb_return_code == TransitionCallbackReturn.ERROR:
+            # TODO(ivanpauno): I don't understand what rclcpp is doing here ...
+            # It's triggering the error transition twice (?)
+            # https://github.com/ros2/rclcpp/blob/b2b676d3172ada509e58fa552a676a446809d83c/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp#L428-L443
+            pass
+        return cb_return_code
+
+    def __check_is_initialized(self):
+        # TODO(ivanpauno): This sanity check is probably not needed, just doing the same checks as
+        # rclcpp for the moment.
+        if not self._state_machine.initialized:
+            raise RuntimeError(
+                'Internal error: got service request while lifecycle state machine '
+                'is not initialized.')
+
+    def __on_change_state(
+        self,
+        req: lifecycle_msgs.srv.ChangeState.Request,
+        resp: lifecycle_msgs.srv.ChangeState.Response
+    ):
+        self.__check_is_initialized()
+        transition_id = req.transition.id;
+        if req.transition.label:
+            try:
+                transition_id = self._state_machine.get_transition_by_label(req.transition.label)
+            except _rclpy.RCLError:
+                resp.success = False
+                return resp
+        cb_return_code = self.__change_state(transition_id);
+        resp.success = cb_return_code == TransitionCallbackReturn.SUCCESS
+        return resp
+
+    def _on_get_state(
+        self,
+        req: lifecycle_msgs.srv.GetState.Request,
+        resp: lifecycle_msgs.srv.GetState.Response
+    ):
+        self.__check_is_initialized()
+        resp.current_state.id, resp.current_state.label = self._state_machine.current_state
+        return resp
+
+    def _on_get_available_states(
+        self,
+        req: lifecycle_msgs.srv.GetAvailableStates.Request,
+        resp: lifecycle_msgs.srv.GetAvailableStates.Response
+    ):
+        self.__check_is_initialized()
+        for id, label in self._state_machine.available_states:
+            resp.available_states.append(lifecycle_msgs.msg.State(id=id, label=label))
+        return resp
+
+    def _on_get_available_transitions(
+        self,
+        req: lifecycle_msgs.srv.GetAvailableTransitions.Request,
+        resp: lifecycle_msgs.srv.GetAvailableTransitions.Response
+    ):
+        self.__check_is_initialized()
+        for id, label, start_id, start_label, goal_id, goal_label in self._state_machine.available_transitions:
+            item = lifecycle_msgs.msg.TransitionDescription()
+            item.transition.id = id
+            item.transition.label = label
+            item.start_state.id = start_id
+            item.start_state.label = start_label
+            item.goal_state.id = goal_id
+            item.goal_state.label = goal_label
+            resp.available_transitions.append(item)
+        return resp
+
+    def _on_get_transition_graph(
+        self,
+        req: lifecycle_msgs.srv.GetAvailableTransitions.Request,
+        resp: lifecycle_msgs.srv.GetAvailableTransitions.Response
+    ):
+        self.__check_is_initialized()
+        for id, label, start_id, start_label, goal_id, goal_label in self._state_machine.transition_graph:
+            item = lifecycle_msgs.msg.TransitionDescription()
+            item.transition.id = id
+            item.transition.label = label
+            item.start_state.id = start_id
+            item.start_state.label = start_label
+            item.goal_state.id = goal_id
+            item.goal_state.label = goal_label
+            resp.available_transitions.append(item)
+        return resp
+
+    def on_configure(self, state) -> TransitionCallbackReturn:
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_cleanup(self, state) -> TransitionCallbackReturn:
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_shutdown(self, state) -> TransitionCallbackReturn:
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_activate(self, state) -> TransitionCallbackReturn:
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_deactivate(self, state) -> TransitionCallbackReturn:
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_error(self, state) -> TransitionCallbackReturn:
+        return TransitionCallbackReturn.SUCCESS
 
 
 class LifecycleNode(LifecycleMixin, Node):
@@ -45,12 +242,3 @@ class LifecycleNode(LifecycleMixin, Node):
         Node.__init__(self, node_name, **kwargs)
         LifecycleMixin.__init__(self,
             enable_communication_interface=enable_communication_interface)
-
-
-class StateMachine:
-    """Lifecycle state machine implementation."""
-
-    def __init__(self, state_machine_impl: _rclpy.LifecycleStateMachine):
-        self._state_machine = state_machine_impl
-    
-    # def 

--- a/rclpy/rclpy/lifecycle.py
+++ b/rclpy/rclpy/lifecycle.py
@@ -65,28 +65,28 @@ class LifecycleMixin:
             self._state_machine.service_get_state,
             lifecycle_msgs.srv.GetState,
             self._state_machine.service_get_state.name,
-            self._on_get_state,
+            self.__on_get_state,
             callback_group,
             QoSProfile(**self._state_machine.service_get_state.qos))
         self._service_get_available_states = Service(
             self._state_machine.service_get_available_states,
             lifecycle_msgs.srv.GetAvailableStates,
             self._state_machine.service_get_available_states.name,
-            self._on_get_available_states,
+            self.__on_get_available_states,
             callback_group,
             QoSProfile(**self._state_machine.service_get_available_states.qos))
         self._service_get_available_transitions = Service(
             self._state_machine.service_get_available_transitions,
             lifecycle_msgs.srv.GetAvailableTransitions,
             self._state_machine.service_get_available_transitions.name,
-            self._on_get_available_transitions,
+            self.__on_get_available_transitions,
             callback_group,
             QoSProfile(**self._state_machine.service_get_available_transitions.qos))
         self._service_get_transition_graph = Service(
             self._state_machine.service_get_transition_graph,
             lifecycle_msgs.srv.GetAvailableTransitions,
             self._state_machine.service_get_transition_graph.name,
-            self._on_get_transition_graph,
+            self.__on_get_transition_graph,
             callback_group,
             QoSProfile(**self._state_machine.service_get_transition_graph.qos))
 
@@ -165,7 +165,7 @@ class LifecycleMixin:
         resp.success = cb_return_code == TransitionCallbackReturn.SUCCESS
         return resp
 
-    def _on_get_state(
+    def __on_get_state(
         self,
         req: lifecycle_msgs.srv.GetState.Request,
         resp: lifecycle_msgs.srv.GetState.Response
@@ -174,7 +174,7 @@ class LifecycleMixin:
         resp.current_state.id, resp.current_state.label = self._state_machine.current_state
         return resp
 
-    def _on_get_available_states(
+    def __on_get_available_states(
         self,
         req: lifecycle_msgs.srv.GetAvailableStates.Request,
         resp: lifecycle_msgs.srv.GetAvailableStates.Response
@@ -184,7 +184,7 @@ class LifecycleMixin:
             resp.available_states.append(lifecycle_msgs.msg.State(id=id, label=label))
         return resp
 
-    def _on_get_available_transitions(
+    def __on_get_available_transitions(
         self,
         req: lifecycle_msgs.srv.GetAvailableTransitions.Request,
         resp: lifecycle_msgs.srv.GetAvailableTransitions.Response
@@ -201,7 +201,7 @@ class LifecycleMixin:
             resp.available_transitions.append(item)
         return resp
 
-    def _on_get_transition_graph(
+    def __on_get_transition_graph(
         self,
         req: lifecycle_msgs.srv.GetAvailableTransitions.Request,
         resp: lifecycle_msgs.srv.GetAvailableTransitions.Response

--- a/rclpy/rclpy/lifecycle.py
+++ b/rclpy/rclpy/lifecycle.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.node import Node
+from rclpy.service import Service
+
+
+class LifecycleMixin:
+    def __init__(self, *, enable_communication_interface: bool = True):
+        self.create_state_machine(enable_communication_interface)
+
+
+    def create_state_machine(self, enable_communication_interface: bool):
+        with self.handle:
+            # self._state_machine = StateMachine(
+            #     _rclpy.LifecycleStateMachine(self.handle, enable_communication_interface))
+            self._state_machine = _rclpy.LifecycleStateMachine(self.handle, enable_communication_interface)
+        self._Node__services.extend(
+            [
+                self._state_machine.service_change_state,
+                self._state_machine.service_get_state,
+                self._state_machine.service_get_available_states,
+                self._state_machine.service_get_available_transitions,
+                self._state_machine.service_get_transition_graph,
+            ]
+        )
+
+
+class LifecycleNode(LifecycleMixin, Node):
+    def __init__(self, node_name, *, enable_communication_interface: bool = True, **kwargs):
+        Node.__init__(self, node_name, **kwargs)
+        LifecycleMixin.__init__(self,
+            enable_communication_interface=enable_communication_interface)
+
+
+class StateMachine:
+    """Lifecycle state machine implementation."""
+
+    def __init__(self, state_machine_impl: _rclpy.LifecycleStateMachine):
+        self._state_machine = state_machine_impl
+    
+    # def 

--- a/rclpy/rclpy/lifecycle.py
+++ b/rclpy/rclpy/lifecycle.py
@@ -314,11 +314,11 @@ class SimpleManagedEntity(ManagedEntity):
 
     def on_activate(self, state) -> TransitionCallbackReturn:
         self._enabled = True
-        return super().on_activate(state)
+        return TransitionCallbackReturn.SUCCESS
 
     def on_deactivate(self, state) -> TransitionCallbackReturn:
         self._enabled = False
-        return super().on_deactivate(state)
+        return TransitionCallbackReturn.SUCCESS
 
     @property
     def enabled(self):

--- a/rclpy/rclpy/lifecycle.py
+++ b/rclpy/rclpy/lifecycle.py
@@ -92,7 +92,8 @@ class SimpleManagedEntity(ManagedEntity):
 class LifecyclePublisher(SimpleManagedEntity, Publisher):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        SimpleManagedEntity.__init__(self)
+        Publisher.__init__(self, *args, **kwargs)
         self.publish = self.when_enabled(self.publish)
 
 
@@ -254,7 +255,13 @@ class LifecycleMixin(ManagedEntity):
                 return ret
         return TransitionCallbackReturn.SUCCESS
 
-    def create_publisher(self, *args, **kwargs):
+    def create_lifecycle_publisher(self, *args, **kwargs):
+        # TODO(ivanpauno): Should we override lifecycle publisher?
+        # There is an issue with python using the overridden method
+        # when creating publishers for builitin publishers (like parameters events).
+        # We could override them after init, similar to what we do to override publish()
+        # in LifecycleNode.
+        # Having both options seem fine.
         if 'publisher_class' in kwargs:
             raise TypeError(
                 "create_publisher() got an unexpected keyword argument 'publisher_class'")
@@ -262,7 +269,7 @@ class LifecycleMixin(ManagedEntity):
         self._managed_entities.add(pub)
         return pub
 
-    def destroy_publisher(self, publisher: LifecyclePublisher):
+    def destroy_lifecycle_publisher(self, publisher: LifecyclePublisher):
         try:
             self._managed_entities.remove(publisher)
         except KeyError:

--- a/rclpy/rclpy/lifecycle/__init__.py
+++ b/rclpy/rclpy/lifecycle/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .managed_entity import ManagedEntity
+from .managed_entity import SimpleManagedEntity
+from .node import LifecycleMixin
+from .node import LifecycleNode
+from .publisher import LifecyclePublisher
+
+from ..impl.implementation_singleton import rclpy_implementation as _rclpy
+
+# reexport LifecycleNode as Node, so it's possible to write:
+# from rclpy.lifecycle import Node
+# Do not include that in __all__ to avoid mixing it up with rclpy.node.Node.
+Node = LifecycleNode
+# same idea here
+Publisher = LifecyclePublisher
+# enum defined in pybind11 plugin
+TransitionCallbackReturn = _rclpy.TransitionCallbackReturnType
+
+
+__all__ = [
+    'LifecycleMixin',
+    'LifecyclePublisher',
+    'ManagedEntity',
+    'SimpleManagedEntity',
+]

--- a/rclpy/rclpy/lifecycle/__init__.py
+++ b/rclpy/rclpy/lifecycle/__init__.py
@@ -14,8 +14,8 @@
 
 from .managed_entity import ManagedEntity
 from .managed_entity import SimpleManagedEntity
-from .node import LifecycleNodeMixin
 from .node import LifecycleNode
+from .node import LifecycleNodeMixin
 from .node import LifecycleState
 from .publisher import LifecyclePublisher
 

--- a/rclpy/rclpy/lifecycle/__init__.py
+++ b/rclpy/rclpy/lifecycle/__init__.py
@@ -14,7 +14,7 @@
 
 from .managed_entity import ManagedEntity
 from .managed_entity import SimpleManagedEntity
-from .node import LifecycleMixin
+from .node import LifecycleNodeMixin
 from .node import LifecycleNode
 from .node import LifecycleState
 from .publisher import LifecyclePublisher
@@ -26,6 +26,7 @@ from ..impl.implementation_singleton import rclpy_implementation as _rclpy
 # Do not include that in __all__ to avoid mixing it up with rclpy.node.Node.
 Node = LifecycleNode
 # same idea here
+NodeMixin = LifecycleNodeMixin
 State = LifecycleState
 Publisher = LifecyclePublisher
 
@@ -34,7 +35,7 @@ TransitionCallbackReturn = _rclpy.TransitionCallbackReturnType
 
 
 __all__ = [
-    'LifecycleMixin',
+    'LifecycleNodeMixin',
     'LifecycleNode',
     'LifecycleState',
     'LifecyclePublisher',

--- a/rclpy/rclpy/lifecycle/__init__.py
+++ b/rclpy/rclpy/lifecycle/__init__.py
@@ -16,6 +16,7 @@ from .managed_entity import ManagedEntity
 from .managed_entity import SimpleManagedEntity
 from .node import LifecycleMixin
 from .node import LifecycleNode
+from .node import LifecycleState
 from .publisher import LifecyclePublisher
 
 from ..impl.implementation_singleton import rclpy_implementation as _rclpy
@@ -25,13 +26,17 @@ from ..impl.implementation_singleton import rclpy_implementation as _rclpy
 # Do not include that in __all__ to avoid mixing it up with rclpy.node.Node.
 Node = LifecycleNode
 # same idea here
+State = LifecycleState
 Publisher = LifecyclePublisher
+
 # enum defined in pybind11 plugin
 TransitionCallbackReturn = _rclpy.TransitionCallbackReturnType
 
 
 __all__ = [
     'LifecycleMixin',
+    'LifecycleNode',
+    'LifecycleState',
     'LifecyclePublisher',
     'ManagedEntity',
     'SimpleManagedEntity',

--- a/rclpy/rclpy/lifecycle/managed_entity.py
+++ b/rclpy/rclpy/lifecycle/managed_entity.py
@@ -1,0 +1,77 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+
+from ..impl.implementation_singleton import rclpy_implementation as _rclpy
+
+
+TransitionCallbackReturn = _rclpy.TransitionCallbackReturnType
+
+
+class ManagedEntity:
+
+    def on_configure(self, state) -> TransitionCallbackReturn:
+        """Handle configure transition request."""
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_cleanup(self, state) -> TransitionCallbackReturn:
+        """Handle cleanup transition request."""
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_shutdown(self, state) -> TransitionCallbackReturn:
+        """Handle shutdown transition request."""
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_activate(self, state) -> TransitionCallbackReturn:
+        """Handle activate transition request."""
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_deactivate(self, state) -> TransitionCallbackReturn:
+        """Handle deactivate transition request."""
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_error(self, state) -> TransitionCallbackReturn:
+        """Handle error transition request."""
+        return TransitionCallbackReturn.SUCCESS
+
+
+class SimpleManagedEntity(ManagedEntity):
+    """A simple managed entity that only sets a flag when activated/deactivated."""
+
+    def __init__(self):
+        self._enabled = False
+
+    def on_activate(self, state) -> TransitionCallbackReturn:
+        self._enabled = True
+        return TransitionCallbackReturn.SUCCESS
+
+    def on_deactivate(self, state) -> TransitionCallbackReturn:
+        self._enabled = False
+        return TransitionCallbackReturn.SUCCESS
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    def when_enabled(self, wrapped, when_not_enabled=None):
+        @wraps
+        def only_when_enabled_wrapper(*args, **kwargs):
+            if not self.enabled:
+                if when_not_enabled is not None:
+                    when_not_enabled()
+                return
+            wrapped(*args, **kwargs)
+
+        return only_when_enabled_wrapper

--- a/rclpy/rclpy/lifecycle/managed_entity.py
+++ b/rclpy/rclpy/lifecycle/managed_entity.py
@@ -65,13 +65,17 @@ class SimpleManagedEntity(ManagedEntity):
     def enabled(self):
         return self._enabled
 
-    def when_enabled(self, wrapped, when_not_enabled=None):
-        @wraps
-        def only_when_enabled_wrapper(*args, **kwargs):
-            if not self.enabled:
-                if when_not_enabled is not None:
-                    when_not_enabled()
-                return
-            wrapped(*args, **kwargs)
-
-        return only_when_enabled_wrapper
+    @staticmethod
+    def when_enabled(wrapped=None, *, when_not_enabled=None):
+        def decorator(wrapped):
+            @wraps
+            def only_when_enabled_wrapper(self: SimpleManagedEntity, *args, **kwargs):
+                if not self.enabled:
+                    if when_not_enabled is not None:
+                        when_not_enabled()
+                    return
+                wrapped(*args, **kwargs)
+            return only_when_enabled_wrapper
+        if wrapped is None:
+            return decorator
+        return decorator(wrapped)

--- a/rclpy/rclpy/lifecycle/managed_entity.py
+++ b/rclpy/rclpy/lifecycle/managed_entity.py
@@ -68,13 +68,13 @@ class SimpleManagedEntity(ManagedEntity):
     @staticmethod
     def when_enabled(wrapped=None, *, when_not_enabled=None):
         def decorator(wrapped):
-            @wraps
+            @wraps(wrapped)
             def only_when_enabled_wrapper(self: SimpleManagedEntity, *args, **kwargs):
                 if not self.enabled:
                     if when_not_enabled is not None:
                         when_not_enabled()
                     return
-                wrapped(*args, **kwargs)
+                wrapped(self, *args, **kwargs)
             return only_when_enabled_wrapper
         if wrapped is None:
             return decorator

--- a/rclpy/rclpy/lifecycle/managed_entity.py
+++ b/rclpy/rclpy/lifecycle/managed_entity.py
@@ -62,7 +62,7 @@ class SimpleManagedEntity(ManagedEntity):
         return TransitionCallbackReturn.SUCCESS
 
     @property
-    def enabled(self):
+    def is_activated(self):
         return self._enabled
 
     @staticmethod
@@ -70,7 +70,7 @@ class SimpleManagedEntity(ManagedEntity):
         def decorator(wrapped):
             @wraps(wrapped)
             def only_when_enabled_wrapper(self: SimpleManagedEntity, *args, **kwargs):
-                if not self.enabled:
+                if not self._enabled:
                     if when_not_enabled is not None:
                         when_not_enabled()
                     return

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -174,16 +174,35 @@ class LifecycleNodeMixin(ManagedEntity):
         self._managed_entities.add(entity)
 
     def on_configure(self, state) -> TransitionCallbackReturn:
+        """
+        Handle a configuring transition.
+
+        This is the default on_configure() callback.
+        It will call all on_configure() callbacks of managed entities, giving up at the first
+        entity that returns TransitionCallbackReturn.FAILURE or TransitionCallbackReturn.ERROR.
+
+        It's possible to override this callback if the default behavior is not desired.
+        If you only want to extend what this callback does, make sure to call
+        super().on_configure() in derived classes.
+        """
         for entity in self._managed_entities:
             ret = entity.on_configure(state)
-            # TODO(ivanpauno): Should we stop calling the other managed entities callabacks
-            # if one fails or errors?
-            # Should the behavior be the same in all the other cases?
             if ret != TransitionCallbackReturn.SUCCESS:
                 return ret
         return TransitionCallbackReturn.SUCCESS
 
     def on_cleanup(self, state) -> TransitionCallbackReturn:
+        """
+        Handle a cleaning up transition.
+
+        This is the default on_cleanup() callback.
+        It will call all on_cleanup() callbacks of managed entities, giving up at the first
+        entity that returns TransitionCallbackReturn.FAILURE or TransitionCallbackReturn.ERROR.
+
+        It's possible to override this callback if the default behavior is not desired.
+        If you only want to extend what this callback does, make sure to call
+        super().on_cleanup() in derived classes.
+        """
         for entity in self._managed_entities:
             ret = entity.on_cleanup(state)
             if ret != TransitionCallbackReturn.SUCCESS:
@@ -191,6 +210,17 @@ class LifecycleNodeMixin(ManagedEntity):
         return TransitionCallbackReturn.SUCCESS
 
     def on_shutdown(self, state) -> TransitionCallbackReturn:
+        """
+        Handle a shutting down transition.
+
+        This is the default on_shutdown() callback.
+        It will call all on_shutdown() callbacks of managed entities, giving up at the first
+        entity that returns TransitionCallbackReturn.FAILURE or TransitionCallbackReturn.ERROR.
+
+        It's possible to override this callback if the default behavior is not desired.
+        If you only want to extend what this callback does, make sure to call
+        super().on_shutdown() in derived classes.
+        """
         for entity in self._managed_entities:
             ret = entity.on_shutdown(state)
             if ret != TransitionCallbackReturn.SUCCESS:
@@ -198,6 +228,17 @@ class LifecycleNodeMixin(ManagedEntity):
         return TransitionCallbackReturn.SUCCESS
 
     def on_activate(self, state) -> TransitionCallbackReturn:
+        """
+        Handle an activating transition.
+
+        This is the default on_activate() callback.
+        It will call all on_activate() callbacks of managed entities, giving up at the first
+        entity that returns TransitionCallbackReturn.FAILURE or TransitionCallbackReturn.ERROR.
+
+        It's possible to override this callback if the default behavior is not desired.
+        If you only want to extend what this callback does, make sure to call
+        super().on_activate() in derived classes.
+        """
         for entity in self._managed_entities:
             ret = entity.on_activate(state)
             if ret != TransitionCallbackReturn.SUCCESS:
@@ -205,6 +246,17 @@ class LifecycleNodeMixin(ManagedEntity):
         return TransitionCallbackReturn.SUCCESS
 
     def on_deactivate(self, state) -> TransitionCallbackReturn:
+        """
+        Handle a deactivating transition.
+
+        This is the default on_deactivate() callback.
+        It will call all on_deactivate() callbacks of managed entities, giving up at the first
+        entity that returns TransitionCallbackReturn.FAILURE or TransitionCallbackReturn.ERROR.
+
+        It's possible to override this callback if the default behavior is not desired.
+        If you only want to extend what this callback does, make sure to call
+        super().on_deactivate() in derived classes.
+        """
         for entity in self._managed_entities:
             ret = entity.on_deactivate(state)
             if ret != TransitionCallbackReturn.SUCCESS:
@@ -212,6 +264,17 @@ class LifecycleNodeMixin(ManagedEntity):
         return TransitionCallbackReturn.SUCCESS
 
     def on_error(self, state) -> TransitionCallbackReturn:
+        """
+        Handle a transition error.
+
+        This is the default on_error() callback.
+        It will call all on_error() callbacks of managed entities, giving up at the first
+        entity that returns TransitionCallbackReturn.FAILURE or TransitionCallbackReturn.ERROR.
+
+        It's possible to override this callback if the default behavior is not desired.
+        If you only want to extend what this callback does, make sure to call
+        super().on_error() in derived classes.
+        """
         for entity in self._managed_entities:
             ret = entity.on_error(state)
             if ret != TransitionCallbackReturn.SUCCESS:

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -100,56 +100,57 @@ class LifecycleNodeMixin(ManagedEntity):
         with self.handle:
             self._state_machine = _rclpy.LifecycleStateMachine(
                 self.handle, enable_communication_interface)
-        self._service_change_state = Service(
-            self._state_machine.service_change_state,
-            lifecycle_msgs.srv.ChangeState,
-            self._state_machine.service_change_state.name,
-            self.__on_change_state,
-            callback_group,
-            QoSProfile(**self._state_machine.service_change_state.qos))
-        self._service_get_state = Service(
-            self._state_machine.service_get_state,
-            lifecycle_msgs.srv.GetState,
-            self._state_machine.service_get_state.name,
-            self.__on_get_state,
-            callback_group,
-            QoSProfile(**self._state_machine.service_get_state.qos))
-        self._service_get_available_states = Service(
-            self._state_machine.service_get_available_states,
-            lifecycle_msgs.srv.GetAvailableStates,
-            self._state_machine.service_get_available_states.name,
-            self.__on_get_available_states,
-            callback_group,
-            QoSProfile(**self._state_machine.service_get_available_states.qos))
-        self._service_get_available_transitions = Service(
-            self._state_machine.service_get_available_transitions,
-            lifecycle_msgs.srv.GetAvailableTransitions,
-            self._state_machine.service_get_available_transitions.name,
-            self.__on_get_available_transitions,
-            callback_group,
-            QoSProfile(**self._state_machine.service_get_available_transitions.qos))
-        self._service_get_transition_graph = Service(
-            self._state_machine.service_get_transition_graph,
-            lifecycle_msgs.srv.GetAvailableTransitions,
-            self._state_machine.service_get_transition_graph.name,
-            self.__on_get_transition_graph,
-            callback_group,
-            QoSProfile(**self._state_machine.service_get_transition_graph.qos))
+        if enable_communication_interface:
+            self._service_change_state = Service(
+                self._state_machine.service_change_state,
+                lifecycle_msgs.srv.ChangeState,
+                self._state_machine.service_change_state.name,
+                self.__on_change_state,
+                callback_group,
+                QoSProfile(**self._state_machine.service_change_state.qos))
+            self._service_get_state = Service(
+                self._state_machine.service_get_state,
+                lifecycle_msgs.srv.GetState,
+                self._state_machine.service_get_state.name,
+                self.__on_get_state,
+                callback_group,
+                QoSProfile(**self._state_machine.service_get_state.qos))
+            self._service_get_available_states = Service(
+                self._state_machine.service_get_available_states,
+                lifecycle_msgs.srv.GetAvailableStates,
+                self._state_machine.service_get_available_states.name,
+                self.__on_get_available_states,
+                callback_group,
+                QoSProfile(**self._state_machine.service_get_available_states.qos))
+            self._service_get_available_transitions = Service(
+                self._state_machine.service_get_available_transitions,
+                lifecycle_msgs.srv.GetAvailableTransitions,
+                self._state_machine.service_get_available_transitions.name,
+                self.__on_get_available_transitions,
+                callback_group,
+                QoSProfile(**self._state_machine.service_get_available_transitions.qos))
+            self._service_get_transition_graph = Service(
+                self._state_machine.service_get_transition_graph,
+                lifecycle_msgs.srv.GetAvailableTransitions,
+                self._state_machine.service_get_transition_graph.name,
+                self.__on_get_transition_graph,
+                callback_group,
+                QoSProfile(**self._state_machine.service_get_transition_graph.qos))
 
-        lifecycle_services = [
-            self._service_change_state,
-            self._service_get_state,
-            self._service_get_available_states,
-            self._service_get_available_transitions,
-            self._service_get_transition_graph,
-        ]
-        for s in lifecycle_services:
-            callback_group.add_entity(s)
-        # TODO(ivanpauno): Modify attribute in Node to be "protected" instead of "private".
-        # i.e. Node.__services -> Node._services
-        # Maybe the same with similar attributes (__publishers, etc).
-        # Maybe have some interface to add a service/etc instead (?).
-        self._Node__services.extend(lifecycle_services)
+            lifecycle_services = [
+                self._service_change_state,
+                self._service_get_state,
+                self._service_get_available_states,
+                self._service_get_available_transitions,
+                self._service_get_transition_graph,
+            ]
+            for s in lifecycle_services:
+                callback_group.add_entity(s)
+            # TODO(ivanpauno): Modify attribute in Node to be "protected" instead of "private".
+            # i.e. Node.__services -> Node._services
+            # Maybe the same with similar attributes (__publishers, etc).
+            # Maybe have some interface to add a service/etc instead (?).
+            self._Node__services.extend(lifecycle_services)
 
     def trigger_configure(self):
         self.__change_state(lifecycle_msgs.msg.TRANSITION_CONFIGURE)

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -31,15 +31,13 @@ from rclpy.type_support import check_is_valid_srv_type
 from .managed_entity import ManagedEntity
 from .publisher import LifecyclePublisher
 
-from ..impl.implementation_singleton import rclpy_implementation as _rclpy
-
 
 TransitionCallbackReturn = _rclpy.TransitionCallbackReturnType
 
 
 class LifecycleState(NamedTuple):
     label: str
-    id: int
+    state_id: int
 
 
 class LifecycleNodeMixin(ManagedEntity):
@@ -161,9 +159,11 @@ class LifecycleNodeMixin(ManagedEntity):
     def trigger_shutdown(self):
         current_state = self._state_machine.current_state[1]
         if current_state == 'unconfigured':
-            return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_UNCONFIGURED_SHUTDOWN)
+            return self.__change_state(
+                lifecycle_msgs.msg.Transition.TRANSITION_UNCONFIGURED_SHUTDOWN)
         if current_state == 'inactive':
-            return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_INACTIVE_SHUTDOWN)
+            return self.__change_state(
+                lifecycle_msgs.msg.Transition.TRANSITION_INACTIVE_SHUTDOWN)
         if current_state == 'active':
             return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_ACTIVE_SHUTDOWN)
 
@@ -273,7 +273,7 @@ class LifecycleNodeMixin(ManagedEntity):
     def __change_state(self, transition_id: int) -> TransitionCallbackReturn:
         self.__check_is_initialized()
         initial_state = self._state_machine.current_state
-        initial_state = LifecycleState(id=initial_state[0], label=initial_state[1])
+        initial_state = LifecycleState(state_id=initial_state[0], label=initial_state[1])
         self._state_machine.trigger_transition_by_id(transition_id, True)
 
         cb_return_code = self.__execute_callback(

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -312,9 +312,6 @@ class LifecycleNodeMixin(ManagedEntity):
         a TransitionCallbackReturn value.
         """
         self._callbacks[state_id] = callback
-        # TODO(ivanpauno): Copying rclcpp style.
-        # Maybe having a return value doesn't make sense (?).
-        # Should we error/warn if overridding an existing callback?
         return True
 
     def __execute_callback(

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -144,11 +144,8 @@ class LifecycleNodeMixin(ManagedEntity):
             ]
             for s in lifecycle_services:
                 callback_group.add_entity(s)
-            # TODO(ivanpauno): Modify attribute in Node to be "protected" instead of "private".
-            # i.e. Node.__services -> Node._services
-            # Maybe the same with similar attributes (__publishers, etc).
-            # Maybe have some interface to add a service/etc instead (?).
-            self._Node__services.extend(lifecycle_services)
+            # Extend base class list of services, so they are added to the executor when spinning.
+            self._services.extend(lifecycle_services)
 
     def trigger_configure(self):
         return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE)

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -376,7 +376,7 @@ class LifecycleNode(LifecycleNodeMixin, Node):
     A ROS 2 managed node.
 
     This class extends Node with the methods provided by LifecycleNodeMixin.
-    Methods in LifecycleNodeMixin overridde the ones in Node.
+    Methods in LifecycleNodeMixin override the ones in Node.
     """
 
     def __init__(self, node_name, *, enable_communication_interface: bool = True, **kwargs):

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -163,6 +163,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 lifecycle_msgs.msg.Transition.TRANSITION_INACTIVE_SHUTDOWN)
         if current_state == 'active':
             return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_ACTIVE_SHUTDOWN)
+        raise _rclpy.RCLError('Shutdown transtion not possible')
 
     def trigger_activate(self):
         return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE)

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -261,14 +261,10 @@ class LifecycleNodeMixin(ManagedEntity):
         self, current_state_id: int, previous_state: LifecycleState
     ) -> TransitionCallbackReturn:
         cb = self._callbacks.get(current_state_id, None)
-        if current_state_id == lifecycle_msgs.msg.State.TRANSITION_STATE_CONFIGURING:
-            print(f'cb: {cb}')
         if cb is None:
             return TransitionCallbackReturn.SUCCESS
         try:
             ret = cb(previous_state)
-            if current_state_id == lifecycle_msgs.msg.State.TRANSITION_STATE_CONFIGURING:
-                print(f'ret: {ret}')
             return ret
         except Exception:
             # TODO(ivanpauno): log sth here

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -346,8 +346,6 @@ class LifecycleNodeMixin(ManagedEntity):
         return cb_return_code
 
     def __check_is_initialized(self):
-        # TODO(ivanpauno): This sanity check is probably not needed, just doing the same checks as
-        # rclcpp for the moment.
         if not self._state_machine.initialized:
             raise RuntimeError(
                 'Internal error: got service request while lifecycle state machine '

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -34,4 +34,4 @@ class LifecyclePublisher(SimpleManagedEntity, Publisher):
 
         See rclpy.publisher.Publisher.publish() for more details.
         """
-        Publisher.publish(msg)
+        Publisher.publish(self, msg)

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -21,6 +21,7 @@ from .managed_entity import SimpleManagedEntity
 
 
 class LifecyclePublisher(SimpleManagedEntity, Publisher):
+    """Managed publisher entity."""
 
     def __init__(self, *args, **kwargs):
         SimpleManagedEntity.__init__(self)
@@ -28,4 +29,9 @@ class LifecyclePublisher(SimpleManagedEntity, Publisher):
 
     @SimpleManagedEntity.when_enabled
     def publish(self, msg: Union[MsgType, bytes]) -> None:
+        """
+        Publish a message if the lifecycle publisher is enabled.
+
+        See rclpy.publisher.Publisher.publish() for more details.
+        """
         Publisher.publish(msg)

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.publisher import Publisher
+from .managed_entity import SimpleManagedEntity
+
+
+class LifecyclePublisher(SimpleManagedEntity, Publisher):
+
+    def __init__(self, *args, **kwargs):
+        SimpleManagedEntity.__init__(self)
+        Publisher.__init__(self, *args, **kwargs)
+        self.publish = self.when_enabled(self.publish)

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
+from rclpy.publisher import MsgType
 from rclpy.publisher import Publisher
+
 from .managed_entity import SimpleManagedEntity
 
 
@@ -21,4 +25,7 @@ class LifecyclePublisher(SimpleManagedEntity, Publisher):
     def __init__(self, *args, **kwargs):
         SimpleManagedEntity.__init__(self)
         Publisher.__init__(self, *args, **kwargs)
-        self.publish = self.when_enabled(self.publish)
+
+    @SimpleManagedEntity.when_enabled
+    def publish(self, msg: Union[MsgType, bytes]) -> None:
+        Publisher.publish(msg)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1652,7 +1652,7 @@ class Node:
         self.destroy_timer(rate._timer)
         rate.destroy()
 
-    def destroy_node(self) -> bool:
+    def destroy_node(self):
         """
         Destroy the node.
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -22,6 +22,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import Type
 from typing import TypeVar
 from typing import Union
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1245,6 +1245,7 @@ class Node:
         callback_group: Optional[CallbackGroup] = None,
         event_callbacks: Optional[PublisherEventCallbacks] = None,
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
+        publisher_class: Type[Publisher] = Publisher,
     ) -> Publisher:
         """
         Create a new publisher.
@@ -1294,7 +1295,7 @@ class Node:
             self._validate_topic_or_service_name(topic)
 
         try:
-            publisher = Publisher(
+            publisher = publisher_class(
                 publisher_object, msg_type, topic, qos_profile,
                 event_callbacks=event_callbacks or PublisherEventCallbacks(),
                 callback_group=callback_group)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -153,12 +153,12 @@ class Node:
         self.__handle = None
         self._context = get_default_context() if context is None else context
         self._parameters: dict = {}
-        self.__publishers: List[Publisher] = []
-        self.__subscriptions: List[Subscription] = []
-        self.__clients: List[Client] = []
-        self.__services: List[Service] = []
-        self.__timers: List[Timer] = []
-        self.__guards: List[GuardCondition] = []
+        self._publishers: List[Publisher] = []
+        self._subscriptions: List[Subscription] = []
+        self._clients: List[Client] = []
+        self._services: List[Service] = []
+        self._timers: List[Timer] = []
+        self._guards: List[GuardCondition] = []
         self.__waitables: List[Waitable] = []
         self._default_callback_group = MutuallyExclusiveCallbackGroup()
         self._parameters_callbacks: List[Callable[[List[Parameter]], SetParametersResult]] = []
@@ -228,32 +228,32 @@ class Node:
     @property
     def publishers(self) -> Iterator[Publisher]:
         """Get publishers that have been created on this node."""
-        yield from self.__publishers
+        yield from self._publishers
 
     @property
     def subscriptions(self) -> Iterator[Subscription]:
         """Get subscriptions that have been created on this node."""
-        yield from self.__subscriptions
+        yield from self._subscriptions
 
     @property
     def clients(self) -> Iterator[Client]:
         """Get clients that have been created on this node."""
-        yield from self.__clients
+        yield from self._clients
 
     @property
     def services(self) -> Iterator[Service]:
         """Get services that have been created on this node."""
-        yield from self.__services
+        yield from self._services
 
     @property
     def timers(self) -> Iterator[Timer]:
         """Get timers that have been created on this node."""
-        yield from self.__timers
+        yield from self._timers
 
     @property
     def guards(self) -> Iterator[GuardCondition]:
         """Get guards that have been created on this node."""
-        yield from self.__guards
+        yield from self._guards
 
     @property
     def waitables(self) -> Iterator[Waitable]:
@@ -1303,7 +1303,7 @@ class Node:
         except Exception:
             publisher_object.destroy_when_not_in_use()
             raise
-        self.__publishers.append(publisher)
+        self._publishers.append(publisher)
         self._wake_executor()
 
         for event_callback in publisher.event_handlers:
@@ -1381,7 +1381,7 @@ class Node:
             subscription_object.destroy_when_not_in_use()
             raise
         callback_group.add_entity(subscription)
-        self.__subscriptions.append(subscription)
+        self._subscriptions.append(subscription)
         self._wake_executor()
 
         for event_handler in subscription.event_handlers:
@@ -1427,7 +1427,7 @@ class Node:
             client_impl, srv_type, srv_name, qos_profile,
             callback_group)
         callback_group.add_entity(client)
-        self.__clients.append(client)
+        self._clients.append(client)
         self._wake_executor()
         return client
 
@@ -1471,7 +1471,7 @@ class Node:
             service_impl,
             srv_type, srv_name, callback, callback_group, qos_profile)
         callback_group.add_entity(service)
-        self.__services.append(service)
+        self._services.append(service)
         self._wake_executor()
         return service
 
@@ -1502,7 +1502,7 @@ class Node:
         timer = Timer(callback, callback_group, timer_period_nsec, clock, context=self.context)
 
         callback_group.add_entity(timer)
-        self.__timers.append(timer)
+        self._timers.append(timer)
         self._wake_executor()
         return timer
 
@@ -1517,7 +1517,7 @@ class Node:
         guard = GuardCondition(callback, callback_group, context=self.context)
 
         callback_group.add_entity(guard)
-        self.__guards.append(guard)
+        self._guards.append(guard)
         self._wake_executor()
         return guard
 
@@ -1549,8 +1549,8 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        if publisher in self.__publishers:
-            self.__publishers.remove(publisher)
+        if publisher in self._publishers:
+            self._publishers.remove(publisher)
             for event_handler in publisher.event_handlers:
                 self.__waitables.remove(event_handler)
             try:
@@ -1567,8 +1567,8 @@ class Node:
 
         :return: ``True`` if succesful, ``False`` otherwise.
         """
-        if subscription in self.__subscriptions:
-            self.__subscriptions.remove(subscription)
+        if subscription in self._subscriptions:
+            self._subscriptions.remove(subscription)
             for event_handler in subscription.event_handlers:
                 self.__waitables.remove(event_handler)
             try:
@@ -1585,8 +1585,8 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        if client in self.__clients:
-            self.__clients.remove(client)
+        if client in self._clients:
+            self._clients.remove(client)
             try:
                 client.destroy()
             except InvalidHandle:
@@ -1601,8 +1601,8 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        if service in self.__services:
-            self.__services.remove(service)
+        if service in self._services:
+            self._services.remove(service)
             try:
                 service.destroy()
             except InvalidHandle:
@@ -1617,8 +1617,8 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        if timer in self.__timers:
-            self.__timers.remove(timer)
+        if timer in self._timers:
+            self._timers.remove(timer)
             try:
                 timer.destroy()
             except InvalidHandle:
@@ -1633,8 +1633,8 @@ class Node:
 
         :return: ``True`` if successful, ``False`` otherwise.
         """
-        if guard in self.__guards:
-            self.__guards.remove(guard)
+        if guard in self._guards:
+            self._guards.remove(guard)
             try:
                 guard.destroy()
             except InvalidHandle:
@@ -1672,18 +1672,18 @@ class Node:
 
         # Destroy dependent items eagerly to work around a possible hang
         # https://github.com/ros2/build_cop/issues/248
-        while self.__publishers:
-            self.destroy_publisher(self.__publishers[0])
-        while self.__subscriptions:
-            self.destroy_subscription(self.__subscriptions[0])
-        while self.__clients:
-            self.destroy_client(self.__clients[0])
-        while self.__services:
-            self.destroy_service(self.__services[0])
-        while self.__timers:
-            self.destroy_timer(self.__timers[0])
-        while self.__guards:
-            self.destroy_guard_condition(self.__guards[0])
+        while self._publishers:
+            self.destroy_publisher(self._publishers[0])
+        while self._subscriptions:
+            self.destroy_subscription(self._subscriptions[0])
+        while self._clients:
+            self.destroy_client(self._clients[0])
+        while self._services:
+            self.destroy_service(self._services[0])
+        while self._timers:
+            self.destroy_timer(self._timers[0])
+        while self._guards:
+            self.destroy_guard_condition(self._guards[0])
         self.__node.destroy_when_not_in_use()
         self._wake_executor()
 

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -29,6 +29,7 @@
 #include "exceptions.hpp"
 #include "graph.hpp"
 #include "guard_condition.hpp"
+#include "lifecycle.hpp"
 #include "logging.hpp"
 #include "logging_api.hpp"
 #include "names.hpp"
@@ -230,4 +231,5 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   rclpy::define_logging_api(m);
   rclpy::define_signal_handler_api(m);
   rclpy::define_clock_event(m);
+  rclpy::define_lifecycle_api(m);
 }

--- a/rclpy/src/rclpy/lifecycle.cpp
+++ b/rclpy/src/rclpy/lifecycle.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include <pybind11/pybind11.h>
 
 #include <lifecycle_msgs/msg/transition_event.h>
@@ -29,6 +31,7 @@
 #include "exceptions.hpp"
 #include "lifecycle.hpp"
 #include "node.hpp"
+#include "service.hpp"
 
 namespace py = pybind11;
 
@@ -58,93 +61,56 @@ public:
       throw rclpy::RCLError("Failed to create lifecycle state machine");
     }
   }
+
+  ~LifecycleStateMachine()
+  {
+    this->destroy();
+  }
   
   void init()
   {
     if (state_machine_.options.enable_com_interface) {
-      
+      srv_change_state_ = std::make_shared<rclpy::Service>(
+        node_,
+        std::shared_ptr<rcl_service_t>(
+          this->shared_from_this(), &state_machine_.com_interface.srv_change_state));
+      srv_get_state_ = std::make_shared<rclpy::Service>(
+        node_,
+        std::shared_ptr<rcl_service_t>(
+          this->shared_from_this(), &state_machine_.com_interface.srv_get_state));
+      srv_get_available_states_ = std::make_shared<rclpy::Service>(
+        node_,
+        std::shared_ptr<rcl_service_t>(
+          this->shared_from_this(), &state_machine_.com_interface.srv_get_available_states));
+      srv_get_available_transitions_ = std::make_shared<rclpy::Service>(
+        node_,
+        std::shared_ptr<rcl_service_t>(
+          this->shared_from_this(), &state_machine_.com_interface.srv_get_available_transitions));
+      srv_get_transition_graph_ = std::make_shared<rclpy::Service>(
+        node_,
+        std::shared_ptr<rcl_service_t>(
+          this->shared_from_this(), &state_machine_.com_interface.srv_get_transition_graph));
     }
-    // if (enable_com_interface) {
-    //   {
-    //     srv_change_state_ = rclpy::Service(
-    //       node,
-    //       &state_machine_.com_interface.srv_change_state);
-    //     node_services_interface_->add_service(
-    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
-    //       nullptr);
-    //   }
-
-    //   { // get_state
-    //     auto cb = std::bind(
-    //       &LifecycleNodeInterfaceImpl::on_get_state, this,
-    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-    //     rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
-    //     any_cb.set(std::move(cb));
-
-    //     srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
-    //       node_base_interface_->get_shared_rcl_node_handle(),
-    //       &state_machine_.com_interface.srv_get_state,
-    //       any_cb);
-    //     node_services_interface_->add_service(
-    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
-    //       nullptr);
-    //   }
-
-    //   { // get_available_states
-    //     auto cb = std::bind(
-    //       &LifecycleNodeInterfaceImpl::on_get_available_states, this,
-    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-    //     rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
-    //     any_cb.set(std::move(cb));
-
-    //     srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
-    //       node_base_interface_->get_shared_rcl_node_handle(),
-    //       &state_machine_.com_interface.srv_get_available_states,
-    //       any_cb);
-    //     node_services_interface_->add_service(
-    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
-    //       nullptr);
-    //   }
-
-    //   { // get_available_transitions
-    //     auto cb = std::bind(
-    //       &LifecycleNodeInterfaceImpl::on_get_available_transitions, this,
-    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-    //     rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
-    //     any_cb.set(std::move(cb));
-
-    //     srv_get_available_transitions_ =
-    //       std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
-    //       node_base_interface_->get_shared_rcl_node_handle(),
-    //       &state_machine_.com_interface.srv_get_available_transitions,
-    //       any_cb);
-    //     node_services_interface_->add_service(
-    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
-    //       nullptr);
-    //   }
-
-    //   { // get_transition_graph
-    //     auto cb = std::bind(
-    //       &LifecycleNodeInterfaceImpl::on_get_transition_graph, this,
-    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-    //     rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
-    //     any_cb.set(std::move(cb));
-
-    //     srv_get_transition_graph_ =
-    //       std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
-    //       node_base_interface_->get_shared_rcl_node_handle(),
-    //       &state_machine_.com_interface.srv_get_transition_graph,
-    //       any_cb);
-    //     node_services_interface_->add_service(
-    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
-    //       nullptr);
-    //   }
-    // }
   }
 
-  ~LifecycleStateMachine()
+  void
+  destroy() override
   {
-
+    srv_change_state_.reset();
+    srv_get_state_.reset();
+    srv_get_available_states_.reset();
+    srv_get_available_transitions_.reset();
+    srv_get_transition_graph_.reset();
+    rcl_ret_t ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_.rcl_ptr());
+    if (RCL_RET_OK != ret) {
+      // Warning should use line number of the current stack frame
+      int stack_level = 1;
+      PyErr_WarnFormat(
+        PyExc_RuntimeWarning, stack_level, "Failed to fini lifecycle state machine: %s",
+        rcl_get_error_string().str);
+      rcl_reset_error();
+    }
+    node_.destroy();
   }
 
   bool
@@ -175,6 +141,36 @@ public:
     }
   }
 
+  std::shared_ptr<rclpy::Service>
+  get_srv_change_state()
+  {
+    return srv_change_state_;
+  }
+
+  std::shared_ptr<rclpy::Service>
+  get_srv_get_state()
+  {
+    return srv_get_state_;
+  }
+
+  std::shared_ptr<rclpy::Service>
+  get_srv_get_available_states()
+  {
+    return srv_get_available_states_;
+  }
+
+  std::shared_ptr<rclpy::Service>
+  get_srv_get_available_transitions()
+  {
+    return srv_get_available_transitions_;
+  }
+
+  std::shared_ptr<rclpy::Service>
+  get_srv_get_transition_graph()
+  {
+    return srv_get_transition_graph_;
+  }
+
   void
   print()
   {
@@ -183,8 +179,21 @@ public:
 
 private:
   rclpy::Node node_;
+  std::shared_ptr<rclpy::Service> srv_change_state_;
+  std::shared_ptr<rclpy::Service> srv_get_state_;
+  std::shared_ptr<rclpy::Service> srv_get_available_states_;
+  std::shared_ptr<rclpy::Service> srv_get_available_transitions_;
+  std::shared_ptr<rclpy::Service> srv_get_transition_graph_;
   rcl_lifecycle_state_machine_t state_machine_;
 };
+
+enum class TransitionCallbackReturnType
+{
+  Success = lifecycle_msgs__msg__Transition__TRANSITION_CALLBACK_SUCCESS,
+  Failure = lifecycle_msgs__msg__Transition__TRANSITION_CALLBACK_FAILURE,
+  Error = lifecycle_msgs__msg__Transition__TRANSITION_CALLBACK_ERROR,
+};
+
 }
 
 namespace rclpy
@@ -192,5 +201,42 @@ namespace rclpy
 void
 define_lifecycle_api(py::module m)
 {
+  py::class_<LifecycleStateMachine, Destroyable, std::shared_ptr<LifecycleStateMachine>>(
+    m, "LifecycleStateMachine")
+    .def(py::init([](Node node, bool enable_com_interface)
+      {
+        auto state_machine = std::make_shared<LifecycleStateMachine>(std::move(node), enable_com_interface);
+        state_machine->init();
+        return state_machine;
+      }
+    ))
+    .def(
+      "is_initialized", &LifecycleStateMachine::is_initialized,
+      "Check if state machine is initialized.")
+    .def(
+      "trigger_transition_by_id", &LifecycleStateMachine::trigger_transition_by_id,
+      "Trigger a transition by transition id.")
+    .def(
+      "trigger_transition_by_label", &LifecycleStateMachine::trigger_transition_by_id,
+      "Trigger a transition by label.")
+    .def(
+      "get_srv_change_state", &LifecycleStateMachine::get_srv_change_state,
+      "Get the change state service.")
+    .def(
+      "get_srv_get_state", &LifecycleStateMachine::get_srv_get_state,
+      "Get the get state service.")
+    .def(
+      "get_srv_get_available_states", &LifecycleStateMachine::get_srv_get_available_states,
+      "Get the get available states service.")
+    .def(
+      "get_srv_get_available_transitions", &LifecycleStateMachine::get_srv_get_available_transitions,
+      "Get the get available transitions service.")
+    .def(
+      "get_srv_get_transition_graph", &LifecycleStateMachine::get_srv_get_transition_graph,
+      "Get the get transition graph service.");
+  py::enum_<TransitionCallbackReturnType>(m, "TransitionCallbackReturnType")
+    .value("SUCCESS", TransitionCallbackReturnType::Success)
+    .value("FAILURE", TransitionCallbackReturnType::Failure)
+    .value("ERROR", TransitionCallbackReturnType::Error);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/lifecycle.cpp
+++ b/rclpy/src/rclpy/lifecycle.cpp
@@ -345,9 +345,15 @@ define_lifecycle_api(py::module m)
     "service_get_transition_graph", &LifecycleStateMachine::get_srv_get_transition_graph,
     "Get the get transition graph service.");
   py::enum_<TransitionCallbackReturnType>(m, "TransitionCallbackReturnType")
-  .value("SUCCESS", TransitionCallbackReturnType::Success)
-  .value("FAILURE", TransitionCallbackReturnType::Failure)
-  .value("ERROR", TransitionCallbackReturnType::Error)
+  .value(
+    "SUCCESS", TransitionCallbackReturnType::Success,
+    "Callback succeeded.")
+  .value(
+    "FAILURE", TransitionCallbackReturnType::Failure,
+    "Callback failed.")
+  .value(
+    "ERROR", TransitionCallbackReturnType::Error,
+    "Callback had an error.")
   .def(
     "to_label", &convert_callback_ret_code_to_label,
     "Convert the transition callback return code to a transition label");

--- a/rclpy/src/rclpy/lifecycle.cpp
+++ b/rclpy/src/rclpy/lifecycle.cpp
@@ -1,0 +1,196 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include <lifecycle_msgs/msg/transition_event.h>
+#include <lifecycle_msgs/srv/change_state.h>
+#include <lifecycle_msgs/srv/get_state.h>
+#include <lifecycle_msgs/srv/get_available_states.h>
+#include <lifecycle_msgs/srv/get_available_transitions.h>
+
+#include <rcl_lifecycle/rcl_lifecycle.h>
+
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#include <rosidl_runtime_c/service_type_support_struct.h>
+
+#include "destroyable.hpp"
+#include "exceptions.hpp"
+#include "lifecycle.hpp"
+#include "node.hpp"
+
+namespace py = pybind11;
+
+namespace
+{
+class LifecycleStateMachine : public rclpy::Destroyable, public std::enable_shared_from_this<LifecycleStateMachine>
+{
+public:
+  LifecycleStateMachine(
+    rclpy::Node node, bool enable_com_interface)
+  : node_(std::move(node))
+  {
+    state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
+    auto state_machine_options = rcl_lifecycle_get_default_state_machine_options();
+    state_machine_options.enable_com_interface = enable_com_interface;
+    rcl_ret_t ret = rcl_lifecycle_state_machine_init(
+      &state_machine_,
+      node_.rcl_ptr(),
+      ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent),
+      ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, ChangeState),
+      ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetState),
+      ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetAvailableStates),
+      ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetAvailableTransitions),
+      ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetAvailableTransitions),
+      &state_machine_options);
+    if (RCL_RET_OK != ret) {
+      throw rclpy::RCLError("Failed to create lifecycle state machine");
+    }
+  }
+  
+  void init()
+  {
+    if (state_machine_.options.enable_com_interface) {
+      
+    }
+    // if (enable_com_interface) {
+    //   {
+    //     srv_change_state_ = rclpy::Service(
+    //       node,
+    //       &state_machine_.com_interface.srv_change_state);
+    //     node_services_interface_->add_service(
+    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
+    //       nullptr);
+    //   }
+
+    //   { // get_state
+    //     auto cb = std::bind(
+    //       &LifecycleNodeInterfaceImpl::on_get_state, this,
+    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    //     rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
+    //     any_cb.set(std::move(cb));
+
+    //     srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
+    //       node_base_interface_->get_shared_rcl_node_handle(),
+    //       &state_machine_.com_interface.srv_get_state,
+    //       any_cb);
+    //     node_services_interface_->add_service(
+    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
+    //       nullptr);
+    //   }
+
+    //   { // get_available_states
+    //     auto cb = std::bind(
+    //       &LifecycleNodeInterfaceImpl::on_get_available_states, this,
+    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    //     rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
+    //     any_cb.set(std::move(cb));
+
+    //     srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
+    //       node_base_interface_->get_shared_rcl_node_handle(),
+    //       &state_machine_.com_interface.srv_get_available_states,
+    //       any_cb);
+    //     node_services_interface_->add_service(
+    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
+    //       nullptr);
+    //   }
+
+    //   { // get_available_transitions
+    //     auto cb = std::bind(
+    //       &LifecycleNodeInterfaceImpl::on_get_available_transitions, this,
+    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    //     rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+    //     any_cb.set(std::move(cb));
+
+    //     srv_get_available_transitions_ =
+    //       std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+    //       node_base_interface_->get_shared_rcl_node_handle(),
+    //       &state_machine_.com_interface.srv_get_available_transitions,
+    //       any_cb);
+    //     node_services_interface_->add_service(
+    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
+    //       nullptr);
+    //   }
+
+    //   { // get_transition_graph
+    //     auto cb = std::bind(
+    //       &LifecycleNodeInterfaceImpl::on_get_transition_graph, this,
+    //       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+    //     rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+    //     any_cb.set(std::move(cb));
+
+    //     srv_get_transition_graph_ =
+    //       std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+    //       node_base_interface_->get_shared_rcl_node_handle(),
+    //       &state_machine_.com_interface.srv_get_transition_graph,
+    //       any_cb);
+    //     node_services_interface_->add_service(
+    //       std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
+    //       nullptr);
+    //   }
+    // }
+  }
+
+  ~LifecycleStateMachine()
+  {
+
+  }
+
+  bool
+  is_initialized()
+  {
+    return RCL_RET_OK == rcl_lifecycle_state_machine_is_initialized(&state_machine_);
+  }
+
+  void
+  trigger_transition_by_id(uint8_t transition_id, bool publish_update)
+  {
+    if (
+      rcl_lifecycle_trigger_transition_by_id(
+        &state_machine_, transition_id, publish_update) != RCL_RET_OK)
+    {
+      throw rclpy::RCLError("Failed to trigger lifecycle state machine transition");;
+    }
+  }
+
+  void
+  trigger_transition_by_label(std::string label, bool publish_update)
+  {
+    if (
+      rcl_lifecycle_trigger_transition_by_label(
+        &state_machine_, label.c_str(), publish_update) != RCL_RET_OK)
+    {
+      throw rclpy::RCLError("Failed to trigger lifecycle state machine transition");;
+    }
+  }
+
+  void
+  print()
+  {
+    rcl_print_state_machine(&state_machine_);
+  }
+
+private:
+  rclpy::Node node_;
+  rcl_lifecycle_state_machine_t state_machine_;
+};
+}
+
+namespace rclpy
+{
+void
+define_lifecycle_api(py::module m)
+{
+}
+}  // namespace rclpy

--- a/rclpy/src/rclpy/lifecycle.hpp
+++ b/rclpy/src/rclpy/lifecycle.hpp
@@ -1,0 +1,31 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__LIFECYCLE_API_HPP_
+#define RCLPY__LIFECYCLE_API_HPP_
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace rclpy
+{
+/// Define methods on a module for the lifecycle API
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ */
+void
+define_lifecycle_api(py::module module);
+}  // namespace rclpy
+#endif  // RCLPY__LIFECYCLE_API_HPP_

--- a/rclpy/src/rclpy/lifecycle.hpp
+++ b/rclpy/src/rclpy/lifecycle.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCLPY__LIFECYCLE_API_HPP_
-#define RCLPY__LIFECYCLE_API_HPP_
+#ifndef RCLPY__LIFECYCLE_HPP_
+#define RCLPY__LIFECYCLE_HPP_
 
 #include <pybind11/pybind11.h>
 
@@ -28,4 +28,4 @@ namespace rclpy
 void
 define_lifecycle_api(py::module module);
 }  // namespace rclpy
-#endif  // RCLPY__LIFECYCLE_API_HPP_
+#endif  // RCLPY__LIFECYCLE_HPP_

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -34,9 +34,9 @@ Service::destroy()
 }
 
 Service::Service(
-  Node & node, py::object pysrv_type, std::string service_name,
+  Node node, py::object pysrv_type, std::string service_name,
   py::object pyqos_profile)
-: node_(node)
+: node_(std::move(node))
 {
   auto srv_type = static_cast<rosidl_service_type_support_t *>(
     common_get_type_support(pysrv_type));
@@ -86,6 +86,11 @@ Service::Service(
   }
 }
 
+Service::Service(
+  Node node, std::shared_ptr<rcl_service_t> rcl_service)
+: node_(std::move(node)), rcl_service_(rcl_service)
+{}
+
 void
 Service::service_send_response(py::object pyresponse, rmw_request_id_t * header)
 {
@@ -126,7 +131,7 @@ void
 define_service(py::object module)
 {
   py::class_<Service, Destroyable, std::shared_ptr<Service>>(module, "Service")
-  .def(py::init<Node &, py::object, std::string, py::object>())
+  .def(py::init<Node, py::object, std::string, py::object>())
   .def_property_readonly(
     "pointer", [](const Service & service) {
       return reinterpret_cast<size_t>(service.rcl_ptr());

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -22,6 +22,7 @@
 
 #include "exceptions.hpp"
 #include "service.hpp"
+#include "utils.hpp"
 
 namespace rclpy
 {
@@ -109,7 +110,6 @@ py::tuple
 Service::service_take_request(py::object pyrequest_type)
 {
   auto taken_request = create_from_py(pyrequest_type);
-
   rmw_service_info_t header;
 
   py::tuple result_tuple(2);
@@ -127,6 +127,20 @@ Service::service_take_request(py::object pyrequest_type)
 
   return result_tuple;
 }
+
+const char *
+Service::get_service_name()
+{
+  return rcl_service_get_service_name(rcl_service_.get());
+}
+
+py::dict
+Service::get_qos_profile()
+{
+  const auto * options = rcl_service_get_options(rcl_service_.get());
+  return rclpy::convert_to_qos_dict(&options->qos);
+}
+
 void
 define_service(py::object module)
 {
@@ -137,6 +151,12 @@ define_service(py::object module)
       return reinterpret_cast<size_t>(service.rcl_ptr());
     },
     "Get the address of the entity as an integer")
+  .def_property_readonly(
+    "name", &Service::get_service_name,
+    "Get the name of the service")
+  .def_property_readonly(
+    "qos", &Service::get_qos_profile,
+    "Get the qos profile of the service")
   .def(
     "service_send_response", &Service::service_send_response,
     "Send a response")

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -34,9 +34,9 @@ Service::destroy()
 }
 
 Service::Service(
-  Node node, py::object pysrv_type, std::string service_name,
+  Node & node, py::object pysrv_type, std::string service_name,
   py::object pyqos_profile)
-: node_(std::move(node))
+: node_(node)
 {
   auto srv_type = static_cast<rosidl_service_type_support_t *>(
     common_get_type_support(pysrv_type));
@@ -87,8 +87,8 @@ Service::Service(
 }
 
 Service::Service(
-  Node node, std::shared_ptr<rcl_service_t> rcl_service)
-: node_(std::move(node)), rcl_service_(rcl_service)
+  Node & node, std::shared_ptr<rcl_service_t> rcl_service)
+: node_(node), rcl_service_(rcl_service)
 {}
 
 void
@@ -131,7 +131,7 @@ void
 define_service(py::object module)
 {
   py::class_<Service, Destroyable, std::shared_ptr<Service>>(module, "Service")
-  .def(py::init<Node, py::object, std::string, py::object>())
+  .def(py::init<Node &, py::object, std::string, py::object>())
   .def_property_readonly(
     "pointer", [](const Service & service) {
       return reinterpret_cast<size_t>(service.rcl_ptr());

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -52,11 +52,11 @@ public:
    * \return capsule containing the rcl_service_t
    */
   Service(
-    Node node, py::object pysrv_type, std::string service_name,
+    Node & node, py::object pysrv_type, std::string service_name,
     py::object pyqos_profile);
 
   Service(
-    Node node, std::shared_ptr<rcl_service_t> rcl_service);
+    Node & node, std::shared_ptr<rcl_service_t> rcl_service);
 
   ~Service() = default;
 

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -91,6 +91,12 @@ public:
     return rcl_service_.get();
   }
 
+  const char *
+  get_service_name();
+
+  py::dict
+  get_qos_profile();
+
   /// Force an early destruction of this object
   void
   destroy() override;

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -52,8 +52,11 @@ public:
    * \return capsule containing the rcl_service_t
    */
   Service(
-    Node & node, py::object pysrv_type, std::string service_name,
+    Node node, py::object pysrv_type, std::string service_name,
     py::object pyqos_profile);
+
+  Service(
+    Node node, std::shared_ptr<rcl_service_t> rcl_service);
 
   ~Service() = default;
 

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -15,7 +15,9 @@
 import pytest
 
 import rclpy
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.lifecycle import LifecycleNode
+from rclpy.lifecycle import TransitionCallbackReturn
 
 
 def test_lifecycle_node_init():
@@ -40,6 +42,43 @@ def test_lifecycle_node_init():
     node.destroy_node()
     with pytest.raises(TypeError):
         LifecycleNode('test_lifecycle_node_init_3', enable_communication_interface='asd')
+
+
+def test_lifecycle_state_transitions():
+    node = LifecycleNode('test_lifecycle_state_transitions_1', enable_communication_interface=False)
+    # normal transitions
+    assert node.trigger_configure() == TransitionCallbackReturn.SUCCESS
+    assert node.trigger_activate() == TransitionCallbackReturn.SUCCESS
+    assert node.trigger_deactivate() == TransitionCallbackReturn.SUCCESS
+    assert node.trigger_cleanup() == TransitionCallbackReturn.SUCCESS
+    # some that are not possible from the current state
+    with pytest.raises(_rclpy.RCLError):
+        node.trigger_activate()
+    with pytest.raises(_rclpy.RCLError):
+        node.trigger_deactivate()
+    assert node.trigger_shutdown() == TransitionCallbackReturn.SUCCESS
+    node.destroy_node()
+
+    class ErrorOnConfigureHandledCorrectlyNode(LifecycleNode):
+        on_configure = lambda: TransitionCallbackReturn.ERROR
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    node = ErrorOnConfigureHandledCorrectlyNode('test_lifecycle_state_transitions_2', enable_communication_interface=False)
+    assert node.trigger_configure() == TransitionCallbackReturn.ERROR
+    assert node._state_machine.current_state[1] == 'unconfigured'
+
+    class ErrorOnConfigureHandledInCorrectlyNode(LifecycleNode):
+        on_configure = lambda: TransitionCallbackReturn.ERROR
+        on_error = lambda: TransitionCallbackReturn.FAILURE
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    node = ErrorOnConfigureHandledInCorrectlyNode('test_lifecycle_state_transitions_3', enable_communication_interface=False)
+    assert node.trigger_configure() == TransitionCallbackReturn.ERROR
+    assert node._state_machine.current_state[1] == 'finalized'
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -12,14 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import rclpy
 from rclpy.lifecycle import LifecycleNode
 
 
 def test_lifecycle_node_init():
     rclpy.init()
-    node = LifecycleNode('my_lifecycle_node')
+    node = LifecycleNode('test_lifecycle_node_init_1')
     assert node
+    node.destroy_node()
+    node = LifecycleNode('test_lifecycle_node_init_2', enable_communication_interface=False)
+    assert node
+    # Make sure services were not created
+    assert not hasattr(node, '_service_change_state')
+    assert not hasattr(node, '_service_get_state')
+    assert not hasattr(node, '_service_get_available_states')
+    assert not hasattr(node, '_service_get_available_transitions')
+    assert not hasattr(node, '_service_get_transition_graph')
+    # Make sure also that the services were not created in the pybind11 plugin
+    assert not node._state_machine.service_change_state
+    assert not node._state_machine.service_get_state
+    assert not node._state_machine.service_get_available_states
+    assert not node._state_machine.service_get_available_transitions
+    assert not node._state_machine.service_get_transition_graph
+    node.destroy_node()
+    with pytest.raises(TypeError):
+        LifecycleNode('test_lifecycle_node_init_3', enable_communication_interface='asd')
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from unittest import mock
+
+import pytest
 
 import rclpy
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
@@ -49,7 +50,8 @@ def test_lifecycle_node_init():
 
 
 def test_lifecycle_state_transitions():
-    node = LifecycleNode('test_lifecycle_state_transitions_1', enable_communication_interface=False)
+    node = LifecycleNode(
+        'test_lifecycle_state_transitions_1', enable_communication_interface=False)
     # normal transitions
     assert node.trigger_configure() == TransitionCallbackReturn.SUCCESS
     assert node.trigger_activate() == TransitionCallbackReturn.SUCCESS
@@ -64,27 +66,36 @@ def test_lifecycle_state_transitions():
     node.destroy_node()
 
     class ErrorOnConfigureHandledCorrectlyNode(LifecycleNode):
-        on_configure = lambda: TransitionCallbackReturn.ERROR
+
+        def on_configure(self):
+            return TransitionCallbackReturn.ERROR
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
-    node = ErrorOnConfigureHandledCorrectlyNode('test_lifecycle_state_transitions_2', enable_communication_interface=False)
+    node = ErrorOnConfigureHandledCorrectlyNode(
+        'test_lifecycle_state_transitions_2', enable_communication_interface=False)
     assert node.trigger_configure() == TransitionCallbackReturn.ERROR
     assert node._state_machine.current_state[1] == 'unconfigured'
 
     class ErrorOnConfigureHandledInCorrectlyNode(LifecycleNode):
-        on_configure = lambda: TransitionCallbackReturn.ERROR
-        on_error = lambda: TransitionCallbackReturn.FAILURE
+
+        def on_configure(self):
+            return TransitionCallbackReturn.ERROR
+
+        def on_error(self):
+            return TransitionCallbackReturn.ERROR
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
-    node = ErrorOnConfigureHandledInCorrectlyNode('test_lifecycle_state_transitions_3', enable_communication_interface=False)
+    node = ErrorOnConfigureHandledInCorrectlyNode(
+        'test_lifecycle_state_transitions_3', enable_communication_interface=False)
     assert node.trigger_configure() == TransitionCallbackReturn.ERROR
     assert node._state_machine.current_state[1] == 'finalized'
 
 # TODO(ivanpauno): Add automated tests for lifecycle services!!
+
 
 def test_lifecycle_publisher():
     node = LifecycleNode('test_lifecycle_publisher', enable_communication_interface=False)

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.lifecycle import LifecycleNode
+
+
+def test_lifecycle_node_init():
+    rclpy.init()
+    node = LifecycleNode('my_lifecycle_node')

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -60,8 +60,13 @@ def test_lifecycle_state_transitions():
         'test_lifecycle_state_transitions_1', enable_communication_interface=False)
     # normal transitions
     assert node.trigger_configure() == TransitionCallbackReturn.SUCCESS
-    assert node.trigger_activate() == TransitionCallbackReturn.SUCCESS
-    assert node.trigger_deactivate() == TransitionCallbackReturn.SUCCESS
+    # test many times back to back, to make sure it works robustly
+    for _ in range(10):
+        assert node.trigger_cleanup() == TransitionCallbackReturn.SUCCESS
+        assert node.trigger_configure() == TransitionCallbackReturn.SUCCESS
+    for _ in range(10):
+        assert node.trigger_activate() == TransitionCallbackReturn.SUCCESS
+        assert node.trigger_deactivate() == TransitionCallbackReturn.SUCCESS
     assert node.trigger_cleanup() == TransitionCallbackReturn.SUCCESS
     # some that are not possible from the current state
     with pytest.raises(_rclpy.RCLError):

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -184,11 +184,3 @@ def test_lifecycle_publisher():
         pub.publish(msg)
         mock_publish.assert_called()
         mock_publish.assert_called_with(pub, msg)
-
-
-# TODO(ivanpauno): DELETE THIS BEFORE MERGING
-# CREATE A lifecycle_py demo
-if __name__ == '__main__':
-    rclpy.init()
-    node = LifecycleNode('my_lifecycle_node')
-    rclpy.spin(node)

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -19,6 +19,7 @@ from rclpy.lifecycle import LifecycleNode
 def test_lifecycle_node_init():
     rclpy.init()
     node = LifecycleNode('my_lifecycle_node')
+    assert node
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -69,7 +69,19 @@ def test_lifecycle_state_transitions():
     with pytest.raises(_rclpy.RCLError):
         node.trigger_deactivate()
     assert node.trigger_shutdown() == TransitionCallbackReturn.SUCCESS
+    with pytest.raises(_rclpy.RCLError):
+        node.trigger_shutdown()
     node.destroy_node()
+    # Again but trigger shutdown from 'inactive' instead of 'unconfigured'
+    node = LifecycleNode(
+        'test_lifecycle_state_transitions_2', enable_communication_interface=False)
+    assert node.trigger_shutdown() == TransitionCallbackReturn.SUCCESS
+    # Again but trigger shutdown from 'active'
+    node = LifecycleNode(
+        'test_lifecycle_state_transitions_3', enable_communication_interface=False)
+    assert node.trigger_configure() == TransitionCallbackReturn.SUCCESS
+    assert node.trigger_activate() == TransitionCallbackReturn.SUCCESS
+    assert node.trigger_shutdown() == TransitionCallbackReturn.SUCCESS
 
     class ErrorOnConfigureHandledCorrectlyNode(LifecycleNode):
 

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -19,3 +19,9 @@ from rclpy.lifecycle import LifecycleNode
 def test_lifecycle_node_init():
     rclpy.init()
     node = LifecycleNode('my_lifecycle_node')
+
+
+if __name__ == '__main__':
+    rclpy.init()
+    node = LifecycleNode('my_lifecycle_node')
+    rclpy.spin(node)

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -75,6 +75,7 @@ def test_lifecycle_state_transitions():
 
     node = ErrorOnConfigureHandledCorrectlyNode(
         'test_lifecycle_state_transitions_2', enable_communication_interface=False)
+    assert node._state_machine.current_state[1] == 'unconfigured'
     assert node.trigger_configure() == TransitionCallbackReturn.ERROR
     assert node._state_machine.current_state[1] == 'unconfigured'
 


### PR DESCRIPTION
Fixes https://github.com/ros2/rclpy/issues/604.

I took into account the feedback provided here https://github.com/ros2/rclcpp/issues/1846, so you don't need to manually call on_activate/on_deactivate for managed entities like `LifecyclePublisher`.
I'm open to revert that bit, though I think it's a good idea.

~I have only manually tested that the lifecycle node services work correctly.
I have not tested the lifecycle publisher at all.~
This PR has tests now.
~I could write some automated tests for the lifecycle builtin services though.~
Done as well.

~This is not ready to be merged, though early feedback is appreciated anyway.~
This is ready now.

~I'm working to add a demo equivalent to [demos/lifecycle](https://github.com/ros2/demos/tree/master/lifecycle), but that shouldn't block this from being reviewed.~
PR with demo ready: https://github.com/ros2/demos/pull/547.