### PR TITLE
Update MultiThreadExecutor to catch exceptions

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -752,6 +752,8 @@ class MultiThreadedExecutor(Executor):
             pass
         else:
             self._executor.submit(handler)
+            if handler.exception() is not None:
+                raise handler.exception()
 
     def spin_once(self, timeout_sec: float = None) -> None:
         self._spin_once_impl(timeout_sec)


### PR DESCRIPTION
Currently if one uses MultiThreadExecutor the exceptions raised when spinning are not caught by the executor and thus errors are not properly raised

Signed-off-by: Roey Perfetto <roey.w.perfetto@gmail.com>