### PR TITLE
Add on_parameter_event method to the AsyncParameterClient.

### DIFF
--- a/rclpy/rclpy/parameter_client.py
+++ b/rclpy/rclpy/parameter_client.py
@@ -16,6 +16,7 @@ import time
 from typing import Callable, List, Optional, Sequence, Union
 
 from rcl_interfaces.msg import Parameter as ParameterMsg
+from rcl_interfaces.msg import ParameterEvent
 from rcl_interfaces.srv import DescribeParameters
 from rcl_interfaces.srv import GetParameters
 from rcl_interfaces.srv import GetParameterTypes
@@ -26,8 +27,12 @@ from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
 from rclpy.parameter import Parameter as Parameter
 from rclpy.parameter import parameter_dict_from_yaml_file
+from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
+from rclpy.qos_event import SubscriptionEventCallbacks
+from rclpy.qos_overriding_options import QoSOverridingOptions
+from rclpy.subscription import Subscription
 from rclpy.task import Future
 
 
@@ -43,7 +48,7 @@ class AsyncParameterClient:
 
         An AsyncParameterClient that uses services offered by a remote node
         to query and modify parameters in a streamlined way.
-        
+
         Usage example:
 
         .. code-block:: python
@@ -329,3 +334,22 @@ class AsyncParameterClient:
         param_dict = parameter_dict_from_yaml_file(parameter_file, use_wildcard)
         future = self.set_parameters_atomically(list(param_dict.values()), callback=callback)
         return future
+
+    def on_parameter_event(
+        self, callback: Callable,
+        qos_profile: QoSProfile = qos_profile_parameter_events,
+        *,
+        callback_group: Optional[CallbackGroup] = None,
+        event_callbacks: Optional[SubscriptionEventCallbacks] = None,
+        qos_overriding_options: Optional[QoSOverridingOptions] = None,
+        raw: bool = False
+    ) -> Subscription:
+        return self.node.create_subscription(
+            ParameterEvent,
+            '/parameter_events',
+            callback,
+            qos_profile,
+            callback_group=callback_group,
+            event_callbacks=event_callbacks,
+            qos_overriding_options=qos_overriding_options,
+            raw=raw)


### PR DESCRIPTION
This essentially is just a subscription to the /parameter_event topic, but makes it match the rclcpp API of the same name.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix https://github.com/ros2/rclpy/issues/1060