### PR TITLE
Move /clock callback processing to seperate thread.

### DIFF
--- a/rclpy/rclpy/callback_groups.py
+++ b/rclpy/rclpy/callback_groups.py
@@ -39,6 +39,14 @@ class CallbackGroup:
         """
         self.entities.add(weakref.ref(entity))
 
+    def get_entites(self):
+        """
+        Get all entities from the callback group.
+
+        :return: A set containing weakrefs to the entities.
+        """
+        return self.entities
+
     def has_entity(self, entity) -> bool:
         """
         Determine if an entity has been added to this group.

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -277,7 +277,7 @@ class Executor:
                 # Rebuild the wait set so it doesn't include this node
                 self._guard.trigger()
 
-    def remove_callback_group(self, group, node: 'Node') -> None:
+    def remove_callback_group(self, group: 'CallbackGroup', node: 'Node') -> None:
         """
         Stop managing this group's callbacks.
 
@@ -286,7 +286,7 @@ class Executor:
         """
         with self._nodes_lock:
             try:
-                self._nodes.remove((group, node))
+                self._cb_groups.remove((group, node))
             except KeyError:
                 pass
             else:
@@ -480,8 +480,8 @@ class Executor:
         self,
         timeout_sec: float = None,
         nodes: List['Node'] = None,
-        call_back_groups: List[Tuple[CallbackGroup, 'Node']] = None,
         condition: Callable[[], bool] = lambda: False,
+        call_back_groups: List[Tuple[CallbackGroup, 'Node']] = None,
     ) -> Generator[Tuple[Task, WaitableEntityType, 'Node'], None, None]:
         """
         Yield callbacks that are ready to be executed.

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -76,6 +76,7 @@ class TimeSource:
                 callback_group = MutuallyExclusiveCallbackGroup()
 
                 def clock_thread_fun(clock_executor, future):
+                    print("Start thread") # Only works if this print is there wtf. Definetly a TODO regarding some concurrency
                     clock_executor.add_callback_group(callback_group, node)
                     clock_executor.spin_until_future_complete(future)
 

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -64,7 +64,7 @@ class TimeSource:
                 node = self._get_node()
                 if node is not None:
                     node.destroy_subscription(self._clock_sub)
-                    self._clock_thread_future.done()
+                    self._clock_thread_future.set_result(None)
                     self._clock_thread.join()
                     self._clock_thread = None
                     self._clock_sub = None
@@ -79,7 +79,7 @@ class TimeSource:
                     clock_executor.add_callback_group(callback_group, node)
                     clock_executor.spin_until_future_complete(future)
 
-                self._clock_thread_future = Future()
+                self._clock_thread_future = Future(executor=self._clock_executor)
                 self._clock_thread = threading.Thread(
                     target=clock_thread_fun,
                     args=(self._clock_executor, self._clock_thread_future))


### PR DESCRIPTION
This PR moves the spinning of the Executor for the /clock subscriber to a seperate thread. (#792)
As described in the issue this needs support for spinning a callback group in its own Executor. Support for this exists in rclcpp and was sugested for rclpy in #850. The current implementation is a bit hacky imo., so suggestions regarding a different way of implementing this are welcome.

Fixes #792 and partially #850