### PR TITLE
Make rclpy.try_shutdown() behavior to follow rclpy.shutdown() more closely

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -54,7 +54,7 @@ from rclpy.utilities import get_default_context
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa: F401
 from rclpy.utilities import ok  # noqa: F401 forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
-from rclpy.utilities import try_shutdown as _try_shutdown
+from rclpy.utilities import try_shutdown  # noqa: F401
 
 # Avoid loading extensions on module import
 if TYPE_CHECKING:
@@ -100,6 +100,13 @@ def get_global_executor() -> 'Executor':
         # imported locally to avoid loading extensions on module import
         from rclpy.executors import SingleThreadedExecutor
         __executor = SingleThreadedExecutor()
+        context = get_default_context()
+
+        def reset_executor():
+            global __executor
+            __executor.shutdown()
+            __executor = None
+        context.on_shutdown(reset_executor)
     return __executor
 
 
@@ -116,10 +123,6 @@ def shutdown(*, context: Context = None, uninstall_handlers: Optional[bool] = No
         If `True`, signal handlers will be uninstalled.
         If not, signal handlers won't be uninstalled.
     """
-    global __executor
-    if __executor is not None:
-        __executor.shutdown()
-        __executor = None
     _shutdown(context=context)
     if (
         uninstall_handlers or (
@@ -127,23 +130,6 @@ def shutdown(*, context: Context = None, uninstall_handlers: Optional[bool] = No
                 context is None or context is get_default_context()))
     ):
         uninstall_signal_handlers()
-
-
-def try_shutdown(*, context: Context = None) -> None:
-    """
-    Try shutting down a previously initialized context.
-
-    This will also shutdown the global executor if the context was successfuly shutdown.
-
-    :param context: The context to invalidate. If ``None``, then the default context is used
-        (see :func:`.get_default_context`).
-    """
-    global __executor
-    _try_shutdown(context=context)
-    if not ok():
-        if __executor is not None:
-            __executor.shutdown()
-            __executor = None
 
 
 def create_node(

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -54,7 +54,7 @@ from rclpy.utilities import get_default_context
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa: F401
 from rclpy.utilities import ok  # noqa: F401 forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
-from rclpy.utilities import try_shutdown  # noqa: F401
+from rclpy.utilities import try_shutdown as _try_shutdown
 
 # Avoid loading extensions on module import
 if TYPE_CHECKING:
@@ -127,6 +127,23 @@ def shutdown(*, context: Context = None, uninstall_handlers: Optional[bool] = No
                 context is None or context is get_default_context()))
     ):
         uninstall_signal_handlers()
+
+
+def try_shutdown(*, context: Context = None) -> None:
+    """
+    Try shutting down a previously initialized context.
+
+    This will also shutdown the global executor if the context was successfuly shutdown.
+
+    :param context: The context to invalidate. If ``None``, then the default context is used
+        (see :func:`.get_default_context`).
+    """
+    global __executor
+    _try_shutdown(context=context)
+    if not ok():
+        if __executor is not None:
+            __executor.shutdown()
+            __executor = None
 
 
 def create_node(

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -127,7 +127,7 @@ class Context:
                 if ismethod(callback):
                     self._callbacks.append(weakref.WeakMethod(callback, self._remove_callback))
                 else:
-                    self._callbacks.append(weakref.ref(callback, self._remove_callback))
+                    self._callbacks.append(callback)
 
     def _logging_fini(self):
         # This function must be called with self._lock held.

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -60,9 +60,19 @@ def shutdown(*, context=None):
 
 def try_shutdown(*, context=None):
     """Shutdown rclpy if not already shutdown."""
+    global g_context_lock
+    global g_default_context
     if context is None:
-        context = get_default_context()
-    return context.try_shutdown()
+        # Replace the default context with a new one if shutdown was successful
+        # or if the context was already shutdown.
+        with g_context_lock:
+            if g_default_context is None:
+                g_default_context = Context()
+            g_default_context.try_shutdown()
+            if not g_default_context.ok():
+                g_default_context = None
+    else:
+        return context.try_shutdown()
 
 
 def get_rmw_implementation_identifier():


### PR DESCRIPTION
Needed by https://github.com/ros2/ros2cli/pull/683.

I'm not sure if this is the ideal approach, maybe init()/shutdown() are doing too much (?).
I'm open to alternatives.