### PR TITLE
Document that Future.result() may return None

### DIFF
--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -88,7 +88,7 @@ class Future:
 
         :raises: Exception if one was set during the task.
 
-        :return: The result set by the task
+        :return: The result set by the task, or None if no result was set.
         """
         if self._exception:
             raise self.exception()


### PR DESCRIPTION
I noticed this can happen when a service client does not receive a response from a server and the client times out.

Loosely related to https://github.com/ros2/rclpy/issues/367.