### PR TITLE
Support for pre-set and post-set parameter callback.

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -982,7 +982,7 @@ class Node:
 
     def remove_pre_set_parameters_callback(
             self,
-            callback: Callable[[List[Parameter]], None]
+            callback: Callable[[List[Parameter]], List[Parameter]]
     ) -> None:
         """
         Remove a callback from list of callbacks.

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -740,44 +740,11 @@ class Node:
         :raises: ParameterNotDeclaredException if undeclared parameters are not allowed,
             and at least one parameter in the list hadn't been declared beforehand.
         """
-        return self._set_parameters(parameter_list)
-
-    def _set_parameters(
-        self,
-        parameter_list: List[Parameter],
-        descriptors: Optional[Dict[str, ParameterDescriptor]] = None
-    ) -> List[SetParametersResult]:
-        """
-        Set parameters for the node, and return the result for the set action.
-
-        Method for internal usage; applies a setter method for each parameters in the list.
-        By default it checks if the parameters were declared, raising an exception if at least
-        one of them was not.
-
-        TODO(deepanshu): update this documentation based on new callbacks
-        If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
-        will be called prior to setting the parameters for the node, once for each parameter.
-        If the callback doesn't succeed for a given parameter, it won't be set and either an
-        unsuccessful result will be returned for that parameter, or an exception will be raised
-        according to `raise_on_failure` flag.
-
-        :param parameter_list: List of parameters to set.
-        :param descriptors: Descriptors to set to the given parameters.
-            If descriptors are given, each parameter in the list must have a corresponding one.
-        :return: The result for each set action as a list.
-        :raises: ParameterNotDeclaredException if undeclared parameters are not allowed in this
-            method and at least one parameter in the list hadn't been declared beforehand.
-        """
-        if descriptors is not None:
-            assert all(parameter.name in descriptors for parameter in parameter_list)
-
         results = []
         for param in parameter_list:
-            result = self._set_parameters_atomically(
-                [param],
-                descriptors
-            )
+            result = self._set_parameters_atomically([param])
             results.append(result)
+
         return results
 
     def set_parameters_atomically(self, parameter_list: List[Parameter]) -> SetParametersResult:
@@ -848,6 +815,7 @@ class Node:
             True if they should be stored despite not having an actual value.
         :return: Aggregate result of setting all the parameters atomically.
         """
+        print("## _set_parameters_atomically_common")
 
         if descriptors is not None:
             # If new descriptors are provided, ensure every parameter has an assigned descriptor

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -724,6 +724,7 @@ class Node:
         declared before being set even if they were not declared beforehand.
         Parameter overrides are ignored by this method.
 
+        TODO(deepanshu): update this documentation based on new callbacks
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node, once for each parameter.
         If the callback prevents a parameter from being set, then it will be reflected in the
@@ -753,6 +754,7 @@ class Node:
         By default it checks if the parameters were declared, raising an exception if at least
         one of them was not.
 
+        TODO(deepanshu): update this documentation based on new callbacks
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node, once for each parameter.
         If the callback doesn't succeed for a given parameter, it won't be set and either an
@@ -792,6 +794,7 @@ class Node:
         If undeclared parameters are allowed for the node, then all the parameters will be
         implicitly declared before being set even if they were not declared beforehand.
 
+        TODO(deepanshu): update this documentation based on new callbacks
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node only once for all parameters.
         If the callback prevents the parameters from being set, then it will be reflected in the
@@ -836,6 +839,7 @@ class Node:
         This internal method does not reject undeclared parameters.
         If :param:`allow_not_set_type` is False, a parameter with type NOT_SET will be undeclared.
 
+        TODO(deepanshu): update this documentation based on new callbacks
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node only once for all parameters.
         If the callback prevents the parameters from being set, then it will be reflected in the

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -988,14 +988,24 @@ class Node:
         set by the user. The modified list of parameters is then forwarded to the
         "on set parameter" callback for validation.
 
-        The callback takes a LIST of parameters to be set. This LIST of parameters
-        can further be modified based on the user requirement.
+        The callback takes a list of parameters to be set and returns a list of
+        modified parameters.
 
         One of the use case of "pre set callback" can be updating additional parameters
         conditioned on changes to a parameter.
 
-        Note that once the parameters are modified parameters they will be set atomically.
-        This is because the change of one parameter is conditioned on some other parameter.
+        All parameters in the modified list will be set atomically.
+
+        Note that the callback is only called while setting parameters with `set_parameters`,
+        `set_parameters_atomically`, or externally with a parameters service.
+
+        The callback is not called when parameters are declared with `declare_parameter`
+        or `declare_parameters`.
+
+        The callback is not called when parameters are undeclared with `undeclare_parameter`.
+
+        An empty modified parameter list from the callback will result in "set_parameter*"
+        returning an unsuccessful result.
 
         :param callback: The function that is called before parameters are validated.
         """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -161,7 +161,9 @@ class Node:
         self._guards: List[GuardCondition] = []
         self.__waitables: List[Waitable] = []
         self._default_callback_group = MutuallyExclusiveCallbackGroup()
-        self._parameters_callbacks: List[Callable[[List[Parameter]], SetParametersResult]] = []
+        self._pre_set_parameters_callbacks: List[Callable[[List[Parameter]], None]] = []
+        self._on_set_parameters_callbacks: List[Callable[[List[Parameter]], SetParametersResult]] = []
+        self._post_set_parameters_callbacks: List[Callable[[List[Parameter]], None]] = []
         self._rate_group = ReentrantCallbackGroup()
         self._allow_undeclared_parameters = allow_undeclared_parameters
         self._parameter_overrides = {}
@@ -347,7 +349,8 @@ class Node:
         Declare and initialize a parameter.
 
         This method, if successful, will result in any callback registered with
