### PR TITLE
Make rclpy dependencies explicit

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
+find_package(rosidl_runtime_c REQUIRED)
 
 # Find python before pybind11
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
@@ -113,6 +114,7 @@ target_link_libraries(_rclpy_pybind11 PRIVATE
   rcl_logging_interface::rcl_logging_interface
   rcpputils::rcpputils
   rcutils::rcutils
+  rosidl_runtime_c::rosidl_runtime_c
 )
 configure_build_install_location(_rclpy_pybind11)
 

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -23,12 +23,14 @@
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
 
-  <depend>rmw_implementation</depend>
   <depend>rcl</depend>
   <depend>rcl_lifecycle</depend>
   <depend>rcl_logging_interface</depend>
   <depend>rcl_action</depend>
   <depend>rcl_yaml_param_parser</depend>
+  <depend>rmw</depend>
+  <depend>rmw_implementation</depend>
+  <depend>rosidl_runtime_c</depend>
   <depend>unique_identifier_msgs</depend>
 
   <exec_depend>ament_index_python</exec_depend>

--- a/rclpy/src/rclpy/_rclpy_logging.cpp
+++ b/rclpy/src/rclpy/_rclpy_logging.cpp
@@ -139,8 +139,8 @@ rclpy_logging_rcutils_log(
  * Raises ValueError if log level is not a string.
  *
  * \param[in] log_level Name of the log level.
- * \return NULL on failure
-           Log level associated with the string representation
+ * \return NULL on failure,
+ * \return Log level associated with the string representation otherwise.
  */
 int
 rclpy_logging_severity_level_from_string(const char * log_level)

--- a/rclpy/src/rclpy/_rclpy_logging.cpp
+++ b/rclpy/src/rclpy/_rclpy_logging.cpp
@@ -19,10 +19,10 @@ namespace py = pybind11;
 #include <rcutils/allocator.h>
 #include <rcutils/error_handling.h>
 #include <rcutils/logging.h>
-#include <rcutils/time.h>
 
 #include <rcl_logging_interface/rcl_logging_interface.h>
 
+#include <stdexcept>
 #include <string>
 
 #include "logging_api.hpp"

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -15,7 +15,11 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/domain_id.h>
-#include <rcl_action/rcl_action.h>
+#include <rcl/time.h>
+#include <rcl_action/types.h>
+
+#include <rmw/qos_profiles.h>
+#include <rmw/time.h>
 
 #include "action_client.hpp"
 #include "action_goal_handle.hpp"

--- a/rclpy/src/rclpy/action_client.cpp
+++ b/rclpy/src/rclpy/action_client.cpp
@@ -15,12 +15,18 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
+#include <rcl/types.h>
+#include <rcl_action/action_client.h>
+#include <rcl_action/wait.h>
+#include <rosidl_runtime_c/action_type_support_struct.h>
+#include <rmw/types.h>
 
 #include <memory>
 #include <string>
 
 #include "action_client.hpp"
 #include "exceptions.hpp"
+#include "node.hpp"
 #include "utils.hpp"
 
 namespace rclpy

--- a/rclpy/src/rclpy/action_client.hpp
+++ b/rclpy/src/rclpy/action_client.hpp
@@ -17,7 +17,8 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl_action/rcl_action.h>
+#include <rcl_action/action_client.h>
+#include <rmw/types.h>
 
 #include <memory>
 

--- a/rclpy/src/rclpy/action_client.hpp
+++ b/rclpy/src/rclpy/action_client.hpp
@@ -45,12 +45,12 @@ public:
    *
    * \param[in] node Node to add the action client to.
    * \param[in] pyaction_type Action module associated with the action client.
-   * \param[in] pyaction_name Python object containing the action name.
+   * \param[in] action_name The action name.
    * \param[in] goal_service_qos rmw_qos_profile_t object for the goal service.
    * \param[in] result_service_qos rmw_qos_profile_t object for the result service.
    * \param[in] cancel_service_qos rmw_qos_profile_t object for the cancel service.
-   * \param[in] feedback_qos rmw_qos_profile_t object for the feedback subscriber.
-   * \param[in] status_qos rmw_qos_profile_t object for the status subscriber.
+   * \param[in] feedback_topic_qos rmw_qos_profile_t object for the feedback subscriber.
+   * \param[in] status_topic_qos rmw_qos_profile_t object for the status subscriber.
    */
   ActionClient(
     Node & node,
@@ -68,7 +68,7 @@ public:
    * Raises RuntimeError if the underlying rcl library returns an error when taking the response.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pygoal_response_type An instance of the response message type to take.
+   * \param[in] pymsg_type An instance of the response message type to take.
    * \return 2-tuple (sequence number, received response), or
    * \return 2-tuple (None, None) if there is no response, or
    * \return (None, None) if there is a failure in the rcl API call.
@@ -82,7 +82,7 @@ public:
    * Raises RuntimeError if the underlying rcl library returns an error when sending the request.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pyresult_request The request message to send.
+   * \param[in] pyrequest The request message to send.
    * \return sequence_number the index of the sent request
    */
   int64_t
@@ -94,7 +94,7 @@ public:
    * Raises RuntimeError if the underlying rcl library returns an error when taking the response.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pycancel_response_type An instance of the response message type to take.
+   * \param[in] pymsg_type An instance of the response message type to take.
    * \return 2-tuple (sequence number, received response), or
    * \return 2-tuple (None, None) if there is no response, or
    * \return (None, None) if there is a failure in the rcl API call.
@@ -108,8 +108,8 @@ public:
    * Raises RuntimeError if the underlying rcl library returns an error when sending the request.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pycancel_request The request message to send.
-   * \return sequence_number the index of the sent request
+   * \param[in] pyrequest The request message to send.
+   * \return The index of the sent request.
    */
   int64_t
   send_cancel_request(py::object pyrequest);
@@ -121,7 +121,7 @@ public:
    * the case where there are no messages available.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pyfeedback_type Instance of the feedback message type to take.
+   * \param[in] pymsg_type Instance of the feedback message type to take.
    * \return Python message with all fields populated with received message, or
    * \return None if there is nothing to take, or
    * \return None if there is a failure in the rcl API call.
@@ -136,7 +136,7 @@ public:
    * the case where there are no messages available.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pystatus_type Instance of the status message type to take.
+   * \param[in] pymsg_type Instance of the status message type to take.
    * \return Python message with all fields populated with received message, or
    * \return None if there is nothing to take, or
    * \return None if there is a failure in the rcl API call.
@@ -150,8 +150,8 @@ public:
    * Raises RuntimeError on failure.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pygoal_request The request message to send.
-   * \return sequence_number PyLong object representing the index of the sent request
+   * \param[in] pyrequest The request message to send.
+   * \return The index of the sent request
    */
   int64_t
   send_goal_request(py::object pyrequest);
@@ -162,7 +162,7 @@ public:
    * Raises RuntimeError if the underlying rcl library returns an error when taking the response.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pyresult_response_type An instance of the response message type to take.
+   * \param[in] pymsg_type An instance of the response message type to take.
    * \return 2-tuple (sequence number, received response), or
    * \return 2-tuple (None, None) if there is no response, or
    * \return (None, None) if there is a failure in the rcl API call.

--- a/rclpy/src/rclpy/action_goal_handle.cpp
+++ b/rclpy/src/rclpy/action_goal_handle.cpp
@@ -15,11 +15,14 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
+#include <rcl_action/action_server.h>
+#include <rcl_action/goal_handle.h>
+#include <rcl_action/types.h>
 
 #include <memory>
-#include <string>
 
 #include "action_goal_handle.hpp"
+#include "action_server.hpp"
 #include "exceptions.hpp"
 #include "utils.hpp"
 

--- a/rclpy/src/rclpy/action_goal_handle.hpp
+++ b/rclpy/src/rclpy/action_goal_handle.hpp
@@ -17,7 +17,8 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl_action/rcl_action.h>
+#include <rcl_action/goal_handle.h>
+#include <rcl_action/types.h>
 
 #include <memory>
 
@@ -28,8 +29,6 @@ namespace py = pybind11;
 
 namespace rclpy
 {
-
-class ActionServer;
 
 class ActionGoalHandle : public Destroyable, public std::enable_shared_from_this<ActionGoalHandle>
 {

--- a/rclpy/src/rclpy/action_server.cpp
+++ b/rclpy/src/rclpy/action_server.cpp
@@ -11,16 +11,27 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include <rcl_action/action_server.h>
+#include <rcl_action/wait.h>
+#include <rcl/error_handling.h>
+#include <rcl/time.h>
+#include <rcl/types.h>
+#include <rosidl_runtime_c/action_type_support_struct.h>
+#include <rmw/types.h>
+
 #include <memory>
+#include <stdexcept>
 #include <string>
 
-#include "pybind11/pybind11.h"
-
-#include "rcl/error_handling.h"
-#include "rcpputils/scope_exit.hpp"
+#include <rcpputils/scope_exit.hpp>
 
 #include "action_server.hpp"
+#include "clock.hpp"
 #include "exceptions.hpp"
+#include "node.hpp"
 
 namespace rclpy
 {

--- a/rclpy/src/rclpy/action_server.hpp
+++ b/rclpy/src/rclpy/action_server.hpp
@@ -17,7 +17,8 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl_action/rcl_action.h>
+#include <rcl_action/action_server.h>
+#include <rmw/types.h>
 
 #include <memory>
 

--- a/rclpy/src/rclpy/action_server.hpp
+++ b/rclpy/src/rclpy/action_server.hpp
@@ -48,12 +48,13 @@ public:
    * \param[in] node Node to add the action server to.
    * \param[in] rclpy_clock Clock use to create the action server.
    * \param[in] pyaction_type Action module associated with the action server.
-   * \param[in] pyaction_name Python object containing the action name.
+   * \param[in] action_name The action name.
    * \param[in] goal_service_qos rmw_qos_profile_t object for the goal service.
    * \param[in] result_service_qos rmw_qos_profile_t object for the result service.
    * \param[in] cancel_service_qos rmw_qos_profile_t object for the cancel service.
-   * \param[in] feedback_qos rmw_qos_profile_t object for the feedback subscriber.
-   * \param[in] status_qos rmw_qos_profile_t object for the status subscriber.
+   * \param[in] feedback_topic_qos rmw_qos_profile_t object for the feedback subscriber.
+   * \param[in] status_topic_qos rmw_qos_profile_t object for the status subscriber.
+   * \param[in] result_timeout The number of seconds to wait for the result.
    */
   ActionServer(
     Node & node,
@@ -97,7 +98,7 @@ public:
    * Raises RCLError if an error occurs in rcl
    * Raises RuntimeError on failure.
    *
-   * \param[in] pyheader Pointer to the message header.
+   * \param[in] header Pointer to the message header.
    * \param[in] pyresponse The response message to send.
    */
   void
@@ -135,7 +136,7 @@ public:
    * Raises RCLError if an error occurs in rcl
    * Raises RuntimeError on failure.
    *
-   * \param[in] pyheader Pointer to the message header.
+   * \param[in] header Pointer to the message header.
    * \param[in] pyresponse The response message to send.
    */
   void
@@ -168,10 +169,10 @@ public:
   notify_goal_done();
 
   /// Check if a goal is already being tracked by an action server.
-  /*
+  /**
    * Raises AttributeError if there is an issue parsing the pygoal_info.
    *
-   * \param[in] pygoal_info the identifiers of goals that expired, or set to `NULL` if unused
+   * \param[in] pygoal_info The identifiers of goals that expired, or set to `NULL` if unused.
    * \return True if the goal exists, false otherwise.
    */
   bool
@@ -184,13 +185,19 @@ public:
    * Raises RuntimeError on failure while publishing a status message.
    * Raises RCLError if an error occurs in rcl
    *
-   * \return the cancel response message
+   * \param[in] pycancel_request The request message to send.
+   * \param[in] pycancel_response_type The cancel response type.
+   * \return The cancel response message.
    */
   py::object
   process_cancel_request(
     py::object pycancel_request, py::object pycancel_response_type);
 
   /// Expires goals associated with an action server.
+  /**
+   * \param[in] max_num_goals The maximum number of goals to expire.
+   * \return A tuple of GoalInfos corresponding to the canceled goals.
+   */
   py::tuple
   expire_goals(int64_t max_num_goals);
 
@@ -214,7 +221,7 @@ public:
    * Raises RuntimeError on failure.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pywait_set Capsule pointing to the wait set structure.
+   * \param[in] wait_set Capsule pointing to the wait set structure.
    * \return A tuple of booleans representing ready sub-entities.
    *       (is_goal_request_ready,
    *        is_cancel_request_ready,
@@ -229,7 +236,7 @@ public:
    * Raises RuntimeError on failure.
    * Raises RCLError if an error occurs in rcl
    *
-   * \param[in] pywait_set Capsule pointer to an rcl_wait_set_t.
+   * \param[in] wait_set Capsule pointer to an rcl_wait_set_t.
    */
   void
   add_to_waitset(WaitSet & wait_set);

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -14,13 +14,18 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/client.h>
 #include <rcl/error_handling.h>
+#include <rcl/graph.h>
+#include <rosidl_runtime_c/service_type_support_struct.h>
+#include <rmw/types.h>
 
 #include <memory>
 #include <string>
 
 #include "client.hpp"
 #include "exceptions.hpp"
+#include "node.hpp"
 #include "python_allocator.hpp"
 #include "utils.hpp"
 

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -42,7 +42,7 @@ public:
    *
    * \param[in] node Node to add the client to
    * \param[in] pysrv_type Service module associated with the client
-   * \param[in] service_name Python object containing the service name
+   * \param[in] service_name The service name
    * \param[in] pyqos rmw_qos_profile_t object for this client
    */
   Client(Node & node, py::object pysrv_type, const char * service_name, py::object pyqos);

--- a/rclpy/src/rclpy/clock.cpp
+++ b/rclpy/src/rclpy/clock.cpp
@@ -14,14 +14,12 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/allocator.h>
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
 #include <rcl/time.h>
 #include <rcl/types.h>
 
-#include <cstring>
 #include <memory>
-#include <stdexcept>
 
 #include "clock.hpp"
 

--- a/rclpy/src/rclpy/clock.hpp
+++ b/rclpy/src/rclpy/clock.hpp
@@ -20,7 +20,6 @@
 #include <rcl/time.h>
 
 #include <memory>
-#include <string>
 
 #include "destroyable.hpp"
 #include "exceptions.hpp"

--- a/rclpy/src/rclpy/clock_event.cpp
+++ b/rclpy/src/rclpy/clock_event.cpp
@@ -15,14 +15,12 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
 #include <rcl/time.h>
 #include <rcl/types.h>
 
-#include <condition_variable>
-#include <cstring>
+#include <chrono>
 #include <memory>
-#include <stdexcept>
+#include <mutex>
 
 #include "clock_event.hpp"
 

--- a/rclpy/src/rclpy/clock_event.hpp
+++ b/rclpy/src/rclpy/clock_event.hpp
@@ -17,17 +17,11 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/error_handling.h>
-#include <rcl/rcl.h>
 #include <rcl/time.h>
-#include <rcl/types.h>
 
-#include <chrono>
 #include <condition_variable>
-#include <cstring>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 
 #include "clock.hpp"
 

--- a/rclpy/src/rclpy/context.cpp
+++ b/rclpy/src/rclpy/context.cpp
@@ -14,15 +14,18 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/allocator.h>
 #include <rcl/context.h>
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
+#include <rcl/init.h>
+#include <rcl/init_options.h>
 #include <rcl/types.h>
 
 #include <algorithm>
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <vector>
 
 #include "context.hpp"

--- a/rclpy/src/rclpy/context.hpp
+++ b/rclpy/src/rclpy/context.hpp
@@ -17,9 +17,10 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/context.h>
 #include <rcl/error_handling.h>
+#include <rcl/init_options.h>
 
-#include <functional>
 #include <memory>
 
 #include "destroyable.hpp"

--- a/rclpy/src/rclpy/destroyable.cpp
+++ b/rclpy/src/rclpy/destroyable.cpp
@@ -15,6 +15,7 @@
 #include <pybind11/pybind11.h>
 
 #include <memory>
+#include <stdexcept>
 
 #include "destroyable.hpp"
 #include "exceptions.hpp"

--- a/rclpy/src/rclpy/duration.cpp
+++ b/rclpy/src/rclpy/duration.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <pybind11/pybind11.h>
+
 #include <rcl/time.h>
 
 #include "duration.hpp"

--- a/rclpy/src/rclpy/graph.cpp
+++ b/rclpy/src/rclpy/graph.cpp
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
+#include <pybind11/pybind11.h>
+
+#include <rcl/allocator.h>
+#include <rcl/error_handling.h>
+#include <rcl/graph.h>
+#include <rcutils/error_handling.h>
+
 #include <string>
 
-#include "pybind11/pybind11.h"
-
-#include "rcl/error_handling.h"
-#include "rcl/graph.h"
-#include "rcutils/error_handling.h"
-#include "rcpputils/scope_exit.hpp"
+#include <rcpputils/scope_exit.hpp>
 
 #include "exceptions.hpp"
 #include "graph.hpp"
+#include "node.hpp"
 #include "utils.hpp"
 
 namespace rclpy

--- a/rclpy/src/rclpy/graph.hpp
+++ b/rclpy/src/rclpy/graph.hpp
@@ -17,9 +17,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/graph.h>
-
-#include <memory>
 #include <string>
 
 #include "node.hpp"

--- a/rclpy/src/rclpy/guard_condition.cpp
+++ b/rclpy/src/rclpy/guard_condition.cpp
@@ -16,12 +16,11 @@
 
 #include <rcl/error_handling.h>
 #include <rcl/guard_condition.h>
-#include <rcl/rcl.h>
 #include <rcl/types.h>
 
 #include <memory>
-#include <stdexcept>
 
+#include "context.hpp"
 #include "exceptions.hpp"
 #include "guard_condition.hpp"
 

--- a/rclpy/src/rclpy/guard_condition.hpp
+++ b/rclpy/src/rclpy/guard_condition.hpp
@@ -17,14 +17,12 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/error_handling.h>
 #include <rcl/guard_condition.h>
 
 #include <memory>
 
 #include "context.hpp"
 #include "destroyable.hpp"
-#include "exceptions.hpp"
 #include "utils.hpp"
 
 namespace py = pybind11;

--- a/rclpy/src/rclpy/lifecycle.cpp
+++ b/rclpy/src/rclpy/lifecycle.cpp
@@ -21,12 +21,15 @@
 #include <lifecycle_msgs/srv/get_available_states.h>
 #include <lifecycle_msgs/srv/get_available_transitions.h>
 
+#include <rcl/error_handling.h>
+#include <rcl/types.h>
 #include <rcl_lifecycle/rcl_lifecycle.h>
 
 #include <rosidl_runtime_c/message_type_support_struct.h>
 #include <rosidl_runtime_c/service_type_support_struct.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/rclpy/src/rclpy/logging.cpp
+++ b/rclpy/src/rclpy/logging.cpp
@@ -14,11 +14,12 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/allocator.h>
 #include <rcl/error_handling.h>
 #include <rcl/logging.h>
-#include <rcl/rcl.h>
 #include <rcl/types.h>
 #include <rcutils/logging.h>
+#include <rcutils/time.h>
 
 #include <mutex>
 #include <stdexcept>

--- a/rclpy/src/rclpy/logging.hpp
+++ b/rclpy/src/rclpy/logging.hpp
@@ -39,7 +39,7 @@ private:
 /// Initialize rcl logging
 /**
  * Raises RuntimeError if rcl logging could not be initialized
- * \param[in] pycontext a context instance to use to retrieve global CLI arguments
+ * \param[in] _context A context instance to use to retrieve global CLI arguments.
  */
 void
 logging_configure(Context & _context);

--- a/rclpy/src/rclpy/names.hpp
+++ b/rclpy/src/rclpy/names.hpp
@@ -59,7 +59,7 @@ get_validation_error_for_full_topic_name(const char * topic_name);
  * Raises MemoryError if memory could not be allocated
  * Raises RMWError if an unexpected error happened while validating the namespace
  *
- * \param[in] namespace namespace to be validated
+ * \param[in] namespace_ namespace to be validated
  * \return tuple of error message and invalid index if invalid, or
  * \return None if valid
  */
@@ -96,7 +96,7 @@ expand_topic_name(const char * topic, const char * node_name, const char * node_
  * Raises ValueError if the capsule is not the correct type
  * Raises RCLError if an unexpected error happens
  *
- * \param[in] Node node to remap the topic name
+ * \param[in] node node to remap the topic name
  * \param[in] topic_name topic string to be remapped
  * \return remapped topic name
  */

--- a/rclpy/src/rclpy/node.cpp
+++ b/rclpy/src/rclpy/node.cpp
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <pybind11/pybind11.h>
+
+#include <rcl_action/rcl_action.h>
+#include <rcl/error_handling.h>
+#include <rcl/graph.h>
+#include <rcl/types.h>
+#include <rcl_interfaces/msg/parameter_type.h>
+#include <rcl_yaml_param_parser/parser.h>
+#include <rcutils/format_string.h>
+
 #include <limits>
 #include <memory>
 #include <stdexcept>
@@ -19,17 +29,7 @@
 #include <utility>
 #include <vector>
 
-#include "pybind11/pybind11.h"
-
-#include "rcl_action/rcl_action.h"
-#include "rcl/error_handling.h"
-#include "rcl/graph.h"
-#include "rcl/rcl.h"
-#include "rcl/types.h"
-#include "rcl_interfaces/msg/parameter_type.h"
-#include "rcl_yaml_param_parser/parser.h"
-#include "rcpputils/scope_exit.hpp"
-#include "rcutils/format_string.h"
+#include <rcpputils/scope_exit.hpp>
 
 #include "exceptions.hpp"
 #include "logging.hpp"

--- a/rclpy/src/rclpy/node.hpp
+++ b/rclpy/src/rclpy/node.hpp
@@ -40,7 +40,7 @@ public:
    * Raises MemoryError if memory could not be allocated for the node
    *
    * \param[in] node_name name of the node to be created
-   * \param[in] namespace namespace for the node
+   * \param[in] namespace_ namespace for the node
    * \param[in] context Context
    * \param[in] pycli_args a sequence of command line arguments for just this node, or None
    * \param[in] use_global_arguments if true then the node will also use cli arguments on context
@@ -91,7 +91,7 @@ public:
   get_namespace();
 
   /// Returns the count of all the publishers known for that topic in the entire ROS graph.
-  /*
+  /**
    * Raises RCLError if an error occurs in rcl
    *
    * \param[in] topic_name Name of the topic to count the number of publishers
@@ -101,8 +101,7 @@ public:
   get_count_publishers(const char * topic_name);
 
   /// Returns the count of all the subscribers known for that topic in the entire ROS graph
-  /*
-   *
+  /**
    * Raises RCLError if an error occurs in rcl
    *
    * \param[in] topic_name Name of the topic to count the number of subscribers
@@ -144,7 +143,7 @@ public:
   get_parameters(py::object pyparameter_cls);
 
   /// Get action client names and types by node.
-  /*
+  /**
    * \param[in] remote_node_name the node name of the actions to return
    * \param[in] remote_node_namespace the node namespace of the actions to return
    * \return list of action client names and their types
@@ -154,7 +153,7 @@ public:
     const char * remote_node_name, const char * remote_node_namespace);
 
   /// Get action server names and types by node.
-  /*
+  /**
    * \param[in] remote_node_name the node name of the actions to return
    * \param[in] remote_node_namespace the node namespace of the actions to return
    * \return list of action server names and their types
@@ -164,7 +163,7 @@ public:
     const char * remote_node_name, const char * remote_node_namespace);
 
   /// Get action names and types.
-  /*
+  /**
    * \return list of action names and types
    */
   py::list
@@ -186,8 +185,7 @@ private:
   /**
    * Raises RCLError if the names are unavailable.
    *
-   * \param[in] get_enclaves specifies if the output includes the enclaves names
-   *            or not
+   * \param[in] get_enclaves specifies whether the output includes the enclaves names
    * \return Python list of tuples, containing:
    *  node name, node namespace, and
    *  enclave if `get_enclaves` is true.

--- a/rclpy/src/rclpy/node.hpp
+++ b/rclpy/src/rclpy/node.hpp
@@ -17,7 +17,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/graph.h>  // rcl_names_and_types_t
+#include <rcl/node.h>
 
 #include <memory>
 

--- a/rclpy/src/rclpy/publisher.cpp
+++ b/rclpy/src/rclpy/publisher.cpp
@@ -15,11 +15,15 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
+#include <rcl/publisher.h>
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#include <rmw/serialized_message.h>
 
 #include <memory>
 #include <string>
 
 #include "exceptions.hpp"
+#include "node.hpp"
 #include "publisher.hpp"
 #include "utils.hpp"
 

--- a/rclpy/src/rclpy/publisher.hpp
+++ b/rclpy/src/rclpy/publisher.hpp
@@ -39,15 +39,15 @@ class Publisher : public Destroyable, public std::enable_shared_from_this<Publis
 {
 public:
   /// Create a publisher
-  /*
+  /**
    * Raises ValueError if the topic name is invalid
    * Raises ValueError if the capsules are not the correct types
    * Raises RCLError if the publisher cannot be created
    *
-   * \param[in] node node to add the publisher to
-   * \param[in] pymsg_type Message type associated with the publisher
-   * \param[in] topic The name of the topic to attach the publisher to
-   * \param[in] pyqos_profile rmw_qos_profile_t object for this publisher
+   * \param[in] node Node to add the publisher to.
+   * \param[in] pymsg_type Message type associated with the publisher.
+   * \param[in] topic The name of the topic to attach the publisher to.
+   * \param[in] pyqos_profile rmw_qos_profile_t object for this publisher.
    */
   Publisher(
     Node & node, py::object pymsg_type, std::string topic,
@@ -84,7 +84,7 @@ public:
   /**
    * Raises RCLError if the message cannot be published
    *
-   * \param[in] pymsg Message to send
+   * \param[in] pymsg Message to send.
    */
   void
   publish(py::object pymsg);
@@ -93,7 +93,7 @@ public:
   /**
    * Raises RCLError if the message cannot be published
    *
-   * \param[in] msg serialized message to send
+   * \param[in] msg The serialized message to send.
    */
   void
   publish_raw(std::string msg);
@@ -120,7 +120,7 @@ public:
    *
    * Raises RCLError if an error occurs, such as the middleware not supporting this feature.
    *
-   * \param[in] pytimeout the duration to wait for all published message data to be acknowledged.
+   * \param[in] pytimeout The duration to wait for all published message data to be acknowledged.
    * \return `true` if all published message data is acknowledged before the timeout, otherwise
    *   `false`.
    */

--- a/rclpy/src/rclpy/publisher.hpp
+++ b/rclpy/src/rclpy/publisher.hpp
@@ -19,7 +19,6 @@
 
 #include <rcl/publisher.h>
 #include <rcl/time.h>
-#include <rmw/types.h>
 
 #include <memory>
 #include <string>

--- a/rclpy/src/rclpy/python_allocator.hpp
+++ b/rclpy/src/rclpy/python_allocator.hpp
@@ -17,6 +17,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <stdexcept>
+
 namespace rclpy
 {
 //----------- Declaration ----------

--- a/rclpy/src/rclpy/qos.cpp
+++ b/rclpy/src/rclpy/qos.cpp
@@ -14,15 +14,15 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/rcl.h>
 #include <rcl/time.h>
 #include <rmw/error_handling.h>
 #include <rmw/incompatible_qos_events_statuses.h>
 #include <rmw/qos_profiles.h>
+#include <rmw/time.h>
 #include <rmw/types.h>
 
 #include <cstring>
-#include <memory>
+#include <stdexcept>
 #include <string>
 
 #include "exceptions.hpp"

--- a/rclpy/src/rclpy/qos.cpp
+++ b/rclpy/src/rclpy/qos.cpp
@@ -63,7 +63,7 @@ _convert_py_duration_to_rmw_time(const rcl_duration_t & duration, rmw_time_t * o
   out_time->nsec = duration.nanoseconds % (1000LL * 1000LL * 1000LL);
 }
 
-// Create an rmw_qos_profile_t instance.
+/// Create an rmw_qos_profile_t instance.
 /**
  * Raises ValueError if a any capsule is not of the expected type.
  * Raises MemoryError if rmw_qos_profile_t allocation fails.
@@ -118,7 +118,7 @@ create_qos_profile(
   return qos_profile;
 }
 
-// Fetch a predefined rmw_qos_profile_t instance.
+/// Fetch a predefined rmw_qos_profile_t instance.
 /**
  * Raises InvalidArgument if the given \p qos_profile_name is unknown.
  *

--- a/rclpy/src/rclpy/qos.hpp
+++ b/rclpy/src/rclpy/qos.hpp
@@ -15,10 +15,9 @@
 #ifndef RCLPY__QOS_HPP_
 #define RCLPY__QOS_HPP_
 
-#include <rmw/qos_profiles.h>
-
 #include <pybind11/pybind11.h>
 
+#include <rmw/qos_profiles.h>
 
 namespace py = pybind11;
 

--- a/rclpy/src/rclpy/qos_event.cpp
+++ b/rclpy/src/rclpy/qos_event.cpp
@@ -19,9 +19,8 @@
 #include <rmw/incompatible_qos_events_statuses.h>
 
 #include <memory>
-#include <string>
+#include <stdexcept>
 #include <utility>
-#include <variant>  // NOLINT
 
 #include "exceptions.hpp"
 #include "qos_event.hpp"

--- a/rclpy/src/rclpy/qos_event.hpp
+++ b/rclpy/src/rclpy/qos_event.hpp
@@ -20,7 +20,7 @@
 #include <rcl/event.h>
 
 #include <memory>
-#include <variant>  // NOLINT
+#include <variant>
 
 #include "destroyable.hpp"
 #include "publisher.hpp"

--- a/rclpy/src/rclpy/qos_event.hpp
+++ b/rclpy/src/rclpy/qos_event.hpp
@@ -43,7 +43,7 @@ public:
    * Raises MemoryError if the event can't be allocated
    * Raises RCLError if event initialization failed in rcl
    *
-   * \param[in] ssubscription Subscription wrapping the underlying ``rcl_subscription_t`` object.
+   * \param[in] subscription Subscription wrapping the underlying ``rcl_subscription_t`` object.
    * \param[in] event_type Type of event to create
    */
   QoSEvent(rclpy::Subscription & subscriber, rcl_subscription_event_type_t event_type);

--- a/rclpy/src/rclpy/serialization.cpp
+++ b/rclpy/src/rclpy/serialization.cpp
@@ -15,13 +15,12 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
 #include <rcl/types.h>
 #include <rcutils/allocator.h>
 #include <rcutils/error_handling.h>
-
-#include <memory>
-#include <stdexcept>
+#include <rmw/rmw.h>
+#include <rmw/serialized_message.h>
+#include <rosidl_runtime_c/message_type_support_struct.h>
 
 #include "exceptions.hpp"
 #include "serialization.hpp"

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -15,12 +15,15 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
+#include <rcl/service.h>
+#include <rosidl_runtime_c/service_type_support_struct.h>
+#include <rmw/types.h>
 
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "exceptions.hpp"
+#include "node.hpp"
 #include "service.hpp"
 #include "utils.hpp"
 

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -17,8 +17,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/timer.h>
-#include <rcl/rcl.h>
+#include <rcl/service.h>
 #include <rmw/types.h>
 
 #include <memory>

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -44,7 +44,7 @@ public:
    * Raises ValueError if the capsules are not the correct types
    * Raises RCLError if the service could not be created
    *
-   * \param[in] node node to add the service to
+   * \param[in] node Node to add the service to
    * \param[in] pysrv_type Service module associated with the service
    * \param[in] service_name Python object for the service name
    * \param[in] pyqos_profile QoSProfile Python object for this service
@@ -65,7 +65,7 @@ public:
    * Raises RCLError if the response could not be sent
    *
    * \param[in] pyresponse reply message to send
-   * \param[in] pyheader Capsule pointing to the rmw_request_id_t header of the request we respond to
+   * \param[in] header Capsule pointing to the rmw_request_id_t header of the request we respond to
    */
   void
   service_send_response(py::object pyresponse, rmw_request_id_t * header);
@@ -90,9 +90,11 @@ public:
     return rcl_service_.get();
   }
 
+  /// Get the service name.
   const char *
   get_service_name();
 
+  /// Get the QoS profile for this service.
   py::dict
   get_qos_profile();
 

--- a/rclpy/src/rclpy/signal_handler.cpp
+++ b/rclpy/src/rclpy/signal_handler.cpp
@@ -16,17 +16,16 @@
 
 #include <pybind11/pybind11.h>
 
-#include <csignal>
+#include <rcl/allocator.h>
+#include <rcl/error_handling.h>
+#include <rcl/guard_condition.h>
+#include <rcutils/logging_macros.h>
 
 #include <atomic>
+#include <csignal>
+#include <stdexcept>
 #include <string>
 #include <thread>
-
-#include "rcl/error_handling.h"
-#include "rcl/rcl.h"
-
-#include "rcutils/allocator.h"
-#include "rcutils/logging_macros.h"
 
 #include "context.hpp"
 #include "guard_condition.hpp"

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -15,13 +15,18 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
+#include <rcl/node.h>
+#include <rcl/subscription.h>
 #include <rcl/types.h>
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#include <rmw/types.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include "exceptions.hpp"
+#include "node.hpp"
 #include "serialization.hpp"
 #include "subscription.hpp"
 #include "utils.hpp"

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -18,7 +18,6 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/subscription.h>
-#include <rmw/types.h>
 
 #include <memory>
 #include <string>

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -39,10 +39,10 @@ class Subscription : public Destroyable, public std::enable_shared_from_this<Sub
 {
 public:
   /// Create a subscription
-  /*
+  /**
    * Raises RCLError if the subscription could not be created
    *
-   * \param[in] node node to add the subscriber to
+   * \param[in] node Node to add the subscriber to
    * \param[in] pymsg_type Message module associated with the subscriber
    * \param[in] topic The topic name
    * \param[in] pyqos_profile rmw_qos_profile_t object for this subscription

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -14,17 +14,15 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rcl/context.h>
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
 #include <rcl/timer.h>
 #include <rcl/types.h>
 
 #include <memory>
-#include <stdexcept>
 
-#include "exceptions.hpp"
+#include "clock.hpp"
 #include "context.hpp"
+#include "exceptions.hpp"
 #include "timer.hpp"
 
 namespace rclpy

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -43,8 +43,8 @@ public:
    * Raises ValueError if argument cannot be converted
    *
    * \param[in] clock pycapsule containing an rcl_clock_t
-   * \param[in] pycontext Capsule for an rcl_timer_t
-   * \param[in] period_nsec the period of the timer in nanoseconds
+   * \param[in] context Capsule for an rcl_timer_t
+   * \param[in] period_nsec The period of the timer in nanoseconds
    * \return a timer capsule
    */
   Timer(Clock & clock, Context & context, int64_t period_nsec);

--- a/rclpy/src/rclpy/utils.cpp
+++ b/rclpy/src/rclpy/utils.cpp
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
+#include <pybind11/pybind11.h>
 
+#include <rcl/allocator.h>
+#include <rcl/arguments.h>
+#include <rcl/error_handling.h>
+#include <rcl/graph.h>
+#include <rcl/publisher.h>
+#include <rcl_action/rcl_action.h>
+#include <rmw/rmw.h>
+#include <rmw/time.h>
+#include <rmw/topic_endpoint_info.h>
+#include <rmw/types.h>
+
+#include <cassert>
 #include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "pybind11/pybind11.h"
-
-#include "rcl/error_handling.h"
-#include "rcl_action/rcl_action.h"
-#include "rcpputils/scope_exit.hpp"
+#include <rcpputils/scope_exit.hpp>
 
 #include "exceptions.hpp"
 #include "utils.hpp"

--- a/rclpy/src/rclpy/utils.hpp
+++ b/rclpy/src/rclpy/utils.hpp
@@ -35,7 +35,7 @@ typedef void destroy_ros_message_function (void *);
 
 /// Convert a C rcl_names_and_types_t into a Python list.
 /**
- * \param[in] names_and_types The names and types struct to convert.
+ * \param[in] topic_names_and_types The names and types struct to convert.
  * \return List of tuples, where the first element of each tuple is a string
  *   for the name and the second element is a list of strings for the types.
  */
@@ -44,7 +44,7 @@ convert_to_py_names_and_types(const rcl_names_and_types_t * topic_names_and_type
 
 /// Get the type support structure for a Python ROS message type.
 /**
- * \param[in] pymsg_type The Python ROS message type.
+ * \param[in] pymessage The Python ROS message type.
  * \return The type support structure or NULL if an error occurred.
  */
 void *
@@ -97,7 +97,7 @@ get_rmw_implementation_identifier();
  * Raises RCLError on failure to assert liveliness
  * Raises TypeError if passed object is not a valid Publisher
  *
- * \param[in] pyentity A capsule containing an rcl_publisher_t
+ * \param[in] publisher A capsule containing an rcl_publisher_t
  * \return None
  */
 void
@@ -144,7 +144,7 @@ convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array_t * i
 
 /// Convert a C rmw_qos_profile_t into a Python dictionary with qos profile args.
 /**
- * \param[in] profile Pointer to a rmw_qos_profile_t to convert
+ * \param[in] qos_profile Pointer to a rmw_qos_profile_t to convert
  * \return Python dictionary
  */
 py::dict

--- a/rclpy/src/rclpy/utils.hpp
+++ b/rclpy/src/rclpy/utils.hpp
@@ -17,7 +17,10 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/arguments.h>
 #include <rcl/graph.h>  // rcl_names_and_types_t
+#include <rmw/topic_endpoint_info.h>
+#include <rmw/types.h>
 
 #include <memory>
 

--- a/rclpy/src/rclpy/wait_set.cpp
+++ b/rclpy/src/rclpy/wait_set.cpp
@@ -15,8 +15,8 @@
 #include <pybind11/pybind11.h>
 
 #include <rcl/error_handling.h>
-#include <rcl/rcl.h>
 #include <rcl/types.h>
+#include <rcl/wait.h>
 
 #include <cstring>
 #include <memory>

--- a/rclpy/src/rclpy/wait_set.hpp
+++ b/rclpy/src/rclpy/wait_set.hpp
@@ -45,13 +45,13 @@ public:
   /**
    * Raises RCLError if the wait set could not be initialized
    *
-   * \param[in] node_name string name of the node to be created
    * \param[in] number_of_subscriptions a positive number or zero
    * \param[in] number_of_guard_conditions int
    * \param[in] number_of_timers int
    * \param[in] number_of_clients int
    * \param[in] number_of_services int
-   * \param[in] pycontext Capsule pointing to an rcl_context_t
+   * \param[in] number_of_events int
+   * \param[in] context Capsule pointing to an rcl_context_t
    */
   WaitSet(
     size_t number_of_subscriptions,
@@ -73,7 +73,7 @@ public:
   /**
    * Raises RCLError if any lower level error occurs
    *
-   * \param[in] service a service to add to the wait set
+   * \param[in] service A service to add to the wait set
    * \return Index in waitset entity was added at
    */
   size_t
@@ -83,7 +83,7 @@ public:
   /**
    * Raises RCLError if any lower level error occurs
    *
-   * \param[in] service a service to add to the wait set
+   * \param[in] subscription A subscription to add to the wait set
    * \return Index in waitset entity was added at
    */
   size_t
@@ -93,7 +93,7 @@ public:
   /**
    * Raises RCLError if any lower level error occurs
    *
-   * \param[in] client a client to add to the wait set
+   * \param[in] client A client to add to the wait set
    * \return Index in waitset entity was added at
    */
   size_t
@@ -103,7 +103,7 @@ public:
   /**
    * Raises RCLError if any lower level error occurs
    *
-   * \param[in] timer a guard condition to add to the wait set
+   * \param[in] gc A guard condition to add to the wait set
    * \return Index in waitset entity was added at
    */
   size_t
@@ -113,7 +113,7 @@ public:
   /**
    * Raises RCLError if any lower level error occurs
    *
-   * \param[in] timer a timer to add to the wait set
+   * \param[in] timer A timer to add to the wait set
    * \return Index in waitset entity was added at
    */
   size_t
@@ -123,7 +123,7 @@ public:
   /**
    * Raises RCLError if any lower level error occurs
    *
-   * \param[in] event a QoSEvent to add to the wait set
+   * \param[in] event A QoSEvent to add to the wait set
    * \return Index in waitset entity was added at
    */
   size_t
@@ -135,8 +135,8 @@ public:
    * Raises RuntimeError if the entity type is unknown
    * Raises IndexError if the given index is beyond the number of entities in the set
    *
-   * \param[in] entity_type string defining the entity ["subscription, client, service"]
-   * \param[in] index location in the wait set of the entity to check
+   * \param[in] entity_type String defining the entity ["subscription, client, service"]
+   * \param[in] index Location in the wait set of the entity to check
    * \return True if the entity at the index in the wait set is not NULL
    */
   bool
@@ -146,7 +146,7 @@ public:
   /**
    * Raises RuntimeError if the entity type is not known
    *
-   * \param[in] entity_type string defining the entity ["subscription, client, service"]
+   * \param[in] entity_type String defining the entity ["subscription, client, service"]
    * \return List of wait set entities pointers ready for take
    */
   py::list
@@ -158,7 +158,7 @@ public:
    *
    * This function will wait for an event to happen or for the timeout to expire.
    * A negative timeout means wait forever, a timeout of 0 means no wait
-   * \param[in] timeout optional time to wait before waking up (in nanoseconds)
+   * \param[in] timeout Optional time to wait before waking up (in nanoseconds)
    */
   void
   wait(int64_t timeout);

--- a/rclpy/src/rclpy/wait_set.hpp
+++ b/rclpy/src/rclpy/wait_set.hpp
@@ -17,6 +17,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/wait.h>
+
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
While working on some other things in rclpy, I noticed that rclpy didn't properly declare all of its dependencies.  In particular, it depends on `rosidl_runtime_c` and `rmw`, but neither of these were explicitly called out in the package.xml or CMakeLists.txt.

To fix this, there are 3 patches in this series:

1. Does a pass for include-what-you-use everywhere in the rclpy code.
2. Adds the new dependencies.
3. Fixes up documentation problems noticed while doing the above.

All 3 patches are completely independent, and could all be taken separately.  But given that I noticed them all together, I figured I would open one big PR for it.  Let me know if you'd like me to split it up.