### PR TITLE
Service introspection

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -95,6 +95,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/serialization.cpp
   src/rclpy/service.cpp
   src/rclpy/service_info.cpp
+  src/rclpy/service_introspection.cpp
   src/rclpy/signal_handler.cpp
   src/rclpy/subscription.cpp
   src/rclpy/time_point.cpp

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -143,7 +143,8 @@ def create_node(
     start_parameter_services: bool = True,
     parameter_overrides: List[Parameter] = None,
     allow_undeclared_parameters: bool = False,
-    automatically_declare_parameters_from_overrides: bool = False
+    automatically_declare_parameters_from_overrides: bool = False,
+    enable_service_introspection: bool = False,
 ) -> 'Node':
     """
     Create an instance of :class:`.Node`.
@@ -165,6 +166,7 @@ def create_node(
         This option doesn't affect `parameter_overrides`.
     :param automatically_declare_parameters_from_overrides: If True, the "parameter overrides" will
         be used to implicitly declare parameters on the node during creation, default False.
+    :param enable_service_introspection: Flag to enable service introspection, default False.
     :return: An instance of the newly created node.
     """
     # imported locally to avoid loading extensions on module import
@@ -178,7 +180,8 @@ def create_node(
         allow_undeclared_parameters=allow_undeclared_parameters,
         automatically_declare_parameters_from_overrides=(
             automatically_declare_parameters_from_overrides
-        ))
+        ),
+        enable_service_introspection=enable_service_introspection)
 
 
 def spin_once(node: 'Node', *, executor: 'Executor' = None, timeout_sec: float = None) -> None:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -240,7 +240,7 @@ class Node:
                 namespace='',
                 parameters=[
                     (_rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER, True, ParameterDescriptor()),
-                    (_rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER, True, ParameterDescriptor()),
+                    (_rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_PARAMETER, True, ParameterDescriptor()),
                     (_rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_EVENT_CONTENT_PARAMETER, True, ParameterDescriptor()),
                     (_rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_EVENT_CONTENT_PARAMETER, True, ParameterDescriptor())
                 ])
@@ -1594,27 +1594,27 @@ class Node:
     def _configure_service_introspection(self, parameters: List[Parameter]):
         for param in parameters:
             if param.name == _rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER:
-                for srv in self.services:
-                    _rclpy.service_introspection.configure_service_events(
-                        srv.handle.pointer(),
-                        self.handle.pointer(),
-                        param.value)
-            elif param.name == _rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER:
-                for cli in self.clients:
+                for srv in self.clients:
                     _rclpy.service_introspection.configure_client_events(
-                        cli.handle.pointer(),
-                        self.handle.pointer(),
+                        srv.handle.pointer,
+                        self.handle.pointer,
+                        param.value)
+            elif param.name == _rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_PARAMETER:
+                for cli in self.services:
+                    ret = _rclpy.service_introspection.configure_service_events(
+                        cli.handle.pointer,
+                        self.handle.pointer,
                         param.value)
             elif param.name == _rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_EVENT_CONTENT_PARAMETER:
                 for srv in self.services:
                     _rclpy.service_introspection.configure_service_message_payload(
-                        srv.handle.pointer(),
+                        srv.handle.pointer,
                         param.value)
 
             elif param.name == _rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_EVENT_CONTENT_PARAMETER:
                 for cli in self.clients:
                     _rclpy.service_introspection.configure_client_message_payload(
-                        cli.handle.pointer(),
+                        cli.handle.pointer,
                         param.value)
 
     def create_client(
@@ -1644,7 +1644,8 @@ class Node:
                     self.handle,
                     srv_type,
                     srv_name,
-                    qos_profile.get_c_qos_profile())
+                    qos_profile.get_c_qos_profile(),
+                    self._clock.handle)
         except ValueError:
             failed = True
         if failed:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -125,7 +125,8 @@ class Node:
         start_parameter_services: bool = True,
         parameter_overrides: List[Parameter] = None,
         allow_undeclared_parameters: bool = False,
-        automatically_declare_parameters_from_overrides: bool = False
+        automatically_declare_parameters_from_overrides: bool = False,
+        enable_service_introspection: bool = False,
     ) -> None:
         """
         Create a Node.
@@ -149,6 +150,8 @@ class Node:
             This flag affects the behavior of parameter-related operations.
         :param automatically_declare_parameters_from_overrides: If True, the "parameter overrides"
             will be used to implicitly declare parameters on the node during creation.
+        :param enable_service_introspection: If True, the node will enable introspection of
+            services.
         """
         self.__handle = None
         self._context = get_default_context() if context is None else context
@@ -181,7 +184,8 @@ class Node:
                     self._context.handle,
                     cli_args,
                     use_global_arguments,
