### PR TITLE
Issue 1064

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -102,6 +102,11 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/utils.cpp
   src/rclpy/wait_set.cpp
 )
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+	target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
+endif()
+
 target_include_directories(_rclpy_pybind11 PRIVATE
   src/rclpy/
 )

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -104,7 +104,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
 )
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-	target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
+  target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
 endif()
 
 target_include_directories(_rclpy_pybind11 PRIVATE


### PR DESCRIPTION
This fixes https://github.com/ros2/rclpy/issues/1064. 
When building with Clang, tell cmake to link atomic
to the _rclpy_pybind11 target.

Signed-off-by: Sebastian Freitag
<sebastian.freitag@pylot.tech>