### PR TITLE
fix load_parameter_dict_from_yaml test failure on windows

### DIFF
--- a/rclpy/rclpy/parameter_client.py
+++ b/rclpy/rclpy/parameter_client.py
@@ -22,7 +22,6 @@ from rcl_interfaces.srv import GetParameterTypes
 from rcl_interfaces.srv import ListParameters
 from rcl_interfaces.srv import SetParameters
 from rcl_interfaces.srv import SetParametersAtomically
-
 from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
 from rclpy.parameter import Parameter as Parameter
@@ -127,7 +126,6 @@ class AsyncParameterClient:
                 self._describe_parameters_client.wait_for_service,
                 self._set_parameters_atomically_client.wait_for_service,
         ]
-
         if timeout_sec is None:
             return all([fn() for fn in client_wait_fns])
 
@@ -142,21 +140,22 @@ class AsyncParameterClient:
     def list_parameters(
         self,
         prefixes: Optional[List[str]] = None,
-        depth: int = 1,
+        depth: Optional[int] = None,
         callback: Optional[Callable] = None
     ) -> Future:
         """
         List all parameters with given prefixs.
 
         :param prefixes: List of prefixes to filter by.
-        :param depth: Depth of the parameter tree to list.
+        :param depth: Depth of the parameter tree to list. ``None`` means unlimited.
         :param callback: Callback function to call when the request is complete.
         :return: ``Future`` with the result of the request.
         """
         request = ListParameters.Request()
         if prefixes:
             request.prefixes = prefixes
-        request.depth = depth
+        if depth:
+            request.depth = depth
         future = self._list_parameter_client.call_async(request)
         if callback:
             future.add_done_callback(callback)

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from array import array
+import os
 from tempfile import NamedTemporaryFile
 import unittest
 
@@ -225,11 +226,12 @@ class TestParameter(unittest.TestCase):
             'param_str': Parameter('param_str', Parameter.Type.STRING, 'string').to_parameter_msg()
         }
 
-        with NamedTemporaryFile(mode='w') as f:
+        with NamedTemporaryFile(mode='w', delete=False) as f:
             f.write(yaml_string)
             f.flush()
+            f.close()
             parameter_dict = parameter_dict_from_yaml_file(f.name)
-            print(parameter_dict)
+            os.unlink(f.name)
         assert parameter_dict == expected
 
         self.assertRaises(FileNotFoundError, parameter_dict_from_yaml_file, 'unknown_file')


### PR DESCRIPTION
Resolves windows test failure for `load_parameter_dict_from_yaml_file` caused by windows handling of tempfiles. (See: https://github.com/ros2/rclpy/pull/945#issuecomment-1156703563)

I've also bundled in a small fix in this PR to change the default depth of `list_parameters` to the full depth instead of 1 which to me is a saner default. 