-                    enable_rosout
+                    enable_rosout,
+                    enable_service_introspection
                 )
             except ValueError:
                 # these will raise more specific errors if the name or namespace is bad

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1647,7 +1647,8 @@ class Node:
                     self.handle,
                     srv_type,
                     srv_name,
-                    qos_profile.get_c_qos_profile())
+                    qos_profile.get_c_qos_profile(),
+                    self._clock.handle)
         except ValueError:
             failed = True
         if failed:

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -44,6 +44,7 @@
 #include "serialization.hpp"
 #include "service.hpp"
 #include "service_info.hpp"
+#include "service_introspection.hpp"
 #include "signal_handler.hpp"
 #include "subscription.hpp"
 #include "time_point.hpp"
@@ -240,4 +241,5 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   rclpy::define_signal_handler_api(m);
   rclpy::define_clock_event(m);
   rclpy::define_lifecycle_api(m);
+  rclpy::define_service_introspection(m);
 }

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include "clock.hpp"
 #include "destroyable.hpp"
 #include "node.hpp"
 
@@ -45,7 +46,8 @@ public:
    * \param[in] service_name The service name
    * \param[in] pyqos rmw_qos_profile_t object for this client
    */
-  Client(Node & node, py::object pysrv_type, const char * service_name, py::object pyqos);
+  Client(Node & node, py::object pysrv_type, const char * service_name, py::object pyqos,
+      Clock & clock);
 
   ~Client() = default;
 

--- a/rclpy/src/rclpy/node.cpp
+++ b/rclpy/src/rclpy/node.cpp
@@ -16,6 +16,7 @@
 
 #include <rcl_action/rcl_action.h>
 #include <rcl/error_handling.h>
+#include <rcl/introspection.h>
 #include <rcl/graph.h>
 #include <rcl/types.h>
 #include <rcl_interfaces/msg/parameter_type.h>
