### PR TITLE
Change sphinx theme to readthedocs

### DIFF
--- a/rclpy/docs/source/conf.py
+++ b/rclpy/docs/source/conf.py
@@ -32,7 +32,7 @@
 
 
 # -- Project information -----------------------------------------------------
-import sphinx_rtd_theme
+import sphinx_rtd_theme  # noqa : F401
 
 project = 'rclpy'
 copyright = '2016-2022, Open Source Robotics Foundation, Inc.'  # noqa

--- a/rclpy/docs/source/conf.py
+++ b/rclpy/docs/source/conf.py
@@ -32,7 +32,6 @@
 
 
 # -- Project information -----------------------------------------------------
-import sphinx_rtd_theme  # noqa : F401
 
 project = 'rclpy'
 copyright = '2016-2022, Open Source Robotics Foundation, Inc.'  # noqa

--- a/rclpy/docs/source/conf.py
+++ b/rclpy/docs/source/conf.py
@@ -32,6 +32,7 @@
 
 
 # -- Project information -----------------------------------------------------
+import sphinx_rtd_theme
 
 project = 'rclpy'
 copyright = '2016-2022, Open Source Robotics Foundation, Inc.'  # noqa
@@ -58,6 +59,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -93,7 +95,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -48,6 +48,7 @@
   <test_depend>test_msgs</test_depend>
 
   <doc_depend>python3-sphinx</doc_depend>
+  <doc_depend>python3-sphinx-rtd-theme</doc_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
ROS2's sphinx-generated documentation is overwhelmingly in the Read the Docs theme. This PR moves `rclpy` from the current built-in alabaster theme to read the docs. RTD is also (at least in my experience) nicer to use.