### PR TITLE
Make sure to take out contexts on Action{Client,Server}.

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -351,6 +351,19 @@ class ActionClient(Waitable):
     def add_to_wait_set(self, wait_set):
         """Add entities to wait set."""
         self._client_handle.add_to_waitset(wait_set)
+
+    def __enter__(self):
+        if self._client_handle is None:
+            return None
+
+        return self._client_handle.__enter__()
+
+    def __exit__(self, t, v, tb):
+        if self._client_handle is None:
+            return
+
+        self._client_handle.__exit__(t, v, tb)
+
     # End Waitable API
 
     def send_goal(self, goal, **kwargs):

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -493,6 +493,19 @@ class ActionServer(Waitable):
         """Add entities to wait set."""
         with self._lock:
             self._handle.add_to_waitset(wait_set)
+
+    def __enter__(self):
+        if self._handle is None:
+            return None
+
+        return self._handle.__enter__()
+
+    def __exit__(self, t, v, tb):
+        if self._handle is None:
+            return
+
+        self._handle.__exit__(t, v, tb)
+
     # End Waitable API
 
     def notify_execute(self, goal_handle, execute_callback):


### PR DESCRIPTION
This ensures that the underlying object won't be freed when
e.g. a WaitSet is still using it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should solve https://github.com/ros2/geometry2/issues/503 .  Still in draft because @sloretz and I are still working out some of the details.