### PR TITLE
fix rclpy.shutdown() from hanging when triggered from callback

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -428,7 +428,7 @@ class Executor:
                     # callback group can get executed
 
                     # Catch expected error where calling executor.shutdown()
-                    # from callback causes the GuardCondition to be destroyed 
+                    # from callback causes the GuardCondition to be destroyed
                     try:
                         gc.trigger()
                     except InvalidHandle:

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -190,7 +190,7 @@ class Executor:
         # Task inherits from Future
         return task
 
-    def shutdown(self, timeout_sec: float = 0) -> bool:
+    def shutdown(self, timeout_sec: float = None) -> bool:
         """
         Stop executing callbacks and wait for their completion.
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -85,7 +85,6 @@ class _WorkTracker:
 
         :param timeout_sec: Seconds to wait. Block forever if None or negative. Don't wait if 0
         :type timeout_sec: float or None
-        :param: is_shutdown: if this is a shutdown call
         :rtype: bool True if all work completed
         """
         if timeout_sec is not None and timeout_sec < 0.0:

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -470,7 +470,7 @@ class TestExecutor(unittest.TestCase):
 
         tmr = self.node.create_timer(timer_period, timer_callback)
         executor.add_node(self.node)
-        t = threading.Thread(target=executor.spin_once, daemon=True)
+        t = threading.Thread(target=executor.spin, daemon=True)
         t.start()
         self.assertTrue(shutdown_event.wait(120))
         self.node.destroy_timer(tmr)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -457,7 +457,7 @@ class TestExecutor(unittest.TestCase):
             self.node.destroy_timer(tmr)
 
     def shutdown_executor_from_callback(self):
-        """Test regression of rclpy#944: executor shutdown from callback hangs indefinitely."""
+        """https://github.com/ros2/rclpy/issues/944: allow for executor shutdown from callback."""
         self.assertIsNotNone(self.node.handle)
         timer_period = 0.1
         executor = SingleThreadedExecutor(context=self.context)


### PR DESCRIPTION
This PR closes https://github.com/ros2/rclpy/issues/944 by allowing for a `executor.shutdown` call to happen in a callback. 

A caveat of the proposed approach is that this does raise an `InvalidHandle` but it appears to be harmless and we just catch it. This is what is [currently used](https://github.com/ros2/rclpy/blob/7ffe94865f38c67812799bf5751a8f0f3f918c25/rclpy/rclpy/executors.py#L525-L564) in `rclpy`.  Alternatively we could track whether or not if a `GuardCondition` has been destroyed