### PR TITLE
Allow to create a subscription with a callback that also receives the message info

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -421,10 +421,6 @@ class Executor:
 
                 try:
                     await call_coroutine(entity, *arg)
-                    # if isinstance(arg, tuple):
-                    #     await call_coroutine(entity, *arg)
-                    # else:
-                    #     await call_coroutine(entity, arg)
                 finally:
                     entity.callback_group.ending_execution(entity)
                     # Signal that work has been done so the next callback in a mutually exclusive

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -338,7 +338,6 @@ class Executor:
                 if sub.callback_type is Subscription.CallbackType.MessageOnly:
                     return (msg_info[0], )
                 else:
-                    print(msg_info)
                     return msg_info
         return None
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -336,7 +336,7 @@ class Executor:
         with sub.handle:
             msg_info = sub.handle.take_message(sub.msg_type, sub.raw)
             if msg_info is not None:
-                if sub.callback_type is Subscription.CallbackType.MessageOnly:
+                if sub._callback_type is Subscription.CallbackType.MessageOnly:
                     return (msg_info[0], )
                 else:
                     return msg_info

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -327,8 +327,9 @@ class Executor:
     def _take_timer(self, tmr):
         with tmr.handle:
             tmr.handle.call_timer()
+        return ()
 
-    async def _execute_timer(self, tmr, _):
+    async def _execute_timer(self, tmr):
         await await_or_execute(tmr.callback)
 
     def _take_subscription(self, sub):
@@ -339,7 +340,7 @@ class Executor:
                     return (msg_info[0], )
                 else:
                     return msg_info
-        return None
+        return ()
 
     async def _execute_subscription(self, sub, *args):
         if args:
@@ -347,7 +348,7 @@ class Executor:
 
     def _take_client(self, client):
         with client.handle:
-            return client.handle.take_response(client.srv_type.Response)
+            return (client.handle.take_response(client.srv_type.Response), )
 
     async def _execute_client(self, client, seq_and_response):
         header, response = seq_and_response
@@ -365,7 +366,7 @@ class Executor:
     def _take_service(self, srv):
         with srv.handle:
             request_and_header = srv.handle.service_take_request(srv.srv_type.Request)
-        return request_and_header
+        return (request_and_header, )
 
     async def _execute_service(self, srv, request_and_header):
         if request_and_header is None:
@@ -377,8 +378,9 @@ class Executor:
 
     def _take_guard_condition(self, gc):
         gc._executor_triggered = False
+        return ()
 
-    async def _execute_guard_condition(self, gc, _):
+    async def _execute_guard_condition(self, gc):
         await await_or_execute(gc.callback)
 
     async def _execute_waitable(self, waitable, data):
@@ -418,10 +420,11 @@ class Executor:
                 gc.trigger()
 
                 try:
-                    if isinstance(arg, tuple):
-                        await call_coroutine(entity, *arg)
-                    else:
-                        await call_coroutine(entity, arg)
+                    await call_coroutine(entity, *arg)
+                    # if isinstance(arg, tuple):
+                    #     await call_coroutine(entity, *arg)
+                    # else:
+                    #     await call_coroutine(entity, arg)
                 finally:
                     entity.callback_group.ending_execution(entity)
                     # Signal that work has been done so the next callback in a mutually exclusive
@@ -615,7 +618,7 @@ class Executor:
                         # Only check waitables that were added to the wait set
                         if wt in waitables and wt.is_ready(wait_set):
                             handler = self._make_handler(
-                                wt, node, lambda e: e.take_data(), self._execute_waitable)
+                                wt, node, lambda e: (e.take_data(), ), self._execute_waitable)
                             yielded_work = True
                             yield handler, wt, node
 

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -75,21 +75,6 @@ class Subscription:
 
         self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
             callback_group, subscription_impl, topic)
-        self.callback_type = Subscription.CallbackType.MessageOnly
-        try:
-            inspect.signature(self.callback).bind(object())
-            return
-        except TypeError:
-            pass
-        try:
-            inspect.signature(self.callback).bind(object(), object())
-            self.callback_type = Subscription.CallbackType.WithMessageInfo
-            return
-        except TypeError:
-            pass
-        raise RuntimeError(
-            'Subscription.__init__(): callback should be either be callable with one argument'
-            '(to get only the message) or two (to get message and message info)')
 
     @property
     def handle(self):