-        :func:`add_on_set_parameters_callback` to be called.
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback`
+        to be called.
 
         The name and type in the given descriptor is ignored, and should be specified using
         the name argument to this function and the default value's type instead.
@@ -400,9 +403,9 @@ class Node:
         This allows you to declare several parameters at once without a namespace.
 
         This method, if successful, will result in any callback registered with
-        :func:`add_on_set_parameters_callback` to be called once for each parameter.
-        If one of those calls fail, an exception will be raised and the remaining parameters will
-        not be declared.
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback`
+        to be called once for each parameter. If one of those calls fail, an exception
+        will be raised and the remaining parameters will not be declared.
         Parameters declared up to that point will not be undeclared.
 
         :param namespace: Namespace for parameters.
@@ -509,8 +512,9 @@ class Node:
         """
         Undeclare a previously declared parameter.
 
-        This method will not cause a callback registered with
-        :func:`add_on_set_parameters_callback` to be called.
+        This method will not cause a callback registered with any of the
+        :func:`add_pre_set_parameters_callback`, `add_pre_set_parameters_callback`
+        and `add_post_set_parameters_callback`to be called.
 
         :param name: Fully-qualified name of the parameter, including its namespace.
         :raises: ParameterNotDeclaredException if parameter had not been declared before.
@@ -737,7 +741,8 @@ class Node:
             result = self._set_parameters_atomically(
                 [param],
                 descriptors,
-                allow_not_set_type=allow_undeclared_parameters
+                allow_not_set_type=allow_undeclared_parameters,
+                allow_undeclared_parameters=True
             )
             if raise_on_failure and not result.successful:
                 if result.reason.startswith('Wrong parameter type'):
@@ -775,7 +780,6 @@ class Node:
         :raises: ParameterNotDeclaredException if undeclared parameters are not allowed,
             and at least one parameter in the list hadn't been declared beforehand.
         """
-        self._check_undeclared_parameters(parameter_list)
         return self._set_parameters_atomically(parameter_list)
 
     def _check_undeclared_parameters(self, parameter_list: List[Parameter]):
@@ -798,7 +802,8 @@ class Node:
         self,
         parameter_list: List[Parameter],
         descriptors: Optional[Dict[str, ParameterDescriptor]] = None,
-        allow_not_set_type: bool = False
+        allow_not_set_type: bool = False,
+        allow_undeclared_parameters: bool = False
     ) -> SetParametersResult:
         """
         Set the given parameters, all at one time, and then aggregate result.
@@ -818,8 +823,24 @@ class Node:
             If descriptors are given, each parameter in the list must have a corresponding one.
         :param allow_not_set_type: False if parameters with NOT_SET type shall be undeclared,
             True if they should be stored despite not having an actual value.
+        :param allow_undeclared_parameters: If False, this method will check for undeclared
+            parameters for each of the elements in the parameter list.
         :return: Aggregate result of setting all the parameters atomically.
         """
+
+        # call any user registered pre set parameter callbacks
+        # this callback can make changes to the original parameters list
+        # also check if the changed parameter list is empty or not, if empty return
+        if self._call_pre_set_parameters_callback(parameter_list):
+            result = SetParametersResult()
+            result.successful = False
+            result.reason = "parameter list cannot be empty, this might be due to " \
+                            "pre_set_parameters_callback modifying the original parameters list"
+            return result
+
+        if not allow_undeclared_parameters:
+            self._check_undeclared_parameters(parameter_list)
+
         if descriptors is not None:
             # If new descriptors are provided, ensure every parameter has an assigned descriptor
             # and do not check for read-only.
@@ -831,8 +852,8 @@ class Node:
 
         if not result.successful:
             return result
-        elif self._parameters_callbacks:
-            for callback in self._parameters_callbacks:
+        elif self._on_set_parameters_callbacks:
+            for callback in self._on_set_parameters_callbacks:
                 result = callback(parameter_list)
                 if not result.successful:
                     return result
@@ -880,27 +901,75 @@ class Node:
             parameter_event.stamp = self._clock.now().to_msg()
             self._parameter_event_publisher.publish(parameter_event)
 
+            # call post set parameter registered callbacks
+            if self._post_set_parameters_callbacks:
+                for callback in self._post_set_parameters_callbacks:
+                    callback(parameter_event.new_parameters)
+
         return result
 
+    def add_pre_set_parameters_callback(
+            self,
+            callback: Callable[[List[Parameter]], None]
+    ) -> None:
+        """
+        Add a callback gets triggered before parameters are validated.
+
+        This callback can be used to modify the original list of parameters being
+        set by the user. The modified list of parameters is then forwarded to the
+        "on set parameter" callback for validation.
+
+        The callback takes a LIST of parameters to be set. This LIST of parameters
+        can further be modified based on the user requirement.
+
+        One of the use case of "pre set callback" can be updating additional parameters
+        conditioned on changes to a parameter.
+
+        Note that once the parameters are modified parameters they will be set atomically.
+        This is because the change of one parameter is conditioned on some other parameter.
+
+        :param callback: The function that is called before parameters are validated.
+        """
+        self._pre_set_parameters_callbacks.insert(0, callback)
+
     def add_on_set_parameters_callback(
-        self,
-        callback: Callable[[List[Parameter]], SetParametersResult]
+            self,
+            callback: Callable[[List[Parameter]], SetParametersResult]
     ) -> None:
         """
         Add a callback in front to the list of callbacks.
 
-        Calling this function will add a callback in self._parameter_callbacks list.
+        Calling this function will add a callback in self._on_set_parameter_callbacks list.
 
         It is considered bad practice to reject changes for "unknown" parameters as this prevents
         other parts of the node (that may be aware of these parameters) from handling them.
 
-        :param callback: The function that is called whenever parameters are set for the node.
+        :param callback: The function that is called whenever parameters are being validated for the node.
         """
-        self._parameters_callbacks.insert(0, callback)
+        self._on_set_parameters_callbacks.insert(0, callback)
 
