### PR TITLE
name and type in descriptor(s) is ignored via declare_parameter(s).

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -349,6 +349,9 @@ class Node:
         This method, if successful, will result in any callback registered with
         :func:`add_on_set_parameters_callback` to be called.
 
+        The name and type in the given descriptor is ignored, and should be specified using
+        the name argument to this function and the default value's type instead.
+
         :param name: Fully-qualified name of the parameter, including its namespace.
         :param value: Value of the parameter to declare.
         :param descriptor: Descriptor for the parameter to declare.
@@ -381,6 +384,8 @@ class Node:
 
         The tuples in the given parameter list shall contain the name for each parameter,
         optionally providing a value and a descriptor.
+        The name and type in the given descriptors are ignored, and should be specified using
+        the name argument to this function and the default value's type instead.
         For each entry in the list, a parameter with a name of "namespace.name"
         will be declared.
         The resulting value for each declared parameter will be returned, considering


### PR DESCRIPTION
address https://github.com/ros2/rclpy/issues/879

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>