### PR TITLE
Remove fastrtps customization on tests

### DIFF
--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -31,9 +31,7 @@ from rclpy.qos_event import QoSRequestedDeadlineMissedInfo
 from rclpy.qos_event import QoSRequestedIncompatibleQoSInfo
 from rclpy.qos_event import QoSSubscriptionEventType
 from rclpy.qos_event import SubscriptionEventCallbacks
-from rclpy.qos_event import UnsupportedEventTypeError
 from rclpy.task import Future
-from rclpy.utilities import get_rmw_implementation_identifier
 
 from test_msgs.msg import Empty as EmptyMsg
 


### PR DESCRIPTION
This PR removes the custom code paths that were checking `rmw_get_implementation_identifier()` on events-related tests.

Connected to ros2/rmw_fastrtps#583 