### PR TITLE
[Foxy]: Fix type annotation for get_parameters_by_prefix.

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -20,6 +20,7 @@ from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 from typing import TypeVar
 from typing import Union
@@ -528,7 +529,10 @@ class Node:
 
         return self._parameters.get(name, alternative_value)
 
-    def get_parameters_by_prefix(self, prefix: str) -> List[Parameter]:
+    def get_parameters_by_prefix(self, prefix: str) -> Dict[str, Optional[Union[
+        bool, int, float, str, bytes,
+        Sequence[bool], Sequence[int], Sequence[float], Sequence[str]
+    ]]]:
         """
         Get parameters that have a given prefix in their names as a dictionary.
 


### PR DESCRIPTION
This makes it match Galactic, Humble, and Rolling.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Interestingly, this was fixed in Foxy before: https://github.com/ros2/rclpy/pull/482 .  However, it seems to have been reverted later on in #457 , so this updates the Foxy version with what is in later ROS distributions.