### PR TITLE
Improved publisher typings

### DIFF
--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TypeVar, Union
+from typing import Generic, List, Type, TypeVar, Union
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.duration import Duration
@@ -21,15 +21,17 @@ from rclpy.qos import QoSProfile
 from rclpy.qos_event import PublisherEventCallbacks
 from rclpy.qos_event import QoSEventHandler
 
-MsgType = TypeVar('MsgType')
+from rclpy.type_support import PMsg
+
+MsgType = TypeVar('MsgType', bound=PMsg)
 
 
-class Publisher:
+class Publisher(Generic[MsgType]):
 
     def __init__(
         self,
         publisher_impl: _rclpy.Publisher,
-        msg_type: MsgType,
+        msg_type: Type[MsgType],
         topic: str,
         qos_profile: QoSProfile,
         event_callbacks: PublisherEventCallbacks,
@@ -54,7 +56,7 @@ class Publisher:
         self.topic = topic
         self.qos_profile = qos_profile
 
-        self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
+        self.event_handlers: List[QoSEventHandler] = event_callbacks.create_event_handlers(
             callback_group, publisher_impl, topic)
 
     def publish(self, msg: Union[MsgType, bytes]) -> None:
@@ -120,4 +122,4 @@ class Publisher:
             false.
         """
         with self.handle:
-            return self.__publisher.wait_for_all_acked(timeout._duration_handle)
+            return self.__publisher.wait_for_all_acked(timeout._duration_handle) # type: ignore

--- a/rclpy/rclpy/type_support.py
+++ b/rclpy/rclpy/type_support.py
@@ -12,12 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Protocol, Type
 from rclpy.exceptions import NoTypeSupportImportedException
 
 
-def check_for_type_support(msg_or_srv_type):
+class _PMsgClass(Protocol):
+    _CONVERT_FROM_PY: Any
+    _CONVERT_TO_PY: Any
+    _CREATE_ROS_MESSAGE: Any
+    _DESTROY_ROS_MESSAGE: Any
+
+
+class PMsg(Protocol):
+    @property  # type: ignore
+    def __class__(self) -> _PMsgClass: ...  # type: ignore
+
+
+def check_for_type_support(msg_or_srv_type: Type[object]):
     try:
-        ts = msg_or_srv_type.__class__._TYPE_SUPPORT
+        ts = msg_or_srv_type.__class__._TYPE_SUPPORT  # type: ignore
     except AttributeError as e:
         e.args = (
             e.args[0] +
@@ -26,19 +39,19 @@ def check_for_type_support(msg_or_srv_type):
             *e.args[1:])
         raise
     if ts is None:
-        msg_or_srv_type.__class__.__import_type_support__()
-    if msg_or_srv_type.__class__._TYPE_SUPPORT is None:
+        msg_or_srv_type.__class__.__import_type_support__()  # type: ignore
+    if msg_or_srv_type.__class__._TYPE_SUPPORT is None:  # type: ignore
         raise NoTypeSupportImportedException()
 
 
-def check_is_valid_msg_type(msg_type):
+def check_is_valid_msg_type(msg_type: Type[object]):
     check_for_type_support(msg_type)
     try:
         assert None not in (
-            msg_type.__class__._CREATE_ROS_MESSAGE,
-            msg_type.__class__._CONVERT_FROM_PY,
-            msg_type.__class__._CONVERT_TO_PY,
-            msg_type.__class__._DESTROY_ROS_MESSAGE,
+            msg_type.__class__._CREATE_ROS_MESSAGE,  # type: ignore
+            msg_type.__class__._CONVERT_FROM_PY,  # type: ignore
+            msg_type.__class__._CONVERT_TO_PY,  # type: ignore
+            msg_type.__class__._DESTROY_ROS_MESSAGE,  # type: ignore
         )
     except (AssertionError, AttributeError):
         raise RuntimeError(
@@ -47,12 +60,12 @@ def check_is_valid_msg_type(msg_type):
         ) from None
 
 
-def check_is_valid_srv_type(srv_type):
+def check_is_valid_srv_type(srv_type: Type[object]):
     check_for_type_support(srv_type)
     try:
         assert None not in (
-            srv_type.Response,
-            srv_type.Request,
+            srv_type.Response,  # type: ignore
+            srv_type.Request,  # type: ignore
         )
     except (AssertionError, AttributeError):
         raise RuntimeError(

--- a/rclpy/typings/rclpy/impl/implementation_singleton/node.pyi
+++ b/rclpy/typings/rclpy/impl/implementation_singleton/node.pyi
@@ -1,0 +1,2 @@
+class Node:
+    pass

--- a/rclpy/typings/rclpy/impl/implementation_singleton/publisher.pyi
+++ b/rclpy/typings/rclpy/impl/implementation_singleton/publisher.pyi
@@ -1,0 +1,31 @@
+from rclpy.impl.implementation_singleton.node import Node
+from typing import Any
+
+class Publisher:
+
+    def __init__(
+        self,
+        node: Node,
+        msg_type: Any,
+        topic: str,
+        qos_profile: Any,
+        qos_overriding_options: Any = ...,
+        /
+    ) -> None: ...
+
+    def __enter__(self) -> None: ...
+
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
+        pass
+
+    def publish(self, msg: Any) -> None: ...
+
+    def publish_raw(self, msg: bytes) -> None: ...
+
+    def get_subscription_count(self) -> int: ...
+
+    def get_topic_name(self) -> str: ...
+
+    def destroy_when_not_in_use(self) -> None: ...
+
+    def get_logger_name(self) -> str: ...

--- a/rclpy/typings/rclpy/impl/implementation_singleton/rclpy_implementation.pyi
+++ b/rclpy/typings/rclpy/impl/implementation_singleton/rclpy_implementation.pyi
@@ -1,0 +1,29 @@
+class Publisher:
+
+    def __init__(
+        self,
+        node: Node,
+        msg_type: Any,
+        topic: str,
+        qos_profile: Any,
+        qos_overriding_options: Any = ...,
+        /
+    ) -> None: ...
+
+    def __enter__(self) -> None: ...
+
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
+        pass
+
+    def publish(self, msg: Any) -> None: ...
+
+    def publish_raw(self, msg: bytes) -> None: ...
+
+    def get_subscription_count(self) -> int: ...
+
+    def get_topic_name(self) -> str: ...
+
+    def destroy_when_not_in_use(self) -> None: ...
+
+    def get_logger_name(self) -> str: ...
+


### PR DESCRIPTION
As per discussion in https://github.com/ros2/rclpy/pull/979, this PR introduces better static typings for the Publisher class (along with some changes in type_support, needed to limit the PMsg protocol to be compatible only with ROS messages)