### PR TITLE
Document rclpy.utilities.remove_ros_args

### DIFF
--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -15,14 +15,9 @@
 import os
 import sys
 import threading
+from typing import List
 from typing import Optional
-
-if sys.version_info < (3, 9, 0):
-    from typing import List
-    from typing import Sequence
-else:
-    List = list
-    from collections.abc import Sequence
+from typing import Sequence
 
 import ament_index_python
 

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -15,6 +15,14 @@
 import os
 import sys
 import threading
+from typing import Optional
+
+if sys.version_info < (3, 9, 0):
+    from typing import List
+    from typing import Sequence
+else:
+    List = list
+    from collections.abc import Sequence
 
 import ament_index_python
 
@@ -39,7 +47,14 @@ def get_default_context(*, shutting_down=False):
         return g_default_context
 
 
-def remove_ros_args(args=None):
+def remove_ros_args(args: Optional[Sequence[str]] = None) -> List[str]:
+    """
+    Return a list of only the non-ROS command line arguments.
+
+    :param args: A list of command line arguments to filter from. If None then
+    ``sys.argv`` is used instead.
+    :returns: A list of all command line arguments that are not used by ROS.
+    """
     # imported locally to avoid loading extensions on module import
     from rclpy.impl.implementation_singleton import rclpy_implementation
     return rclpy_implementation.rclpy_remove_ros_args(


### PR DESCRIPTION
I noticed this function was missing a docstring while telling someone about it.