### PR TITLE
Fix incorrect comparsion on whether parameter type is NOT_SET

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -470,7 +470,7 @@ class Node:
                 descriptor.dynamic_typing = True
 
             if isinstance(second_arg, Parameter.Type):
-                if second_arg.value == Parameter.Type.NOT_SET:
+                if second_arg == Parameter.Type.NOT_SET:
                     raise ValueError(
                         f'Cannot declare parameter {{{name}}} as statically typed of type NOT_SET')
                 if descriptor.dynamic_typing is True:


### PR DESCRIPTION
According to current code, if the type of declared parameter is 'NOT_SET', it throws an exception.

https://github.com/ros2/rclpy/blob/3d8547ad80d9fa72335b9ee0c105a80fcaf275c1/rclpy/rclpy/node.py#L472-L475

Actually, If write code like below, it doesn't throw any exception.

```rclpy
self.declare_parameter('my_parameter2', Parameter.Type.NOT_SET)
```

It is because second_arg is an instance of Parameter.Type and it doesn't have `value`. So it is always not equal.
