### PR TITLE
Rewrite test code without depending on parameter client

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -175,6 +175,7 @@ if(BUILD_TESTING)
       test/test_messages.py
       test/test_node.py
       test/test_parameter.py
+      test/test_parameter_client.py
       test/test_parameter_service.py
       test/test_publisher.py
       test/test_qos.py

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -175,7 +175,7 @@ if(BUILD_TESTING)
       test/test_messages.py
       test/test_node.py
       test/test_parameter.py
-      test/test_parameter_client.py
+      test/test_parameter_service.py
       test/test_publisher.py
       test/test_qos.py
       test/test_qos_event.py

--- a/rclpy/test/test_parameter_client.py
+++ b/rclpy/test/test_parameter_client.py
@@ -170,24 +170,3 @@ class TestParameterClient(unittest.TestCase):
         finally:
             if os.path.exists(f.name):
                 os.unlink(f.name)
-
-    def test_get_uninitialized_parameter(self):
-        self.target_node.declare_parameter('uninitialized_parameter', Parameter.Type.STRING)
-
-        # The type in description should be STRING
-        future = self.client.describe_parameters(['uninitialized_parameter'])
-        self.executor.spin_until_future_complete(future)
-        results = future.result()
-        assert results is not None
-        assert len(results.descriptors) == 1
-        assert results.descriptors[0].type == ParameterType.PARAMETER_STRING
-        assert results.descriptors[0].name == 'uninitialized_parameter'
-
-        # The value should be empty
-        future = self.client.get_parameters(['uninitialized_parameter'])
-        self.executor.spin_until_future_complete(future)
-        results = future.result()
-        assert results is not None
-        assert results.values == []
-
-        self.target_node.undeclare_parameter('uninitialized_parameter')

--- a/rclpy/test/test_parameter_client.py
+++ b/rclpy/test/test_parameter_client.py
@@ -170,3 +170,24 @@ class TestParameterClient(unittest.TestCase):
         finally:
             if os.path.exists(f.name):
                 os.unlink(f.name)
+
+    def test_get_uninitialized_parameter(self):
+        self.target_node.declare_parameter('uninitialized_parameter', Parameter.Type.STRING)
+
+        # The type in description should be STRING
+        future = self.client.describe_parameters(['uninitialized_parameter'])
+        self.executor.spin_until_future_complete(future)
+        results = future.result()
+        assert results is not None
+        assert len(results.descriptors) == 1
+        assert results.descriptors[0].type == ParameterType.PARAMETER_STRING
+        assert results.descriptors[0].name == 'uninitialized_parameter'
+
+        # The value should be empty
+        future = self.client.get_parameters(['uninitialized_parameter'])
+        self.executor.spin_until_future_complete(future)
+        results = future.result()
+        assert results is not None
+        assert results.values == []
+
+        self.target_node.undeclare_parameter('uninitialized_parameter')

--- a/rclpy/test/test_parameter_service.py
+++ b/rclpy/test/test_parameter_service.py
@@ -1,0 +1,82 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rcl_interfaces.msg import ParameterType
+from rcl_interfaces.srv import DescribeParameters
+from rcl_interfaces.srv import GetParameters
+import rclpy
+import rclpy.context
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.parameter import Parameter
+from rclpy.qos import qos_profile_services_default
+
+
+class TestParameterService(unittest.TestCase):
+
+    def setUp(self):
+        self.context = rclpy.context.Context()
+        rclpy.init(context=self.context)
+        self.test_node = rclpy.create_node(
+            'test_parameter_service',
+            namespace='/rclpy',
+            context=self.context)
+
+        self.get_parameter_client = self.test_node.create_client(
+            GetParameters, f'/rclpy/test_parameter_service/get_parameters',
+            qos_profile=qos_profile_services_default
+        )
+
+        self.describe_parameters_client = self.test_node.create_client(
+            DescribeParameters, f'/rclpy/test_parameter_service/describe_parameters',
+            qos_profile=qos_profile_services_default
+        )
+
+        self.executor = SingleThreadedExecutor(context=self.context)
+        self.executor.add_node(self.test_node)
+
+    def tearDown(self):
+        self.executor.shutdown()
+        self.test_node.destroy_node()
+        rclpy.shutdown(context=self.context)
+
+    def test_get_uninitialized_parameter(self):
+        self.test_node.declare_parameter('uninitialized_parameter', Parameter.Type.STRING)
+
+        # The type in description should be STRING
+        request = DescribeParameters.Request()
+        request.names = ['uninitialized_parameter']
+        future = self.describe_parameters_client.call_async(request)
+        self.executor.spin_until_future_complete(future)
+        results = future.result()
+        assert results is not None
+        assert len(results.descriptors) == 1
+        assert results.descriptors[0].type == ParameterType.PARAMETER_STRING
+        assert results.descriptors[0].name == 'uninitialized_parameter'
+
+        # The value should be empty
+        request = GetParameters.Request()
+        request.names = ['uninitialized_parameter']
+        future = self.get_parameter_client.call_async(request)
+        self.executor.spin_until_future_complete(future)
+        results = future.result()
+        assert results is not None
+        assert results.values == []
+
+        self.test_node.undeclare_parameter('uninitialized_parameter')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_parameter_service.py
+++ b/rclpy/test/test_parameter_service.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Copyright 2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rclpy/test/test_parameter_service.py
+++ b/rclpy/test/test_parameter_service.py
@@ -35,12 +35,12 @@ class TestParameterService(unittest.TestCase):
             context=self.context)
 
         self.get_parameter_client = self.test_node.create_client(
-            GetParameters, f'/rclpy/test_parameter_service/get_parameters',
+            GetParameters, '/rclpy/test_parameter_service/get_parameters',
             qos_profile=qos_profile_services_default
         )
 
         self.describe_parameters_client = self.test_node.create_client(
-            DescribeParameters, f'/rclpy/test_parameter_service/describe_parameters',
+            DescribeParameters, '/rclpy/test_parameter_service/describe_parameters',
             qos_profile=qos_profile_services_default
         )
 
@@ -74,8 +74,6 @@ class TestParameterService(unittest.TestCase):
         results = future.result()
         assert results is not None
         assert results.values == []
-
-        self.test_node.undeclare_parameter('uninitialized_parameter')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Address this comments https://github.com/ros2/rclpy/pull/1041#issuecomment-1318956122  

I move test code for not depending on parameter client.  
And remove  test_parameter_client.py in CMakeLists.txt since #1033 added this file.   

@ivanpauno Please help to review it, and then I will add this test to backport of #1033. 