### PR TITLE
fix timers in task

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -186,6 +186,7 @@ if(BUILD_TESTING)
       test/test_time_source.py
       test/test_time.py
       test/test_timer.py
+      test/test_timer_in_task.py
       test/test_topic_or_service_is_hidden.py
       test/test_topic_endpoint_info.py
       test/test_type_support.py

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -19,7 +19,6 @@ import multiprocessing
 from threading import Condition
 from threading import Lock
 from threading import RLock
-import time
 from typing import Any
 from typing import Callable
 from typing import Coroutine
@@ -169,6 +168,8 @@ class Executor:
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         self._sigint_gc = SignalHandlerGuardCondition(context)
         self._context.on_shutdown(self.wake)
+        self._spin_until_future_complete_timer: Optional[Timer] = None
+        self._spin_until_future_complete_timeout = False
 
     @property
     def context(self) -> Context:
@@ -287,18 +288,16 @@ class Executor:
             while self._context.ok() and not future.done() and not self._is_shutdown:
                 self.spin_once_until_future_complete(future, timeout_sec)
         else:
-            start = time.monotonic()
-            end = start + timeout_sec
-            timeout_left = timeout_sec
-
-            while self._context.ok() and not future.done() and not self._is_shutdown:
-                self.spin_once_until_future_complete(future, timeout_left)
-                now = time.monotonic()
-
-                if now >= end:
-                    return
-
-                timeout_left = end - now
+            if self._spin_until_future_complete_timer is not None:
+                # this should not happen
+                raise RuntimeError('Executor already spinning')
+            self._spin_until_future_complete_timer = Timer(
+                None, None, timeout_sec_to_nsec(timeout_sec),
+                self._clock, context=self._context)
+            self._spin_until_future_complete_timeout = False
+            while not future.done() and not self._spin_until_future_complete_timeout:
+                self.spin_once()
+            self._spin_until_future_complete_timeout = None
 
     def spin_once(self, timeout_sec: float = None) -> None:
         """
@@ -502,6 +501,8 @@ class Executor:
                     guards.append(gc)
             if timeout_timer is not None:
                 timers.append(timeout_timer)
+            if self._spin_until_future_complete_timer is not None:
+                timers.append(self._spin_until_future_complete_timer)
 
             guards.append(self._guard)
             guards.append(self._sigint_gc)
@@ -663,6 +664,12 @@ class Executor:
                 timeout_nsec == 0 or
                 (timeout_timer is not None and timeout_timer.handle.pointer in timers_ready)
             ):
+                raise TimeoutException()
+            if (
+                self._spin_until_future_complete_timer is not None and
+                self._spin_until_future_complete_timer.handle.pointer in timers_ready
+            ):
+                self._spin_until_future_complete_timeout = True
                 raise TimeoutException()
         if self._is_shutdown:
             raise ShutdownException()

--- a/rclpy/test/test_timer_in_task.py
+++ b/rclpy/test/test_timer_in_task.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import rclpy
+import rclpy.executors
+
+
+class TestTimerInTask(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node('TestTimerInTask', context=cls.context)
+        cls.executor = rclpy.executors.SingleThreadedExecutor(context=cls.context)
+        cls.executor.add_node(cls.node)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown(context=cls.context)
+
+    def test_timer_in_task(self):
+        fut = rclpy.Future()
+
+        async def work():
+            self.node.create_timer(0.1, lambda: fut.set_result(None))
+            await fut
+
+        task = self.executor.create_task(work())
+        self.executor.spin_until_future_complete(task, 1)
+        self.assertTrue(task.done())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #985.

I am not familiar with the executor logic in rclpy, so this is a hacky fix I did. Instead of passing a new timeout each tick, I added `self._spin_until_future_complete_timer` and `self._spin_until_future_complete_timeout` to wake the executor when the timeout is reached. Also added `test_timer_in_task.py` to test the new behavior.

---

Looking at the code of `spin_until_future_complete`, it behaves differently depending on if a timeout is provided.
```python
        if timeout_sec is None or timeout_sec < 0:
            while self._context.ok() and not future.done() and not self._is_shutdown:
                self.spin_once_until_future_complete(future, timeout_sec)
        else:
            start = time.monotonic()
            end = start + timeout_sec
            timeout_left = timeout_sec

            while self._context.ok() and not future.done() and not self._is_shutdown:
                self.spin_once_until_future_complete(future, timeout_left)
                now = time.monotonic()

                if now >= end:
                    return

                timeout_left = end - now
```

This all looks good but furthur investigation of `wait_for_ready_callbacks` (which is eventually called later down the chain),
```python
        while True:
            if self._cb_iter is None or self._last_args != args or self._last_kwargs != kwargs:
                # Create a new generator
                self._last_args = args
                self._last_kwargs = kwargs
                self._cb_iter = self._wait_for_ready_callbacks(*args, **kwargs)

            try:
                return next(self._cb_iter)
            except StopIteration:
                # Generator ran out of work
                self._cb_iter = None
```

It creates a new generator whenever `_last_args` or `_last_kwargs` is different, the "timeout" path of `spin_until_future_complete` does exactly that, each `spin_once_until_future_complete` is passed a different timeout.

My guess is that somehow creating new generators every "tick" causes new "work" to be created, and executing a "work" causes a new generator to be created, resulting in a infinite list of pending "work", which causes the actual task to never be executed.