### PR TITLE
Properly implement action server/client handle cleanup.

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -583,6 +583,5 @@ class ActionClient(Waitable):
 
     def destroy(self):
         """Destroy the underlying action client handle."""
-        with self._node.handle:
-            self._client_handle.destroy_when_not_in_use()
+        self._client_handle.destroy_when_not_in_use()
         self._node.remove_waitable(self)

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -353,15 +353,9 @@ class ActionClient(Waitable):
         self._client_handle.add_to_waitset(wait_set)
 
     def __enter__(self):
-        if self._client_handle is None:
-            return None
-
         return self._client_handle.__enter__()
 
     def __exit__(self, t, v, tb):
-        if self._client_handle is None:
-            return
-
         self._client_handle.__exit__(t, v, tb)
 
     # End Waitable API
@@ -589,13 +583,6 @@ class ActionClient(Waitable):
 
     def destroy(self):
         """Destroy the underlying action client handle."""
-        if self._client_handle is None:
-            return
         with self._node.handle:
             self._client_handle.destroy_when_not_in_use()
-            self._node.remove_waitable(self)
-        self._client_handle = None
-
-    def __del__(self):
-        """Destroy the underlying action client handle."""
-        self.destroy()
+        self._node.remove_waitable(self)

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -495,15 +495,9 @@ class ActionServer(Waitable):
             self._handle.add_to_waitset(wait_set)
 
     def __enter__(self):
-        if self._handle is None:
-            return None
-
         return self._handle.__enter__()
 
     def __exit__(self, t, v, tb):
-        if self._handle is None:
-            return
-
         self._handle.__exit__(t, v, tb)
 
     # End Waitable API
@@ -602,16 +596,8 @@ class ActionServer(Waitable):
 
     def destroy(self):
         """Destroy the underlying action server handle."""
-        if self._handle is None:
-            return
-
         for goal_handle in self._goal_handles.values():
             goal_handle.destroy()
 
         self._handle.destroy_when_not_in_use()
         self._node.remove_waitable(self)
-        self._handle = None
-
-    def __del__(self):
-        """Destroy the underlying action server handle."""
-        self.destroy()


### PR DESCRIPTION
In particular, it should never really be the case that the
underlying handle that we are using is None.  That only seemed
to be happening because we were double destroying; once in
the explicit call to destroy(), and once in __del__.  But
we don't actually need __del__; during garbage collection, we'll
drop the reference to the handle and then the underlying object
will get freed anyway.  Just remove all of that extraneous
infrastructure here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Besides being a lot cleaner, this is also likely responsible for warnings during tests on the buildfarm like:

```
04:24:41.497 144: [test_action_client-3] Exception ignored in: <function ActionClient.__del__ at 0x00000245450633A0>
04:24:41.497 144: [test_action_client-3] Traceback (most recent call last):
04:24:41.497 144: [test_action_client-3]   File "C:\ci\ws\install\Lib\site-packages\rclpy\action\client.py", line 588, in __del__
04:24:41.498 144: [test_action_client-3]   File "C:\ci\ws\install\Lib\site-packages\rclpy\action\client.py", line 581, in destroy
04:24:41.498 144: [test_action_client-3] rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
```

(we'll carefully check the results of CI to make sure that this is gone with this fix)