### PR TITLE
time_until_next_call returns max if timer is canceled

### DIFF
--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -20,6 +20,7 @@
 #include <rcl/timer.h>
 #include <rcl/types.h>
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 
@@ -109,7 +110,10 @@ int64_t Timer::time_until_next_call()
 {
   int64_t remaining_time;
   rcl_ret_t ret = rcl_timer_get_time_until_next_call(rcl_timer_.get(), &remaining_time);
-  if (ret != RCL_RET_OK) {
+
+  if (ret == RCL_RET_TIMER_CANCELED) {
+    return std::numeric_limits<int64_t>::max();
+  } else if (ret != RCL_RET_OK) {
     throw RCLError("failed to get time until next timer call");
   }
 

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -84,6 +84,7 @@ public:
   /// Get the time before the timer will be ready
   /**
    * the returned time can be negative, this means that the timer is ready and hasn't been called yet
+   * the returned time for a canceled timer is the max representation of an int64_t
    *
    * Raises RCLError there is an rcl error
    *


### PR DESCRIPTION
The PR https://github.com/ros2/rcl/pull/963 changes `rcl_timer_get_time_until_next_call` to return `RCL_RET_TIMER_CANCELED`  if timer was canceled. 
Here in `rclpy` we'll return `std::numeric_limits<int64_t>::max()` on `time_until_next_call` if timer was canceled.

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>