@@ -104,3 +89,26 @@ class Subscription:
     def topic_name(self):
         with self.handle:
             return self.__subscription.get_topic_name()
+
+    @property
+    def callback(self):
+        return self._callback
+
+    @callback.setter
+    def callback(self, value):
+        self._callback = value
+        self._callback_type = Subscription.CallbackType.MessageOnly
+        try:
+            inspect.signature(value).bind(object())
+            return
+        except TypeError:
+            pass
+        try:
+            inspect.signature(value).bind(object(), object())
+            self._callback_type = Subscription.CallbackType.WithMessageInfo
+            return
+        except TypeError:
+            pass
+        raise RuntimeError(
+            'Subscription.__init__(): callback should be either be callable with one argument'
+            '(to get only the message) or two (to get message and message info)')

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -131,11 +131,20 @@ Subscription::take_message(py::object pymsg_type, bool raw)
 
     pytaken_msg = convert_to_py(taken_msg.get(), pymsg_type);
   }
-
+  py::object pub_seq_number = py::none();
+  if (message_info.publication_sequence_number != RMW_MESSAGE_INFO_SEQUENCE_NUMBER_UNSUPPORTED) {
+    pub_seq_number = py::int_(message_info.publication_sequence_number);
+  }
+  py::object rec_seq_number = py::none();
+  if (message_info.reception_sequence_number != RMW_MESSAGE_INFO_SEQUENCE_NUMBER_UNSUPPORTED) {
+    rec_seq_number = py::int_(message_info.reception_sequence_number);
+  }
   return py::make_tuple(
     pytaken_msg, py::dict(
       "source_timestamp"_a = message_info.source_timestamp,
-      "received_timestamp"_a = message_info.received_timestamp));
+      "received_timestamp"_a = message_info.received_timestamp,
+      "publication_sequence_number"_a = pub_seq_number,
+      "reception_sequence_number"_a = rec_seq_number));
 }
 
 const char *

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -16,6 +16,7 @@ import pytest
 
 import rclpy
 from rclpy.node import Node
+from rclpy.subscription import Subscription
 
 from test_msgs.msg import Empty
 
@@ -66,3 +67,25 @@ def test_get_subscription_topic_name_after_remapping(topic_name, namespace, cli_
         qos_profile=10,
     )
     assert sub.topic_name == expected
+
+
+def test_subscription_callback_type():
+    node = Node('test_node', namespace='test_subscription/test_subscription_callback_type')
+    sub = node.create_subscription(
+        msg_type=Empty,
+        topic='test_subscription/test_subscription_callback_type/topic',
+        qos_profile=10,
+        callback=lambda _: None)
+    assert sub.callback_type == Subscription.CallbackType.MessageOnly
+    sub = node.create_subscription(
+        msg_type=Empty,
+        topic='test_subscription/test_subscription_callback_type/topic',
+        qos_profile=10,
+        callback=lambda _, _2: None)
+    assert sub.callback_type == Subscription.CallbackType.WithMessageInfo
+    with pytest.raises(RuntimeError):
+        node.create_subscription(
+            msg_type=Empty,
+            topic='test_subscription/test_subscription_callback_type/topic',
+            qos_profile=10,
+            callback=lambda _, _2, _3: None)

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -76,13 +76,13 @@ def test_subscription_callback_type():
         topic='test_subscription/test_subscription_callback_type/topic',
         qos_profile=10,
         callback=lambda _: None)
-    assert sub.callback_type == Subscription.CallbackType.MessageOnly
+    assert sub._callback_type == Subscription.CallbackType.MessageOnly
     sub = node.create_subscription(
         msg_type=Empty,
         topic='test_subscription/test_subscription_callback_type/topic',
         qos_profile=10,
         callback=lambda _, _2: None)
-    assert sub.callback_type == Subscription.CallbackType.WithMessageInfo
+    assert sub._callback_type == Subscription.CallbackType.WithMessageInfo
     with pytest.raises(RuntimeError):
         node.create_subscription(
             msg_type=Empty,


### PR DESCRIPTION
The cpp `Subscription.take_message()` was also updated to include `reception_sequence_number`/`publication_sequence_number` in the message info.

This should be merged AFTER the API freeze ends.