### PR TITLE
Avoid exception in Node constructor when use override for 'use_sim_time'

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -207,11 +207,7 @@ class Node:
             self._parameter_overrides.update({p.name: p for p in parameter_overrides})
 
         # Clock that has support for ROS time.
-        # Note: parameter overrides and parameter event publisher need to be ready at this point
-        # to be able to declare 'use_sim_time' if it was not declared yet.
         self._clock = ROSClock()
-        self._time_source = TimeSource(node=self)
-        self._time_source.attach_clock(self._clock)
 
         if automatically_declare_parameters_from_overrides:
             self.declare_parameters(
@@ -221,6 +217,12 @@ class Node:
                     for name, param in self._parameter_overrides.items()],
                 ignore_override=True,
             )
+
+        # Init a time source.
+        # Note: parameter overrides and parameter event publisher need to be ready at this point
+        # to be able to declare 'use_sim_time' if it was not declared yet.
+        self._time_source = TimeSource(node=self)
+        self._time_source.attach_clock(self._clock)
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)

--- a/rclpy/test/test_create_node.py
+++ b/rclpy/test/test_create_node.py
@@ -82,5 +82,6 @@ class TestCreateNode(unittest.TestCase):
             ]
         ).destroy_node()
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_create_node.py
+++ b/rclpy/test/test_create_node.py
@@ -18,6 +18,7 @@ import rclpy
 
 from rclpy.exceptions import InvalidNamespaceException
 from rclpy.exceptions import InvalidNodeNameException
+from rclpy.parameter import Parameter
 
 
 class TestCreateNode(unittest.TestCase):
@@ -71,6 +72,15 @@ class TestCreateNode(unittest.TestCase):
         with self.assertRaisesRegex(InvalidNamespaceException, 'must not contain characters'):
             rclpy.create_node(node_name, namespace=namespace, context=self.context)
 
+    def test_create_node_with_parameter_overrides(self):
+        node_name = 'create_node_with_parameter_overrides_test'
+        rclpy.create_node(
+            node_name, context=self.context,
+            automatically_declare_parameters_from_overrides=True,
+            parameter_overrides=[
+                Parameter('use_sim_time', Parameter.Type.BOOL, True)
+            ]
+        ).destroy_node()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow to create a Node with 'use_sim_time' parameter in parameter overrides.
Avoid exception `
rclpy.exceptions.ParameterAlreadyDeclaredException: ('Parameter(s) already declared', ['use_sim_time'])
`