### PR TITLE
Remove -> bool annotation for destroy_node #886

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1650,7 +1650,7 @@ class Node:
         self.destroy_timer(rate._timer)
         rate.destroy()
 
-    def destroy_node(self) -> bool:
+    def destroy_node(self):
         """
         Destroy the node.
 


### PR DESCRIPTION
Remove -> bool annotation for destroy_node as mentioned in [issue #886](https://github.com/ros2/rclpy/issues/886).