### PR TITLE
Set the default number of threads of the MultiThreadedExecutor to 2

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -734,7 +734,8 @@ class MultiThreadedExecutor(Executor):
 
     :param num_threads: number of worker threads in the pool.
         If ``None``, the number of threads will be automatically set by querying the underlying OS
-        for the CPU affinity of the process space. If it is not set, defaults to 2.
+        for the CPU affinity of the process space.
+        If the OS doesn't provide this information, defaults to 2.
     :param context: The context associated with the executor.
     """
 
@@ -742,7 +743,7 @@ class MultiThreadedExecutor(Executor):
         super().__init__(context=context)
         if num_threads is None:
             # On Linux, it will try to use the number of CPU this process has access to.
-            # On other platforms, os.sched_getaffinity() doesn't exist so we use the number of CPU.
+            # Other platforms, os.sched_getaffinity() doesn't exist so we use the number of CPUs.
             if hasattr(os, 'sched_getaffinity'):
                 num_threads = len(os.sched_getaffinity(0))
             else:

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import asyncio
+import multiprocessing
 import threading
 import time
 import unittest
+import warnings
 
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
@@ -127,6 +129,32 @@ class TestExecutor(unittest.TestCase):
             executor.shutdown()
 
         assert not got_callback
+
+    def test_multi_threaded_executor_num_threads(self):
+        self.assertIsNotNone(self.node.handle)
+
+        # check default behavior, either multiprocessing.cpu_count() or defaults to 2
+        executor = MultiThreadedExecutor(context=self.context)
+        try:
+            platform_threads = max(multiprocessing.cpu_count(), 2)
+        except NotImplementedError:
+            platform_threads = 2
+        self.assertEqual(platform_threads, executor._executor._max_workers)
+        executor.shutdown()
+
+        # check specified thread number w/o warning
+        executor = MultiThreadedExecutor(num_threads=3, context=self.context)
+        self.assertEqual(3, executor._executor._max_workers)
+        executor.shutdown()
+
+        # check specified thread number = 1, expecting UserWarning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=UserWarning)
+            executor = MultiThreadedExecutor(num_threads=1, context=self.context)
+            self.assertEqual(1, executor._executor._max_workers)
+            executor.shutdown()
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
 
     def test_multi_threaded_executor_executes(self):
         self.assertIsNotNone(self.node.handle)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import asyncio
-import multiprocessing
+import os
 import threading
 import time
 import unittest
@@ -133,12 +133,12 @@ class TestExecutor(unittest.TestCase):
     def test_multi_threaded_executor_num_threads(self):
         self.assertIsNotNone(self.node.handle)
 
-        # check default behavior, either multiprocessing.cpu_count() or defaults to 2
+        # check default behavior, either platform configuration or defaults to 2
         executor = MultiThreadedExecutor(context=self.context)
-        try:
-            platform_threads = max(multiprocessing.cpu_count(), 2)
-        except NotImplementedError:
-            platform_threads = 2
+        if hasattr(os, 'sched_getaffinity'):
+            platform_threads = len(os.sched_getaffinity(0))
+        else:
+            platform_threads = os.cpu_count()
         self.assertEqual(platform_threads, executor._executor._max_workers)
         executor.shutdown()
 


### PR DESCRIPTION
https://github.com/ros2/rclcpp/pull/2030 for `rclpy`

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>