-    def remove_on_set_parameters_callback(
-        self,
-        callback: Callable[[List[Parameter]], SetParametersResult]
+    def add_post_set_parameters_callback(
+            self,
+            callback: Callable[[List[Parameter]], None]
+    ) -> None:
+        """
+        Add a callback gets triggered after parameters are set successfully.
+
+        The callback signature is designed to allow handling of the `set_parameter*`
+        or `declare_parameter*` methods. The callback takes a list of parameters that
+        have been set successfully.
+
+        The callback can be valuable as a place to cause side effects based on parameter
+        changes. For instance updating the internally tracked class attributes once the params
+        have been changed successfully.
+
+        :param callback: The function that is called after parameters are set for the node.
+        """
+        self._post_set_parameters_callbacks.insert(0, callback)
+
+    def remove_pre_set_parameters_callback(
+            self,
+            callback: Callable[[List[Parameter]], None]
     ) -> None:
         """
         Remove a callback from list of callbacks.
@@ -910,7 +979,42 @@ class Node:
         :param callback: The function that is called whenever parameters are set for the node.
         :raises: ValueError if a callback is not present in the list of callbacks.
         """
-        self._parameters_callbacks.remove(callback)
+        self._pre_set_parameters_callbacks.remove(callback)
+
+    def remove_on_set_parameters_callback(
+            self,
+            callback: Callable[[List[Parameter]], SetParametersResult]
+    ) -> None:
+        """
+        Remove a callback from list of callbacks.
+
+        Calling this function will remove the callback from self._parameter_callbacks list.
+
+        :param callback: The function that is called whenever parameters are set for the node.
+        :raises: ValueError if a callback is not present in the list of callbacks.
+        """
+        self._on_set_parameters_callbacks.remove(callback)
+
+    def remove_post_set_parameters_callback(
+            self,
+            callback: Callable[[List[Parameter]], None]
+    ) -> None:
+        """
+        Remove a callback from list of callbacks.
+
+        Calling this function will remove the callback from self._parameter_callbacks list.
+
+        :param callback: The function that is called whenever parameters are set for the node.
+        :raises: ValueError if a callback is not present in the list of callbacks.
+        """
+        self._post_set_parameters_callbacks.remove(callback)
+
+    def _call_pre_set_parameters_callback(self, parameter_list):
+        if self._pre_set_parameters_callbacks:
+            for callback in self._pre_set_parameters_callbacks:
+                callback(parameter_list)
+
+        return len(parameter_list) == 0
 
     def _apply_descriptors(
         self,

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -414,8 +414,8 @@ class Node:
         If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
         will be called after setting the parameters successfully for the node, once for each parameter.
 
-        Note: The callbacks registered with func:`add_pre_set_parameters_callback` are not called while
-        declaring the parameters.
+        This method will `not` result in any callbacks registered with :func:`add_pre_set_parameters_callback`
+        to be called.
 
         :param namespace: Namespace for parameters.
         :param parameters: List of tuples with parameters to declare.

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -162,7 +162,8 @@ class Node:
         self.__waitables: List[Waitable] = []
         self._default_callback_group = MutuallyExclusiveCallbackGroup()
         self._pre_set_parameters_callbacks: List[Callable[[List[Parameter]], List[Parameter]]] = []
-        self._on_set_parameters_callbacks: List[Callable[[List[Parameter]], SetParametersResult]] = []
+        self._on_set_parameters_callbacks: \
+            List[Callable[[List[Parameter]], SetParametersResult]] = []
         self._post_set_parameters_callbacks: List[Callable[[List[Parameter]], None]] = []
         self._rate_group = ReentrantCallbackGroup()
         self._allow_undeclared_parameters = allow_undeclared_parameters
@@ -402,20 +403,22 @@ class Node:
         expanding "namespace.name".
         This allows you to declare several parameters at once without a namespace.
 
-        This method will result in any callback registered with :func:`add_on_set_parameters_callback`
-        and :func:`add_post_set_parameters_callback` to be called once for each parameter.
+        This method will result in any callback registered with
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback`
+        to be called once for each parameter.
 
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node, once for each parameter.
-        If one of the calls due to :func:`add_on_set_parameters_callback` fail, an exception will be
-        raised and the remaining parameters will not be declared. Parameters declared up to that point
-        will not be undeclared.
+        If one of the calls due to :func:`add_on_set_parameters_callback` fail, an exception will
+        be raised and the remaining parameters will not be declared. Parameters declared up to that
+        point will not be undeclared.
 
-        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
-        will be called after setting the parameters successfully for the node, once for each parameter.
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`,
+        it will be called after setting the parameters successfully for the node,
+        once for each parameter.
 
-        This method will `not` result in any callbacks registered with :func:`add_pre_set_parameters_callback`
-        to be called.
+        This method will `not` result in any callbacks registered with
+        :func:`add_pre_set_parameters_callback` to be called.
 
         :param namespace: Namespace for parameters.
         :param parameters: List of tuples with parameters to declare.
@@ -527,18 +530,20 @@ class Node:
         By default, it checks if the parameters were declared, raising an exception if at least
         one of them was not.
 
-        This method will result in any callback registered with :func:`add_on_set_parameters_callback`
-        and :func:`add_post_set_parameters_callback` to be called once for each parameter.
+        This method will result in any callback registered with
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback`
+        to be called once for each parameter.
 
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node, once for each parameter.
         If the callback doesn't succeed for a given parameter an exception will be raised.
 
-        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
-        will be called after setting the parameters successfully for the node, once for each parameter.
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`,
+        it will be called after setting the parameters successfully for the node,
+        once for each parameter.
 
-        Note: The callbacks registered with func:`add_pre_set_parameters_callback` are not called while
-        declaring the parameters.
+        This method will `not` result in any callbacks registered with
+        :func:`add_pre_set_parameters_callback` to be called.
 
         :param parameter_list: List of parameters to set.
         :param descriptors: Descriptors to set to the given parameters.
@@ -740,9 +745,9 @@ class Node:
         declared before being set even if they were not declared beforehand.
         Parameter overrides are ignored by this method.
 
-        This method will result in any callback registered with :func:`add_pre_set_parameters_callback`
-        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback` to be
-        called once for each parameter.
+        This method will result in any callback registered with
+        :func:`add_pre_set_parameters_callback`, :func:`add_on_set_parameters_callback` and
+        :func:`add_post_set_parameters_callback` to be called once for each parameter.
 
         If a callback was registered previously with :func:`add_pre_set_parameters_callback`, it
         will be called prior to the validation of parameters for the node, once for each parameter.
@@ -754,8 +759,9 @@ class Node:
         If this callback prevents a parameter from being set, then it will be reflected in the
         returned result; no exceptions will be raised in this case.
 
-        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
-        will be called after setting the parameters successfully for the node, once for each parameter.
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`,
+        it will be called after setting the parameters successfully for the node,
+        once for each parameter.
 
         For each successfully set parameter, a :class:`ParameterEvent` message is
         published.
@@ -789,9 +795,9 @@ class Node:
         If undeclared parameters are allowed for the node, then all the parameters will be
         implicitly declared before being set even if they were not declared beforehand.
 
-        This method will result in any callback registered with :func:`add_pre_set_parameters_callback`
-        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback` to be
-        called only once for all parameters.
+        This method will result in any callback registered with
+        :func:`add_pre_set_parameters_callback` :func:`add_on_set_parameters_callback` and
+        :func:`add_post_set_parameters_callback` to be called only once for all parameters.
 
         If a callback was registered previously with :func:`add_pre_set_parameters_callback`, it
         will be called prior to the validation of node parameters only once for all parameters.
@@ -827,11 +833,12 @@ class Node:
         if modified_parameter_list is not None:
             parameter_list = modified_parameter_list
 
-            if len(parameter_list) is 0:
+            if len(parameter_list) == 0:
                 result = SetParametersResult()
                 result.successful = False
                 result.reason = "parameter list cannot be empty, this might be due to " \
-                                "pre_set_parameters_callback modifying the original parameters list."
+                                "pre_set_parameters_callback modifying the original parameters " \
+                                "list."
                 return result
 
         self._check_undeclared_parameters(parameter_list)
@@ -849,16 +856,18 @@ class Node:
         This internal method does not reject undeclared parameters.
         If :param:`allow_not_set_type` is False, a parameter with type NOT_SET will be undeclared.
 
-        This method will result in any callback registered with :func:`add_on_set_parameters_callback`
-        and :func:`add_post_set_parameters_callback` to be called only once for all parameters.
+        This method will result in any callback registered with
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback`
+        to be called only once for all parameters.
 
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node only once for all parameters.
         If the callback prevents the parameters from being set, then it will be reflected in the
         returned result; no exceptions will be raised in this case.
 
-        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
-        will be called after setting the node parameters successfully only once for all parameters.
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`,
+        it will be called after setting the node parameters successfully only once for all
+        parameters.
 
         For each successfully set parameter, a :class:`ParameterEvent` message is
         published.
@@ -1004,7 +1013,8 @@ class Node:
         It is considered bad practice to reject changes for "unknown" parameters as this prevents
         other parts of the node (that may be aware of these parameters) from handling them.
 
-        :param callback: The function that is called whenever parameters are being validated for the node.
+        :param callback: The function that is called whenever parameters are being validated
+                         for the node.
         """
         self._on_set_parameters_callbacks.insert(0, callback)
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -885,9 +885,7 @@ class Node:
             self._parameter_event_publisher.publish(parameter_event)
 
             # call post set parameter registered callbacks
-            if self._post_set_parameters_callbacks:
-                for callback in self._post_set_parameters_callbacks:
-                    callback(parameter_event.new_parameters)
+            self._call_post_set_parameters_callback(parameter_list)
 
         return result
 
@@ -916,6 +914,11 @@ class Node:
             return modified_parameter_list
         else:
             return None
+
+    def _call_post_set_parameters_callback(self, parameter_list: [List[Parameter]]):
+        if self._post_set_parameters_callbacks:
+            for callback in self._post_set_parameters_callbacks:
+                callback(parameter_list)
 
     def add_pre_set_parameters_callback(
             self,

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -510,13 +510,29 @@ class Node:
         self,
         parameter_list: List[Parameter],
         descriptors: Optional[Dict[str, ParameterDescriptor]] = None
-        ) -> List[SetParametersResult]:
+    ) -> List[SetParametersResult]:
         """
+       Declare parameters for the node, and return the result for the declare action.
 
-        :param parameter_list:
-        :param descriptors:
-        :return:
-        """
+       Method for internal usage; applies a setter method for each parameters in the list.
+       By default, it checks if the parameters were declared, raising an exception if at least
+       one of them was not.
+
+       If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
+       will be called prior to setting the parameters for the node, once for each parameter.
+       If the callback doesn't succeed for a given parameter, it won't be set and either an
+       unsuccessful result will be returned for that parameter, or an exception will be raised
+       according to `raise_on_failure` flag.
+
+       :param parameter_list: List of parameters to set.
+       :param descriptors: Descriptors to set to the given parameters.
+           If descriptors are given, each parameter in the list must have a corresponding one.
+       :return: The result for each set action as a list.
+       :raises: InvalidParameterValueException if the user-defined callback rejects the
+           parameter value.
+       :raises: ParameterNotDeclaredException if undeclared parameters are not allowed in this
+           method and at least one parameter in the list hadn't been declared beforehand.
+       """
         if descriptors is not None:
             assert all(parameter.name in descriptors for parameter in parameter_list)
 
@@ -725,8 +741,6 @@ class Node:
         """
         return self._set_parameters(parameter_list)
 
-    # raise_on_failure -> True only for declare param
-    # allow_undeclared_parameters -> true only for declare param
     def _set_parameters(
         self,
         parameter_list: List[Parameter],
@@ -749,8 +763,6 @@ class Node:
         :param descriptors: Descriptors to set to the given parameters.
             If descriptors are given, each parameter in the list must have a corresponding one.
         :return: The result for each set action as a list.
-        :raises: InvalidParameterValueException if the user-defined callback rejects the
-            parameter value and raise_on_failure flag is True.
         :raises: ParameterNotDeclaredException if undeclared parameters are not allowed in this
             method and at least one parameter in the list hadn't been declared beforehand.
         """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -836,9 +836,9 @@ class Node:
             if len(parameter_list) == 0:
                 result = SetParametersResult()
                 result.successful = False
-                result.reason = "parameter list cannot be empty, this might be due to " \
-                                "pre_set_parameters_callback modifying the original parameters " \
-                                "list."
+                result.reason = 'parameter list cannot be empty, this might be due to ' \
+                                'pre_set_parameters_callback modifying the original parameters ' \
+                                'list.'
                 return result
 
         self._check_undeclared_parameters(parameter_list)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -402,11 +402,20 @@ class Node:
         expanding "namespace.name".
         This allows you to declare several parameters at once without a namespace.
 
-        This method, if successful, will result in any callback registered with
-        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback`
-        to be called once for each parameter. If one of those calls fail, an exception
-        will be raised and the remaining parameters will not be declared.
-        Parameters declared up to that point will not be undeclared.
+        This method will result in any callback registered with :func:`add_on_set_parameters_callback`
+        and :func:`add_post_set_parameters_callback` to be called once for each parameter.
+
+        If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
+        will be called prior to setting the parameters for the node, once for each parameter.
+        If one of the calls due to :func:`add_on_set_parameters_callback` fail, an exception will be
+        raised and the remaining parameters will not be declared. Parameters declared up to that point
+        will not be undeclared.
+
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
+        will be called after setting the parameters successfully for the node, once for each parameter.
+
+        Note: The callbacks registered with func:`add_pre_set_parameters_callback` are not called while
+        declaring the parameters.
 
         :param namespace: Namespace for parameters.
         :param parameters: List of tuples with parameters to declare.
@@ -512,27 +521,34 @@ class Node:
         descriptors: Optional[Dict[str, ParameterDescriptor]] = None
     ) -> List[SetParametersResult]:
         """
-       Declare parameters for the node, and return the result for the declare action.
+      ` Declare parameters for the node, and return the result for the declare action.
 
-       Method for internal usage; applies a setter method for each parameters in the list.
-       By default, it checks if the parameters were declared, raising an exception if at least
-       one of them was not.
+        Method for internal usage; applies a setter method for each parameters in the list.
+        By default, it checks if the parameters were declared, raising an exception if at least
+        one of them was not.
 
-       If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
-       will be called prior to setting the parameters for the node, once for each parameter.
-       If the callback doesn't succeed for a given parameter, it won't be set and either an
-       unsuccessful result will be returned for that parameter, or an exception will be raised
-       according to `raise_on_failure` flag.
+        This method will result in any callback registered with :func:`add_on_set_parameters_callback`
+        and :func:`add_post_set_parameters_callback` to be called once for each parameter.
 
-       :param parameter_list: List of parameters to set.
-       :param descriptors: Descriptors to set to the given parameters.
+        If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
+        will be called prior to setting the parameters for the node, once for each parameter.
+        If the callback doesn't succeed for a given parameter an exception will be raised.
+
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
+        will be called after setting the parameters successfully for the node, once for each parameter.
+
+        Note: The callbacks registered with func:`add_pre_set_parameters_callback` are not called while
+        declaring the parameters.
+
+        :param parameter_list: List of parameters to set.
+        :param descriptors: Descriptors to set to the given parameters.
            If descriptors are given, each parameter in the list must have a corresponding one.
-       :return: The result for each set action as a list.
-       :raises: InvalidParameterValueException if the user-defined callback rejects the
-           parameter value.
-       :raises: ParameterNotDeclaredException if undeclared parameters are not allowed in this
-           method and at least one parameter in the list hadn't been declared beforehand.
-       """
+        :return: The result for each set action as a list.
+        :raises: InvalidParameterValueException if the user-defined callback rejects the
+            parameter value.
+        :raises: ParameterNotDeclaredException if undeclared parameters are not allowed in this
+            method and at least one parameter in the list hadn't been declared beforehand.`
+        """
         if descriptors is not None:
             assert all(parameter.name in descriptors for parameter in parameter_list)
 
@@ -724,11 +740,23 @@ class Node:
         declared before being set even if they were not declared beforehand.
         Parameter overrides are ignored by this method.
 
-        TODO(deepanshu): update this documentation based on new callbacks
+        This method will result in any callback registered with :func:`add_pre_set_parameters_callback`
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback` to be
+        called once for each parameter.
+
+        If a callback was registered previously with :func:`add_pre_set_parameters_callback`, it
+        will be called prior to the validation of parameters for the node, once for each parameter.
+        If this callback makes modified parameter list empty, then it will be reflected in the
+        returned result; no exceptions will be raised in this case.
+
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node, once for each parameter.
-        If the callback prevents a parameter from being set, then it will be reflected in the
+        If this callback prevents a parameter from being set, then it will be reflected in the
         returned result; no exceptions will be raised in this case.
+
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
+        will be called after setting the parameters successfully for the node, once for each parameter.
+
         For each successfully set parameter, a :class:`ParameterEvent` message is
         published.
 
@@ -761,11 +789,23 @@ class Node:
         If undeclared parameters are allowed for the node, then all the parameters will be
         implicitly declared before being set even if they were not declared beforehand.
 
-        TODO(deepanshu): update this documentation based on new callbacks
+        This method will result in any callback registered with :func:`add_pre_set_parameters_callback`
+        :func:`add_on_set_parameters_callback` and :func:`add_post_set_parameters_callback` to be
+        called only once for all parameters.
+
+        If a callback was registered previously with :func:`add_pre_set_parameters_callback`, it
+        will be called prior to the validation of node parameters only once for all parameters.
+        If this callback makes modified parameter list empty, then it will be reflected in the
+        returned result; no exceptions will be raised in this case.
+
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node only once for all parameters.
         If the callback prevents the parameters from being set, then it will be reflected in the
         returned result; no exceptions will be raised in this case.
+
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
+        will be called after setting the node parameters successfully only once for all parameters.
+
         For each successfully set parameter, a :class:`ParameterEvent` message is published.
 
         If the value type of the parameter is NOT_SET, and the existing parameter type is
@@ -809,11 +849,17 @@ class Node:
         This internal method does not reject undeclared parameters.
         If :param:`allow_not_set_type` is False, a parameter with type NOT_SET will be undeclared.
 
-        TODO(deepanshu): update this documentation based on new callbacks
+        This method will result in any callback registered with :func:`add_on_set_parameters_callback`
+        and :func:`add_post_set_parameters_callback` to be called only once for all parameters.
+
         If a callback was registered previously with :func:`add_on_set_parameters_callback`, it
         will be called prior to setting the parameters for the node only once for all parameters.
         If the callback prevents the parameters from being set, then it will be reflected in the
         returned result; no exceptions will be raised in this case.
+
+        If a callback was registered previously with :func:`add_post_set_parameters_callback`, it
+        will be called after setting the node parameters successfully only once for all parameters.
+
         For each successfully set parameter, a :class:`ParameterEvent` message is
         published.
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -524,7 +524,7 @@ class Node:
         descriptors: Optional[Dict[str, ParameterDescriptor]] = None
     ) -> List[SetParametersResult]:
         """
-      ` Declare parameters for the node, and return the result for the declare action.
+        Declare parameters for the node, and return the result for the declare action.
 
         Method for internal usage; applies a setter method for each parameters in the list.
         By default, it checks if the parameters were declared, raising an exception if at least

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -390,6 +390,14 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         finally:
             node.destroy_node()
 
+    def modify_parameter_callback(self, parameters_list: List[Parameter]):
+        modified_list = parameters_list
+        for param in parameters_list:
+            if param.name == 'foo':
+                modified_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))
+
+        return modified_list
+
     def test_node_set_parameters(self):
         results = self.node.set_parameters([
             Parameter('foo', Parameter.Type.INTEGER, 42),
@@ -410,21 +418,17 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         # that parameter has not been declared will not throw if undeclared
         # parameters are allowed
 
-        def pre_set_callback(parameters_list: List[Parameter]):
-            for param in parameters_list:
-                if param.name == 'foo':
-                    parameters_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))
+        self.node.add_pre_set_parameters_callback(self.modify_parameter_callback)
+        results = self.node.set_parameters([
+            Parameter('foo', Parameter.Type.INTEGER, 42),
+            Parameter('baz', Parameter.Type.DOUBLE, 2.41)
+        ])
 
-        self.node.add_pre_set_parameters_callback(pre_set_callback)
-        #
-        # results = self.node.set_parameters([
-        #     Parameter('foo', Parameter.Type.INTEGER, 42),
-        #     Parameter('baz', Parameter.Type.DOUBLE, 2.41)
-        # ])
+        self.node.remove_pre_set_parameters_callback(self.modify_parameter_callback)
 
-        # self.assertEqual(2, len(results))
-        # self.assertTrue(all(isinstance(result, SetParametersResult) for result in results))
-        # self.assertTrue(all(result.successful for result in results))
+        self.assertEqual(2, len(results))
+        self.assertTrue(all(isinstance(result, SetParametersResult) for result in results))
+        self.assertTrue(all(result.successful for result in results))
         self.assertTrue(self.node.has_parameter('foo'))
         self.assertTrue(self.node.has_parameter('bar'))
         self.assertTrue(self.node.has_parameter('baz'))
@@ -446,24 +450,24 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertIsInstance(result, SetParametersResult)
         self.assertTrue(result.successful)
 
-    def test_node_set_parameters_atomically_add_pre_set_parameter_callback(self):
+        self.node.undeclare_parameter('foo')
+        self.node.undeclare_parameter('bar')
+        self.node.undeclare_parameter('baz')
+
         # adding a parameter using func: "add_pre_set parameter" callback,
         # when that parameter has not been declared will not throw if undeclared
         # parameters are allowed
 
-        def pre_set_callback(parameters_list: List[Parameter]):
-            for param in parameters_list:
-                if param.name == 'foo':
-                    parameters_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))
+        self.node.add_pre_set_parameters_callback(self.modify_parameter_callback)
 
-        self.node.add_pre_set_parameters_callback(pre_set_callback)
-        #
-        # result = self.node.set_parameters_atomically([
-        #     Parameter('foo', Parameter.Type.INTEGER, 42),
-        #     Parameter('baz', Parameter.Type.DOUBLE, 2.41)
-        # ])
+        result = self.node.set_parameters_atomically([
+            Parameter('foo', Parameter.Type.INTEGER, 42),
+            Parameter('baz', Parameter.Type.DOUBLE, 2.41)
+        ])
 
-        # self.assertEqual(True, result.successful)
+        self.node.remove_pre_set_parameters_callback(self.modify_parameter_callback)
+
+        self.assertEqual(True, result.successful)
         self.assertTrue(self.node.has_parameter('foo'))
         self.assertTrue(self.node.has_parameter('bar'))
         self.assertTrue(self.node.has_parameter('baz'))
@@ -1139,6 +1143,40 @@ class TestNode(unittest.TestCase):
         self.assertIsInstance(result[2], SetParametersResult)
         self.assertTrue(result[2].successful)
 
+    def modify_parameter_callback(self, parameter_list: List[Parameter]):
+        modified_list = parameter_list
+        for param in parameter_list:
+            if param.name == 'foo':
+                modified_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))
+
+        return modified_list
+
+    def empty_parameter_callback(self, parameter_list: List[Parameter]):
+        return []
+
+    def test_add_remove_pre_set_parameter_callback(self):
+        callbacks = [self.modify_parameter_callback, self.empty_parameter_callback]
+
+        for callback in callbacks:
+            self.node.add_pre_set_parameters_callback(callback)
+            self.assertTrue(callback in self.node._pre_set_parameters_callbacks)
+        for callback in callbacks:
+            self.node.remove_pre_set_parameters_callback(callback)
+            self.assertFalse(callback in self.node._pre_set_parameters_callbacks)
+
+        self.node.declare_parameter('foo', 0)
+        self.node.declare_parameter('bar', '')
+        self.node.add_pre_set_parameters_callback(self.modify_parameter_callback)
+        results = self.node.set_parameters([Parameter('foo', Parameter.Type.INTEGER, 42)])
+
+        # param 'bar' should be modified because of registered callback
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].successful)
+        self.assertTrue(self.node.has_parameter('foo'))
+        self.assertTrue(self.node.has_parameter('bar'))
+        self.assertTrue(self.node.get_parameter('foo').value == 42)
+        self.assertTrue(self.node.get_parameter('bar').value == 'hello')
+
     def test_node_add_on_set_parameter_callback(self):
         # Add callbacks to the list of callbacks.
         callbacks = [
@@ -1180,55 +1218,6 @@ class TestNode(unittest.TestCase):
         self.assertTrue(result[0].successful)
         self.assertIsInstance(result[1], SetParametersResult)
         self.assertTrue(result[1].successful)
-
-    def test_add_remove_pre_set_parameter_callback(self):
-        def pre_set_param_append_callback(parameter_list: List[Parameter]):
-            for param in parameter_list:
-                if param.name == 'foo':
-                    parameter_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))
-
-        def pre_set_param_empty_callback(parameter_list: List[Parameter]):
-            for param in parameter_list:
-                if param.name == 'foo':
-                    parameter_list = []
-            pass
-
-        callbacks = [
-            pre_set_param_empty_callback,
-            pre_set_param_append_callback]
-
-        for callback in callbacks:
-            self.node.add_pre_set_parameters_callback(callback)
-        for callback in callbacks:
-            self.assertTrue(callback in self.node._pre_set_parameters_callbacks)
-        for callback in callbacks:
-            self.node.remove_pre_set_parameters_callback(callback)
-
-        # adding a parameter using "add_pre_set_parameter" callback, when that
-        # parameter has not been declared before will throw.
-
-        # parameter 'bar' not declared here, only declare 'foo'
-        default_value = 0
-        self.node.declare_parameter('foo', 0)
-        self.node.add_pre_set_parameters_callback(pre_set_param_append_callback)
-
-        with self.assertRaises(ParameterNotDeclaredException):
-            self.node.set_parameters([
-                Parameter('foo', Parameter.Type.INTEGER, 42)])
-        self.assertTrue(self.node.has_parameter('foo'))
-        self.assertEqual(self.node.get_parameter('foo').value, default_value)
-        self.assertFalse(self.node.has_parameter('bar'))
-
-        self.node.remove_pre_set_parameters_callback(pre_set_param_append_callback)
-
-        # An empty list from  'add_pre_set_parameter' callback will return
-        # an unsuccessful result
-        self.node.add_pre_set_parameters_callback(pre_set_param_empty_callback)
-        results = self.node.set_parameters([Parameter('foo', Parameter.Type.INTEGER, 42)])
-        # self.assertFalse(results[0].successful)
-
-    def test_add_remove_post_set_parameter_callback(self):
-        pass
 
     def test_node_remove_from_set_callback(self):
         # Remove callbacks from list of callbacks.
@@ -1275,6 +1264,20 @@ class TestNode(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertIsInstance(result[0], SetParametersResult)
         self.assertTrue(result[0].successful)
+
+    def test_add_remove_post_set_parameter_callback(self):
+        pass
+        # # Add callbacks to the list of callbacks.
+        # callbacks = [
+        #     self.reject_parameter_callback,
+        #     self.reject_parameter_callback_1
+        # ]
+        # for callback in callbacks:
+        #     self.node.add_on_set_parameters_callback(callback)
+        # for callback in callbacks:
+        #     self.assertTrue(callback in self.node._on_set_parameters_callbacks)
+        # for callback in callbacks:
+        #     self.node.remove_on_set_parameters_callback(callback)
 
     def test_node_set_parameters_read_only(self):
         integer_value = 42
@@ -1351,6 +1354,33 @@ class TestNode(unittest.TestCase):
         self.assertEqual(self.node.get_parameter('immutable_foo').value, 42)
         self.assertEqual(self.node.get_parameter('bar').value, 'bye')
         self.assertEqual(self.node.get_parameter('immutable_baz').value, 2.41)
+
+    def test_node_set_parameters_pre_set_parameter_callback(self):
+        # parameter 'bar' not declared here, only declare 'foo'
+        default_value = 0
+        self.node.declare_parameter('foo', default_value)
+        self.node.add_pre_set_parameters_callback(self.modify_parameter_callback)
+
+        # adding a parameter using "add_pre_set_parameter" callback, when that
+        # parameter has not been declared before will throw.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_parameters([
+                Parameter('foo', Parameter.Type.INTEGER, 42)])
+        self.assertTrue(self.node.has_parameter('foo'))
+        self.assertEqual(self.node.get_parameter('foo').value, default_value)
+        self.assertFalse(self.node.has_parameter('bar'))
+
+        self.node.remove_pre_set_parameters_callback(self.modify_parameter_callback)
+
+        # An empty list from  'add_pre_set_parameter' callback will return
+        # an unsuccessful result
+        self.node.add_pre_set_parameters_callback(self.empty_parameter_callback)
+        results = self.node.set_parameters([Parameter('foo', Parameter.Type.INTEGER, 42)])
+
+        self.assertFalse(results[0].successful)
+        self.assertTrue(self.node.has_parameter('foo'))
+        self.assertTrue(self.node.get_parameter('foo').value == default_value)
+        self.assertFalse(self.node.has_parameter('bar'))
 
     def test_node_set_parameters_implicit_undeclare(self):
         parameter_tuples = [

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1266,18 +1266,43 @@ class TestNode(unittest.TestCase):
         self.assertTrue(result[0].successful)
 
     def test_add_remove_post_set_parameter_callback(self):
-        pass
-        # # Add callbacks to the list of callbacks.
-        # callbacks = [
-        #     self.reject_parameter_callback,
-        #     self.reject_parameter_callback_1
-        # ]
-        # for callback in callbacks:
-        #     self.node.add_on_set_parameters_callback(callback)
-        # for callback in callbacks:
-        #     self.assertTrue(callback in self.node._on_set_parameters_callbacks)
-        # for callback in callbacks:
-        #     self.node.remove_on_set_parameters_callback(callback)
+        def successful_parameter_set_callback(parameter_list: List[Parameter]):
+            for param in parameter_list:
+                if param.name == 'param1':
+                    self.track_value1 = param.value
+                elif param.name == 'param2':
+                    self.track_value2 = param.value
+
+        callbacks = [successful_parameter_set_callback]
+
+        for callback in callbacks:
+            self.node.add_post_set_parameters_callback(callback)
+            self.assertTrue(callback in self.node._post_set_parameters_callbacks)
+        for callback in callbacks:
+            self.node.remove_post_set_parameters_callback(callback)
+            self.assertFalse(callback in self.node._post_set_parameters_callbacks)
+
+        self.node.declare_parameter('param1', 0.0)
+        self.node.declare_parameter('param2', 0.0)
+
+        self.track_value1 = self.node.get_parameter('param1')
+        self.track_value2 = self.node.get_parameter('param2')
+
+        self.node.add_post_set_parameters_callback(successful_parameter_set_callback)
+        results = self.node.set_parameters([Parameter('param1', Parameter.Type.DOUBLE, 1.0),
+                                            Parameter('param2', Parameter.Type.DOUBLE, 2.0)])
+
+        # 'track_value1' and 'track_value2' should be updated to
+        # 'param1' and 'param2' value respectively.
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0].successful)
+        self.assertTrue(results[1].successful)
+        self.assertTrue(self.node.has_parameter('param1'))
+        self.assertTrue(self.node.has_parameter('param2'))
+        self.assertEqual(self.node.get_parameter('param1').value, 1.0)
+        self.assertEqual(self.node.get_parameter('param2').value, 2.0)
+        self.assertTrue(self.track_value1 == 1.0)
+        self.assertTrue(self.track_value2 == 2.0)
 
     def test_node_set_parameters_read_only(self):
         integer_value = 42
@@ -1507,6 +1532,33 @@ class TestNode(unittest.TestCase):
         # Confirm that the fourth one does not exist.
         with self.assertRaises(ParameterNotDeclaredException):
             self.node.get_parameter('foobar')
+
+    def test_node_set_parameters_atomically_pre_set_parameter_callback(self):
+        # parameter 'bar' not declared here, only declare 'foo'
+        default_value = 0
+        self.node.declare_parameter('foo', default_value)
+        self.node.add_pre_set_parameters_callback(self.modify_parameter_callback)
+
+        # adding a parameter using "add_pre_set_parameter" callback, when that
+        # parameter has not been declared before will throw.
+        with self.assertRaises(ParameterNotDeclaredException):
+            self.node.set_parameters_atomically([
+                Parameter('foo', Parameter.Type.INTEGER, 42)])
+        self.assertTrue(self.node.has_parameter('foo'))
+        self.assertEqual(self.node.get_parameter('foo').value, default_value)
+        self.assertFalse(self.node.has_parameter('bar'))
+
+        self.node.remove_pre_set_parameters_callback(self.modify_parameter_callback)
+
+        # An empty list from  'add_pre_set_parameter' callback will return
+        # an unsuccessful result
+        self.node.add_pre_set_parameters_callback(self.empty_parameter_callback)
+        result = self.node.set_parameters_atomically([Parameter('foo', Parameter.Type.INTEGER, 42)])
+
+        self.assertFalse(result.successful)
+        self.assertTrue(self.node.has_parameter('foo'))
+        self.assertTrue(self.node.get_parameter('foo').value == default_value)
+        self.assertFalse(self.node.has_parameter('bar'))
 
     def test_node_set_parameters_atomically_rejection(self):
         # Declare a new parameter and set a callback so that it's rejected when set.

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -391,7 +391,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             node.destroy_node()
 
     def modify_parameter_callback(self, parameters_list: List[Parameter]):
-        modified_list = parameters_list
+        modified_list = parameters_list.copy()
         for param in parameters_list:
             if param.name == 'foo':
                 modified_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))
@@ -1144,7 +1144,7 @@ class TestNode(unittest.TestCase):
         self.assertTrue(result[2].successful)
 
     def modify_parameter_callback(self, parameter_list: List[Parameter]):
-        modified_list = parameter_list
+        modified_list = parameter_list.copy()
         for param in parameter_list:
             if param.name == 'foo':
                 modified_list.append(Parameter('bar', Parameter.Type.STRING, 'hello'))

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -1250,7 +1250,8 @@ class TestNode(unittest.TestCase):
         self.assertFalse(result[0].successful)
         # Removing the callback which is causing the rejection.
         self.node.remove_on_set_parameters_callback(self.reject_parameter_callback_1)
-        self.assertFalse(self.reject_parameter_callback_1 in self.node._on_set_parameters_callbacks)
+        self.assertFalse(self.reject_parameter_callback_1 in
+                         self.node._on_set_parameters_callbacks)
         # Now the setting its value again.
         result = self.node.set_parameters(
             [
@@ -1553,7 +1554,8 @@ class TestNode(unittest.TestCase):
         # An empty list from  'add_pre_set_parameter' callback will return
         # an unsuccessful result
         self.node.add_pre_set_parameters_callback(self.empty_parameter_callback)
-        result = self.node.set_parameters_atomically([Parameter('foo', Parameter.Type.INTEGER, 42)])
+        result = self.node.set_parameters_atomically(
+                      [Parameter('foo', Parameter.Type.INTEGER, 42)])
 
         self.assertFalse(result.successful)
         self.assertTrue(self.node.has_parameter('foo'))


### PR DESCRIPTION
This PR supports adding new parameters registered callbacks namely `pre_set_parameter` and `post_set_parameter` callback to node API. Full description can be found in rclcpp version of the PR here https://github.com/ros2/rclcpp/pull/1947

**Design document:** https://github.com/ros2/rclcpp/blob/deepanshu/local-param-changed-callback-support/rclcpp/doc/proposed_node_parameter_callbacks.md
**Demo node:** https://github.com/ros2/demos/pull/565
**rclcpp ticket:**  https://github.com/ros2/rclcpp/pull/1947
**Related discussion:** https://github.com/ros2/rclcpp/issues/1190, https://github.com/ros2/rclcpp/issues/609

Signed-off-by: deepanshu [deepanshubansal01@gmail.com](mailto:deepanshubansal01@gmail.com)