### PR TITLE
Add documentation page for rclpy.clock

### DIFF
--- a/rclpy/docs/source/api.rst
+++ b/rclpy/docs/source/api.rst
@@ -5,6 +5,7 @@ API
    :maxdepth: 2
    :caption: Contents:
 
+   api/clock
    api/init_shutdown
    api/node
    api/topics

--- a/rclpy/docs/source/api/clock.rst
+++ b/rclpy/docs/source/api/clock.rst
@@ -1,0 +1,4 @@
+Clock
+=====
+
+.. automodule:: rclpy.clock


### PR DESCRIPTION
This adds a documentation page for the clock module, and improves the documentation in that module slightly.

![image](https://user-images.githubusercontent.com/4175662/206597895-f3f7459a-a199-4fe4-a07a-1eb234603679.png)
![image](https://user-images.githubusercontent.com/4175662/206597942-dc0cc095-62ff-4b07-9db9-22d018b5e7cd.png)
