### PR TITLE
Expose 'best available' QoS policies

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -362,8 +362,8 @@ class ReliabilityPolicy(QoSPolicyEnum):
     SYSTEM_DEFAULT = 0
     RELIABLE = 1
     BEST_EFFORT = 2
-    BEST_AVAILABLE = 3
-    UNKNOWN = 4
+    UNKNOWN = 3
+    BEST_AVAILABLE = 4
 
 
 # Alias with the old name, for retrocompatibility
@@ -386,8 +386,8 @@ class DurabilityPolicy(QoSPolicyEnum):
     SYSTEM_DEFAULT = 0
     TRANSIENT_LOCAL = 1
     VOLATILE = 2
-    BEST_AVAILABLE = 3
-    UNKNOWN = 4
+    UNKNOWN = 3
+    BEST_AVAILABLE = 4
 
 
 # Alias with the old name, for retrocompatibility
@@ -410,8 +410,8 @@ class LivelinessPolicy(QoSPolicyEnum):
     SYSTEM_DEFAULT = 0
     AUTOMATIC = 1
     MANUAL_BY_TOPIC = 3
-    BEST_AVAILABLE = 4
-    UNKNOWN = 5
+    UNKNOWN = 4
+    BEST_AVAILABLE = 5
 
 
 # Alias with the old name, for retrocompatibility

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -362,7 +362,8 @@ class ReliabilityPolicy(QoSPolicyEnum):
     SYSTEM_DEFAULT = 0
     RELIABLE = 1
     BEST_EFFORT = 2
-    UNKNOWN = 3
+    BEST_AVAILABLE = 3
+    UNKNOWN = 4
 
 
 # Alias with the old name, for retrocompatibility
@@ -385,7 +386,8 @@ class DurabilityPolicy(QoSPolicyEnum):
     SYSTEM_DEFAULT = 0
     TRANSIENT_LOCAL = 1
     VOLATILE = 2
-    UNKNOWN = 3
+    BEST_AVAILABLE = 3
+    UNKNOWN = 4
 
 
 # Alias with the old name, for retrocompatibility
@@ -408,11 +410,24 @@ class LivelinessPolicy(QoSPolicyEnum):
     SYSTEM_DEFAULT = 0
     AUTOMATIC = 1
     MANUAL_BY_TOPIC = 3
-    UNKNOWN = 4
+    BEST_AVAILABLE = 4
+    UNKNOWN = 5
 
 
 # Alias with the old name, for retrocompatibility
 QoSLivelinessPolicy = LivelinessPolicy
+
+# Deadline policy to match the majority of endpoints while being as strict as possible
+# See `RMW_QOS_DEADLINE_BEST_AVAILABLE` in rmw/types.h for more info.
+DeadlineBestAvailable = Duration(nanoseconds=_rclpy.RMW_QOS_DEADLINE_BEST_AVAILABLE)
+
+# Liveliness lease duraiton policy to match the majority of endpoints while being as strict as
+# possible
+# See `RMW_QOS_LIVELINESS_LEASE_DURATION_BEST_AVAILABLE` in rmw/types.h for more info.
+LivelinessLeaseDurationeBestAvailable = Duration(
+    nanoseconds=_rclpy.RMW_QOS_LIVELINESS_LEASE_DURATION_BEST_AVAILABLE
+)
+
 
 # The details of the following profiles can be found at
 # 1. ROS QoS principles:
@@ -440,6 +455,14 @@ qos_profile_parameters = QoSProfile(**_rclpy.rmw_qos_profile_t.predefined(
 #: parameters.
 qos_profile_parameter_events = QoSProfile(**_rclpy.rmw_qos_profile_t.predefined(
     'qos_profile_parameter_events').to_dict())
+#: Match majority of endpoints currently available while maintaining the highest level of service.
+#: Policies are chosen at the time of creating a subscription or publisher.
+#: The middleware is not expected to update policies after creating a subscription or
+#: publisher, even if one or more policies are incompatible with newly discovered endpoints.
+#: Therefore, this profile should be used with care since non-deterministic behavior
+#: can occur due to races with discovery.
+qos_profile_best_available = QoSProfile(**_rclpy.rmw_qos_profile_t.predefined(
+    'qos_profile_best_available').to_dict())
 
 # Separate rcl_action profile defined at
 # ros2/rcl : rcl/rcl_action/include/rcl_action/default_qos.h

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -480,6 +480,7 @@ class QoSPresetProfiles(Enum):
     PARAMETERS = qos_profile_parameters
     PARAMETER_EVENTS = qos_profile_parameter_events
     ACTION_STATUS_DEFAULT = qos_profile_action_status_default
+    BEST_AVAILABLE = qos_profile_best_available
 
     """Noted that the following are duplicated from QoSPolicyEnum.
 

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -73,6 +73,10 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
 
   m.attr("RCL_DEFAULT_DOMAIN_ID") = py::int_(RCL_DEFAULT_DOMAIN_ID);
   m.attr("RMW_DURATION_INFINITE") = py::int_(rmw_time_total_nsec(RMW_DURATION_INFINITE));
+  m.attr("RMW_QOS_DEADLINE_BEST_AVAILABLE") = py::int_(
+    rmw_time_total_nsec(RMW_QOS_DEADLINE_BEST_AVAILABLE));
+  m.attr("RMW_QOS_LIVELINESS_LEASE_DURATION_BEST_AVAILABLE") = py::int_(
+    rmw_time_total_nsec(RMW_QOS_LIVELINESS_LEASE_DURATION_BEST_AVAILABLE));
 
   py::enum_<rcl_clock_change_t>(m, "ClockChange")
   .value(

--- a/rclpy/src/rclpy/qos.cpp
+++ b/rclpy/src/rclpy/qos.cpp
@@ -149,6 +149,9 @@ predefined_qos_profile_from_name(const char * qos_profile_name)
   if (0 == strcmp(qos_profile_name, "qos_profile_parameter_events")) {
     return rmw_qos_profile_parameter_events;
   }
+  if (0 == strcmp(qos_profile_name, "qos_profile_best_available")) {
+    return rmw_qos_profile_best_available;
+  }
 
   std::string error_text = "Requested unknown rmw_qos_profile: ";
   error_text += qos_profile_name;


### PR DESCRIPTION
If users set certain a QoS policy to 'best available', then the middleware will query the graph
for endpoint info before creating a subscription or publisher.
A QoS policy will be selected such that is matches the majority of endpoints while maintaining
the highest level of service possible.

Connects to https://github.com/ros2/rmw/pull/320