### PR TITLE
Improved subscription typings

### DIFF
--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -12,38 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
 import inspect
-from typing import Callable
-from typing import TypeVar
+from enum import Enum
+from typing import Any, Callable, Generic, List, Type, TypeVar, Union
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.node import MsgType
 from rclpy.qos import QoSProfile
-from rclpy.qos_event import QoSEventHandler
-from rclpy.qos_event import SubscriptionEventCallbacks
+from rclpy.qos_event import QoSEventHandler, SubscriptionEventCallbacks
+from rclpy.type_support import PMsg
+
+MsgType = TypeVar('MsgType', bound=PMsg)
 
 
-# For documentation only
-MsgType = TypeVar('MsgType')
-
-
-class Subscription:
+class Subscription(Generic[MsgType]):
 
     class CallbackType(Enum):
         MessageOnly = 0
         WithMessageInfo = 1
 
     def __init__(
-         self,
-         subscription_impl: _rclpy.Subscription,
-         msg_type: MsgType,
-         topic: str,
-         callback: Callable,
-         callback_group: CallbackGroup,
-         qos_profile: QoSProfile,
-         raw: bool,
-         event_callbacks: SubscriptionEventCallbacks,
+        self,
+        subscription_impl: _rclpy.Subscription,
+        msg_type: Type[MsgType],
+        topic: str,
+        callback: Union[Callable[[MsgType], None], Callable[[MsgType, Any], None]],
+        callback_group: CallbackGroup,
+        qos_profile: QoSProfile,
+        raw: bool,
+        event_callbacks: SubscriptionEventCallbacks,
     ) -> None:
         """
         Create a container for a ROS subscription.
@@ -73,7 +71,7 @@ class Subscription:
         self.qos_profile = qos_profile
         self.raw = raw
 
-        self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
+        self.event_handlers: List[QoSEventHandler] = event_callbacks.create_event_handlers(
             callback_group, subscription_impl, topic)
 
     @property
@@ -91,11 +89,11 @@ class Subscription:
             return self.__subscription.get_topic_name()
 
     @property
-    def callback(self):
+    def callback(self) -> Union[Callable[[MsgType], None], Callable[[MsgType, Any], None]]:
         return self._callback
 
     @callback.setter
-    def callback(self, value):
+    def callback(self, value: Union[Callable[[MsgType], None], Callable[[MsgType, Any], None]]):
         self._callback = value
         self._callback_type = Subscription.CallbackType.MessageOnly
         try:

--- a/rclpy/rclpy/type_support.py
+++ b/rclpy/rclpy/type_support.py
@@ -12,12 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Protocol, Type
 from rclpy.exceptions import NoTypeSupportImportedException
 
 
-def check_for_type_support(msg_or_srv_type):
+class _PMsgClass(Protocol):
+    _CONVERT_FROM_PY: Any
+    _CONVERT_TO_PY: Any
+    _CREATE_ROS_MESSAGE: Any
+    _DESTROY_ROS_MESSAGE: Any
+
+
+class PMsg(Protocol):
+    @property  # type: ignore
+    def __class__(self) -> _PMsgClass: ...  # type: ignore
+
+
+def check_for_type_support(msg_or_srv_type: Type[object]):
     try:
-        ts = msg_or_srv_type.__class__._TYPE_SUPPORT
+        ts = msg_or_srv_type.__class__._TYPE_SUPPORT  # type: ignore
     except AttributeError as e:
         e.args = (
             e.args[0] +
@@ -26,19 +39,19 @@ def check_for_type_support(msg_or_srv_type):
             *e.args[1:])
         raise
     if ts is None:
-        msg_or_srv_type.__class__.__import_type_support__()
-    if msg_or_srv_type.__class__._TYPE_SUPPORT is None:
+        msg_or_srv_type.__class__.__import_type_support__()  # type: ignore
+    if msg_or_srv_type.__class__._TYPE_SUPPORT is None:  # type: ignore
         raise NoTypeSupportImportedException()
 
 
-def check_is_valid_msg_type(msg_type):
+def check_is_valid_msg_type(msg_type: Type[object]):
     check_for_type_support(msg_type)
     try:
         assert None not in (
-            msg_type.__class__._CREATE_ROS_MESSAGE,
-            msg_type.__class__._CONVERT_FROM_PY,
-            msg_type.__class__._CONVERT_TO_PY,
-            msg_type.__class__._DESTROY_ROS_MESSAGE,
+            msg_type.__class__._CREATE_ROS_MESSAGE,  # type: ignore
+            msg_type.__class__._CONVERT_FROM_PY,  # type: ignore
+            msg_type.__class__._CONVERT_TO_PY,  # type: ignore
+            msg_type.__class__._DESTROY_ROS_MESSAGE,  # type: ignore
         )
     except (AssertionError, AttributeError):
         raise RuntimeError(
@@ -47,12 +60,12 @@ def check_is_valid_msg_type(msg_type):
         ) from None
 
 
-def check_is_valid_srv_type(srv_type):
+def check_is_valid_srv_type(srv_type: Type[object]):
     check_for_type_support(srv_type)
     try:
         assert None not in (
-            srv_type.Response,
-            srv_type.Request,
+            srv_type.Response,  # type: ignore
+            srv_type.Request,  # type: ignore
         )
     except (AssertionError, AttributeError):
         raise RuntimeError(


### PR DESCRIPTION
As per discussion in #979, this PR introduces better static typings for the Subscription class (along with some changes in type_support, needed to limit the PMsg protocol to be compatible only with ROS messages)