### PR TITLE
Add in a warning for a depth of 0 with KEEP_LAST.

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -164,6 +164,12 @@ class QoSProfile:
     @depth.setter
     def depth(self, value):
         assert isinstance(value, int)
+
+        if self.history == QoSHistoryPolicy.KEEP_LAST and value == 0:
+            warnings.warn(
+                "A zero depth with KEEP_LAST doesn't make sense; no data could be stored. "
+                'This will be interpreted as SYSTEM_DEFAULT')
+
         self._depth = value
 
     @property

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -83,7 +83,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         self.assertEqual(self.node.get_clock().clock_type, ClockType.ROS_TIME)
 
     def test_create_publisher(self):
-        self.node.create_publisher(BasicTypes, 'chatter', 0)
         self.node.create_publisher(BasicTypes, 'chatter', 1)
         self.node.create_publisher(BasicTypes, 'chatter', qos_profile_sensor_data)
         with self.assertRaisesRegex(InvalidTopicNameException, 'must not contain characters'):
@@ -98,7 +97,6 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             self.node.create_publisher(BasicTypes, 'chatter', 'foo')
 
     def test_create_subscription(self):
-        self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 0)
         self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 1)
         self.node.create_subscription(
             BasicTypes, 'chatter', lambda msg: print(msg), qos_profile_sensor_data)
@@ -275,7 +273,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
 
         # Add a subscription
         qos_profile2 = QoSProfile(
-            depth=0,
+            depth=1,
             history=QoSHistoryPolicy.KEEP_LAST,
             deadline=Duration(seconds=15, nanoseconds=1678),
             lifespan=Duration(seconds=29, nanoseconds=2345),

--- a/rclpy/test/test_publisher.py
+++ b/rclpy/test/test_publisher.py
@@ -73,7 +73,7 @@ class TestPublisher(unittest.TestCase):
 
         """
         for topic, target_topic in test_topics:
-            publisher = node.create_publisher(BasicTypes, topic, 0)
+            publisher = node.create_publisher(BasicTypes, topic, 1)
             assert publisher.topic_name == target_topic
             publisher.destroy()
 

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import warnings
 
 from rclpy.duration import Duration
 from rclpy.qos import InvalidQoSProfileException
@@ -125,6 +126,26 @@ class TestQosProfile(unittest.TestCase):
         assert (
             QoSPresetProfiles.SYSTEM_DEFAULT.value ==
             QoSPresetProfiles.get_from_short_key('system_default'))
+
+    def test_keep_last_zero_depth_constructor(self):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter('always', category=UserWarning)
+            qos = QoSProfile(history=QoSHistoryPolicy.KEEP_LAST, depth=0)
+            assert len(caught_warnings) == 1
+            assert issubclass(caught_warnings[0].category, UserWarning)
+            assert("A zero depth with KEEP_LAST doesn't make sense" in str(caught_warnings[0]))
+        assert qos.history == QoSHistoryPolicy.KEEP_LAST
+
+    def test_keep_last_zero_depth_set(self):
+        qos = QoSProfile(history=QoSHistoryPolicy.KEEP_LAST, depth=1)
+        assert qos.depth == 1
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter('always', category=UserWarning)
+            qos.depth = 0
+            assert len(caught_warnings) == 1
+            assert issubclass(caught_warnings[0].category, UserWarning)
+            assert("A zero depth with KEEP_LAST doesn't make sense" in str(caught_warnings[0]))
 
 
 class TestCheckQosCompatibility(unittest.TestCase):


### PR DESCRIPTION
It really doesn't make much sense to have a KeepLast depth of 0; no data could possibly be stored. Indeed, the underlying DDS implementations don't actually support this. It currently "works" because a KeepLast depth of 0 is assumed to be system default, so the RMW layer typically chooses "1" instead. But this isn't something we should be encouraging users to do, so add a warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is the rclpy companion PR to https://github.com/ros2/rclcpp/pull/2048