### PR TITLE
Enable limited use of asyncio with executors

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -159,6 +159,7 @@ if(BUILD_TESTING)
       test/test_action_client.py
       test/test_action_graph.py
       test/test_action_server.py
+      test/test_asyncio_interop.py
       test/test_callback_group.py
       test/test_client.py
       test/test_clock.py

--- a/rclpy/test/test_asyncio_interop.py
+++ b/rclpy/test/test_asyncio_interop.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+
+import pytest
+
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+
+
+MAX_TEST_TIME = 5.0
+TIME_FUDGE_FACTOR = 0.2
+
+
+@pytest.fixture
+def node_and_executor():
+    rclpy.init()
+    node = rclpy.create_node('test_asyncio_interop')
+    executor = SingleThreadedExecutor()
+    executor.add_node(node)
+    yield node, executor
+    executor.shutdown()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+def test_sleep_in_event_loop(node_and_executor):
+    node, executor = node_and_executor
+
+    expected_sleep_time = 0.5
+    sleep_time = None
+
+    async def cb():
+        nonlocal sleep_time
+        start = time.monotonic()
+        await asyncio.sleep(expected_sleep_time)
+        end = time.monotonic()
+        sleep_time = end - start
+
+    guard = node.create_guard_condition(cb)
+    guard.trigger()
+
+    async def spin():
+        nonlocal sleep_time
+        start = time.monotonic()
+        while not sleep_time and MAX_TEST_TIME > time.monotonic() - start:
+            executor.spin_once(timeout_sec=0)
+            # Don't use 100% CPU
+            await asyncio.sleep(0.01)
+
+    asyncio.run(spin())
+    assert sleep_time >= expected_sleep_time
+    assert abs(expected_sleep_time - sleep_time) <= expected_sleep_time * TIME_FUDGE_FACTOR

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import threading
 import time
 import unittest
@@ -157,25 +156,15 @@ class TestExecutor(unittest.TestCase):
         executor.add_node(self.node)
 
         called1 = False
-        called2 = False
 
         async def coroutine():
             nonlocal called1
-            nonlocal called2
             called1 = True
-            await asyncio.sleep(0)
-            called2 = True
 
         tmr = self.node.create_timer(0.1, coroutine)
         try:
             executor.spin_once(timeout_sec=1.23)
             self.assertTrue(called1)
-            self.assertFalse(called2)
-
-            called1 = False
-            executor.spin_once(timeout_sec=0)
-            self.assertFalse(called1)
-            self.assertTrue(called2)
         finally:
             self.node.destroy_timer(tmr)
 
@@ -185,26 +174,16 @@ class TestExecutor(unittest.TestCase):
         executor.add_node(self.node)
 
         called1 = False
-        called2 = False
 
         async def coroutine():
             nonlocal called1
-            nonlocal called2
             called1 = True
-            await asyncio.sleep(0)
-            called2 = True
 
         gc = self.node.create_guard_condition(coroutine)
         try:
             gc.trigger()
             executor.spin_once(timeout_sec=0)
             self.assertTrue(called1)
-            self.assertFalse(called2)
-
-            called1 = False
-            executor.spin_once(timeout_sec=1)
-            self.assertFalse(called1)
-            self.assertTrue(called2)
         finally:
             self.node.destroy_guard_condition(gc)
 

--- a/rclpy/test/test_guard_condition.py
+++ b/rclpy/test/test_guard_condition.py
@@ -26,14 +26,18 @@ class TestGuardCondition(unittest.TestCase):
         rclpy.init(context=cls.context)
         cls.node = rclpy.create_node(
             'TestGuardCondition', namespace='/rclpy/test', context=cls.context)
-        cls.executor = SingleThreadedExecutor(context=cls.context)
-        cls.executor.add_node(cls.node)
 
     @classmethod
     def tearDownClass(cls):
-        cls.executor.shutdown()
         cls.node.destroy_node()
         rclpy.shutdown(context=cls.context)
+
+    def setUp(self):
+        self.executor = SingleThreadedExecutor(context=self.context)
+        self.executor.add_node(self.node)
+
+    def tearDown(self):
+        self.executor.shutdown()
 
     def test_trigger(self):
         called = False


### PR DESCRIPTION
Resolves #962
Alternative to #963

This enables limited use of asyncio primitives with the rclpy executor. The most important parts are the changes to how `Future` instances handle `__await__` and how `Task` instances get scheduled. They allow `Task` to tell when an `asyncio` future is `await`ed, and they allow `Task` to pause itself until the asyncio future completes. A consequence of this is `Task` now requires an executor.

There are limitations coming from asyncio not being thread safe.
* There must be an asyncio event loop running
* A single threaded executor must be used, and that executor must spin periodically in the same thread as asyncio's event loop

Changes
* rclpy `Future.__await__` yields itself instead of `None` - this allows `Task` to know if an rclpy Future is being awaited
* Add `Executor.call_soon()` - This is like `create_task()`, but if the callback is already a task then it won't create one. The naming is taking from asyncio
* `Executor._tasks` is cleared every time tasks are run. `Task` instances schedule themselves when they become unblocked.
* If `Task` detects it's waiting on an asyncio future, then it will make the asyncio future schedule the `Task` when it's done
* Some tests had `asyncio.sleep(0)` in them already, but didn't create an asycnio event loop. Those uses have been removed.
* I removed `Task._lock` because it should never run in parallel now that it schedules itself.
* I removed `Task.executing()` because it would have needed the `Task._lock`, and wasn't used anywhere else.