@@ -372,7 +373,8 @@ Node::Node(
   Context & context,
   py::object pycli_args,
   bool use_global_arguments,
-  bool enable_rosout)
+  bool enable_rosout,
+  bool enable_service_introspection)
 : context_(context)
 {
   rcl_ret_t ret;
@@ -448,6 +450,7 @@ Node::Node(
   options.use_global_arguments = use_global_arguments;
   options.arguments = arguments;
   options.enable_rosout = enable_rosout;
+  options.enable_service_introspection = enable_service_introspection;
 
   {
     rclpy::LoggingGuard scoped_logging_guard;
@@ -521,11 +524,12 @@ Node::get_action_names_and_types()
   return convert_to_py_names_and_types(&names_and_types);
 }
 
+
 void
 define_node(py::object module)
 {
   py::class_<Node, Destroyable, std::shared_ptr<Node>>(module, "Node")
-  .def(py::init<const char *, const char *, Context &, py::object, bool, bool>())
+  .def(py::init<const char *, const char *, Context &, py::object, bool, bool, bool>())
   .def_property_readonly(
     "pointer", [](const Node & node) {
       return reinterpret_cast<size_t>(node.rcl_ptr());

--- a/rclpy/src/rclpy/node.hpp
+++ b/rclpy/src/rclpy/node.hpp
@@ -52,7 +52,8 @@ public:
     Context & context,
     py::object pycli_args,
     bool use_global_arguments,
-    bool enable_rosout);
+    bool enable_rosout,
+    bool enable_service_introspection);
 
   /// Get the fully qualified name of the node.
   /**

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -39,11 +39,8 @@ Service::destroy()
 }
 
 Service::Service(
-  Node & node,
-  py::object pysrv_type,
-  std::string service_name,
-  py::object pyqos_profile,
-  Clock & clock)
+    Node & node, py::object pysrv_type, std::string service_name, py::object pyqos_profile,
+    Clock & clock)
 : node_(node)
 {
   auto srv_type = static_cast<rosidl_service_type_support_t *>(

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -54,7 +54,7 @@ Service::Service(
     service_ops.qos = pyqos_profile.cast<rmw_qos_profile_t>();
   }
 
-  // Create a client
+  // Create a service
   rcl_service_ = std::shared_ptr<rcl_service_t>(
     new rcl_service_t,
     [node](rcl_service_t * service)

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 
+#include "clock.hpp"
 #include "destroyable.hpp"
 #include "node.hpp"
 #include "utils.hpp"
@@ -51,8 +52,11 @@ public:
    * \return capsule containing the rcl_service_t
    */
   Service(
-    Node & node, py::object pysrv_type, std::string service_name,
-    py::object pyqos_profile);
+    Node & node,
+    py::object pysrv_type,
+    std::string service_name,
+    py::object pyqos_profile,
+    Clock & clock);
 
   Service(
     Node & node, std::shared_ptr<rcl_service_t> rcl_service);

--- a/rclpy/src/rclpy/service_introspection.cpp
+++ b/rclpy/src/rclpy/service_introspection.cpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service_introspection.hpp"
+#include "rcl/introspection.h"
+
+namespace rclpy {
+
+void
+define_service_introspection(py::module_ module)
+{
+  py::module_ m2 = module.def_submodule("service_introspection",
+      "utilities for introspecting services");
+
+  m2.def("configure_service_events", &rcl_service_introspection_configure_service_events);
+  m2.def("configure_client_events", &rcl_service_introspection_configure_client_events);
+  m2.def("configure_service_message_payload", &rcl_service_introspection_configure_service_content);
+  m2.def("configure_client_message_payload", &rcl_service_introspection_configure_client_content);
+  m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER") =
+    RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER;
+  m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_PARAMETER") =
+    RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_PARAMETER;
+  m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_EVENT_CONTENT_PARAMETER") =
+    RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_EVENT_CONTENT_PARAMETER;
+  m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_EVENT_CONTENT_PARAMETER") =
+    RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_EVENT_CONTENT_PARAMETER;
+
+} 
+
+} // namespace rclpy

--- a/rclpy/src/rclpy/service_introspection.cpp
+++ b/rclpy/src/rclpy/service_introspection.cpp
@@ -13,20 +13,34 @@
 // limitations under the License.
 
 #include "service_introspection.hpp"
+#include <rcl/node.h>
+#include <rcl/service.h>
+#include <cstddef>
 #include "rcl/introspection.h"
 
 namespace rclpy {
 
+#include <cstdio>
 void
 define_service_introspection(py::module_ module)
 {
   py::module_ m2 = module.def_submodule("service_introspection",
       "utilities for introspecting services");
-
-  m2.def("configure_service_events", &rcl_service_introspection_configure_service_events);
-  m2.def("configure_client_events", &rcl_service_introspection_configure_client_events);
-  m2.def("configure_service_message_payload", &rcl_service_introspection_configure_service_content);
-  m2.def("configure_client_message_payload", &rcl_service_introspection_configure_client_content);
+  m2.def("configure_service_events",
+      [](size_t srv, size_t node, bool opt) {
+      fprintf(stderr, "Calling configure_service_events with srv: %ld, node: %ld, opt %d \n", srv, node, static_cast<int>(opt));
+      return rcl_service_introspection_configure_service_events(reinterpret_cast<rcl_service_t *>(srv), reinterpret_cast<rcl_node_t *>(node), opt);
+      });
+  m2.def("configure_client_events",
+      [](size_t cli, size_t node, bool opt) {
+      return rcl_service_introspection_configure_client_events(reinterpret_cast<rcl_client_t *>(cli), reinterpret_cast<rcl_node_t *>(node), opt);
+      });
+  m2.def("configure_service_message_payload", [](size_t srv, bool opt){
+        return rcl_service_introspection_configure_service_content(reinterpret_cast<rcl_service_t *>(srv), opt);
+      });
+  m2.def("configure_client_message_payload", [](size_t cli, bool opt) {
+      return rcl_service_introspection_configure_client_content(reinterpret_cast<rcl_client_t *>(cli), opt);
+      });
   m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER") =
     RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_PARAMETER;
   m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_PARAMETER") =
@@ -35,7 +49,6 @@ define_service_introspection(py::module_ module)
     RCL_SERVICE_INTROSPECTION_PUBLISH_CLIENT_EVENT_CONTENT_PARAMETER;
   m2.attr("RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_EVENT_CONTENT_PARAMETER") =
     RCL_SERVICE_INTROSPECTION_PUBLISH_SERVICE_EVENT_CONTENT_PARAMETER;
-
+  m2.attr("RCL_SERVICE_INTROSPECTION_TOPIC_POSTFIX") = RCL_SERVICE_INTROSPECTION_TOPIC_POSTFIX;
 } 
-
 } // namespace rclpy

--- a/rclpy/src/rclpy/service_introspection.hpp
+++ b/rclpy/src/rclpy/service_introspection.hpp
@@ -1,0 +1,28 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__SERVICE_INTROSPECTION_HPP_
+#define RCLPY__SERVICE_INTROSPECTION_HPP_
+
+#include "pybind11/pybind11.h"
+
+namespace py = pybind11;
+
+namespace rclpy {
+
+void
+define_service_introspection(py::module_ module);
+
+} // namespace rclpy
+#endif // RCLPY__SERVICE_INTROSPECTION_HPP_


### PR DESCRIPTION
This PR is part of a prototype implementation for https://github.com/ros-infrastructure/rep/pull/360 https://github.com/ros2/ros2/issues/1285. 

Notes:
- A submodule was `pybind`ed for service introspection. This can be flattened if desired.
- Update the various service/client creation methods to pass along a clock interface to satisify changes made in `rcl` for service introspection (https://github.com/ros2/rcl/pull/997)