### PR TITLE
Fix `test_publisher` linter for pydocstyle 6.2.2

### DIFF
--- a/rclpy/test/test_publisher.py
+++ b/rclpy/test/test_publisher.py
@@ -63,14 +63,11 @@ class TestPublisher(unittest.TestCase):
         The node will create publishers with topic in test_topics, and then test if
         the publisher's topic_name property is equal to the expected value.
 
-        Args:
-        ----
-            test_topics: A list of binary tuple in the form (topic, expected topic), the
+        :param test_topics: A list of binary tuple in the form (topic, expected topic), the
             former will be passed to node.create_publisher and the latter will be compared
             with publisher.topic_name
-            node: The node used to create the publisher. The node's namespace will have
+        :param node: The node used to create the publisher. The node's namespace will have
             an effect on the publisher's topic_name.
-
         """
         for topic, target_topic in test_topics:
             publisher = node.create_publisher(BasicTypes, topic, 1)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

[`do_test_topic_name` docstring](https://github.com/ros2/rclpy/blob/rolling/rclpy/test/test_publisher.py#L60) is different from others in rclpy (e.g., [utilities](https://github.com/ros2/rclpy/blob/d2901dded38267b59b6d492cb64425c5bcacf650/rclpy/rclpy/utilities.py#L46)), this causes a test regression in pep257 with the new pydocstyle 6.2.0 version.

This PR changes this docstring format, so it can pass pep257 tests. 

Reference builds:
* [Linux](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/2535/), [Aarch64](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/2219/), [Windows](https://ci.ros2.org/view/nightly/job/nightly_win_deb/2596/)