### PR TITLE
[Foxy] fix memory leak for get_(publishers|subscriptions)_info_by_topic.

### DIFF
--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -1122,6 +1122,7 @@ _get_info_by_topic(
   if (RCL_RET_OK != fini_ret) {
     PyErr_Format(RCLError, "rcl_topic_endpoint_info_array_fini failed.");
     rcl_reset_error();
+    Py_XDECREF(py_info_array);
     return NULL;
   }
   return py_info_array;

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -371,42 +371,42 @@ _rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic
 
   py_node_name = PyUnicode_FromString(topic_endpoint_info->node_name);
   if (!py_node_name) {
-    goto fail;
+    goto cleanup;
   }
   py_node_namespace = PyUnicode_FromString(topic_endpoint_info->node_namespace);
   if (!py_node_namespace) {
-    goto fail;
+    goto cleanup;
   }
   py_topic_type = PyUnicode_FromString(topic_endpoint_info->topic_type);
   if (!py_topic_type) {
-    goto fail;
+    goto cleanup;
   }
   py_endpoint_type = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_type);
   if (!py_endpoint_type) {
-    goto fail;
+    goto cleanup;
   }
 
   py_endpoint_gid = PyList_New(RMW_GID_STORAGE_SIZE);
   if (!py_endpoint_gid) {
-    goto fail;
+    goto cleanup;
   }
   for (size_t i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
     PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_gid[i]);
     if (!py_val_at_index) {
-      goto fail;
+      goto cleanup;
     }
     PyList_SET_ITEM(py_endpoint_gid, i, py_val_at_index);
   }
 
   py_qos_profile = rclpy_common_convert_to_qos_dict(&topic_endpoint_info->qos_profile);
   if (!py_qos_profile) {
-    goto fail;
+    goto cleanup;
   }
 
   // Create dictionary that represents rmw_topic_endpoint_info_t
   py_endpoint_info_dict = PyDict_New();
   if (!py_endpoint_info_dict) {
-    goto fail;
+    goto cleanup;
   }
   // Populate keyword arguments
   // A success returns 0, and a failure returns -1
@@ -418,19 +418,19 @@ _rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic
   set_result += PyDict_SetItemString(py_endpoint_info_dict, "endpoint_gid", py_endpoint_gid);
   set_result += PyDict_SetItemString(py_endpoint_info_dict, "qos_profile", py_qos_profile);
   if (set_result != 0) {
-    goto fail;
+    Py_DECREF(py_endpoint_info_dict);
+    py_endpoint_info_dict = NULL;
+    goto cleanup;
   }
-  return py_endpoint_info_dict;
 
-fail:
+cleanup:
   Py_XDECREF(py_node_name);
   Py_XDECREF(py_node_namespace);
   Py_XDECREF(py_topic_type);
   Py_XDECREF(py_endpoint_type);
   Py_XDECREF(py_endpoint_gid);
   Py_XDECREF(py_qos_profile);
-  Py_XDECREF(py_endpoint_info_dict);
-  return NULL;
+  return py_endpoint_info_dict;
 }
 
 PyObject *


### PR DESCRIPTION
## Bug report

* Operating System: Ubuntu 20.04.2 LTS (5.8.0-41-generic)
* Version or commit hash: https://github.com/ros2/rclpy/commit/1bebfa252d1314ac636bf31d2a86dbe28f759e0c
* Client library (if applicable): rclpy (foxy)
* Python version: python 3.8

Steps to reproduce issue: 
> Run the below code on env which has lots of topics.

```python
import rclpy
from rclpy.node import Node

class MonitoTopics(Node):

    def __init__(self):
        super().__init__('monitor_topics')
        self._timer = self.create_timer(
            timer_period_sec=1.0, 
            callback=self._monitor_topics)

    def _monitor_topics(self):
        for topic_name, topic_types in self.get_topic_names_and_types():
            del topic_types
            for topic_info in self.get_publishers_info_by_topic(topic_name):
                del topic_info
            for topic_info in self.get_subscriptions_info_by_topic(topic_name):
                del topic_info


def main(args=None):
    rclpy.init(args=args)

    node = MonitoTopics()
    rclpy.spin(node)

    # Destroy the node explicitly
    # (optional - otherwise it will be done automatically
    # when the garbage collector destroys the node object)
    node.destroy_node()
    rclpy.shutdown()


if __name__ == '__main__':
    main()
```

Expected behavior
> Memory usage is stable.

Actual behavior
> Memory usage keeps increasing.

Additional information

On python [c-api doc](https://docs.python.org/3.8/c-api/dict.html#c.PyDict_SetItemString), 
> int PyDict_SetItemString(PyObject *p, const char *key, PyObject *val)
> Insert val into the dictionary p using key as a key. key should be a const char*. The key object is created using 
> PyUnicode_FromString(key). Return 0 on success or -1 on failure. This function does not steal a reference to val.

The caller should handle reference of `val` obj when it succeeded. So we need to decrease reference 
at [this](https://github.com/ros2/rclpy/blob/foxy/rclpy/src/rclpy_common/src/common.c#L423).