### PR TITLE
Document rclpy.time.Time class

### DIFF
--- a/rclpy/docs/source/api.rst
+++ b/rclpy/docs/source/api.rst
@@ -10,6 +10,7 @@ API
    api/topics
    api/services
    api/actions
+   api/time
    api/timers
    api/parameters
    api/logging

--- a/rclpy/docs/source/api/time.rst
+++ b/rclpy/docs/source/api/time.rst
@@ -1,0 +1,4 @@
+Time
+=====
+
+.. automodule:: rclpy.time

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -59,7 +59,7 @@ class Time:
         """
         Get time separated into seconds and nanoseconds components.
 
-        :returns: 2-tuple seconds and nanoseconds
+        :return: 2-tuple seconds and nanoseconds
         """
         nanoseconds = self.nanoseconds
         return (nanoseconds // CONVERSION_CONSTANT, nanoseconds % CONVERSION_CONSTANT)

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Tuple
+
 import builtin_interfaces.msg
 from rclpy.duration import Duration
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
@@ -21,6 +23,14 @@ CONVERSION_CONSTANT = 10 ** 9
 
 
 class Time:
+    """
+    Represents a point in time.
+
+    A ``Time`` object is the combination of a duration since an epoch, and a
+    clock type.
+    ``Time`` objects are only comparable with other time points from the same
+    type of clock.
+    """
 
     def __init__(
             self, *,
@@ -41,21 +51,22 @@ class Time:
         self._time_handle = _rclpy.rcl_time_point_t(total_nanoseconds, clock_type)
 
     @property
-    def nanoseconds(self):
+    def nanoseconds(self) -> int:
+        """:return: the total number of nanoseconds since the clock's epoch."""
         return self._time_handle.nanoseconds
 
-    def seconds_nanoseconds(self):
+    def seconds_nanoseconds(self) -> Tuple[int, int]:
         """
-        Get time as separate seconds and nanoseconds components.
+        Get time separated into seconds and nanoseconds components.
 
         :returns: 2-tuple seconds and nanoseconds
-        :rtype: tuple(int, int)
         """
         nanoseconds = self.nanoseconds
         return (nanoseconds // CONVERSION_CONSTANT, nanoseconds % CONVERSION_CONSTANT)
 
     @property
-    def clock_type(self):
+    def clock_type(self) -> _rclpy.ClockType:
+        """:return: the type of clock that produced this instance."""
         return self._time_handle.clock_type
 
     def __repr__(self):
@@ -136,12 +147,27 @@ class Time:
             return self.nanoseconds >= other.nanoseconds
         return NotImplemented
 
-    def to_msg(self):
+    def to_msg(self) -> builtin_interfaces.msg.Time:
+        """
+        Create a ROS message instance from a ``Time`` object.
+
+        :rtype: builtin_interfaces.msg.Time
+        """
         seconds, nanoseconds = self.seconds_nanoseconds()
         return builtin_interfaces.msg.Time(sec=seconds, nanosec=nanoseconds)
 
     @classmethod
-    def from_msg(cls, msg, clock_type: _rclpy.ClockType = _rclpy.ClockType.ROS_TIME):
+    def from_msg(
+        cls, msg: builtin_interfaces.msg.Time,
+        clock_type: _rclpy.ClockType = _rclpy.ClockType.ROS_TIME
+    ) -> 'Time':
+        """
+        Create a ``Time`` instance from a ROS message.
+
+        :param msg: the message instance to convert.
+        :type msg: builtin_interfaces.msg.Time
+        :rtype: Time
+        """
         if not isinstance(msg, builtin_interfaces.msg.Time):
             raise TypeError('Must pass a builtin_interfaces.msg.Time object')
         return cls(seconds=msg.sec, nanoseconds=msg.nanosec, clock_type=clock_type)


### PR DESCRIPTION
This adds documentation for the Time class. Here's how it looks.

![image](https://user-images.githubusercontent.com/4175662/202009244-a1ab456b-d1cd-4fb0-8c95-2a2cdc8795c1.png)
