### PR TITLE
Call destroy() before removing ServerGoalHandle

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -405,6 +405,7 @@ class ActionServer(Waitable):
     async def _execute_expire_goals(self, expired_goals):
         for goal in expired_goals:
             goal_uuid = bytes(goal.goal_id.uuid)
+            self._goal_handles[goal_uuid].destroy()
             del self._goal_handles[goal_uuid]
 
     def _send_result_response(self, request_header, future):


### PR DESCRIPTION
Signed-off-by: Tamaki Nishino <otamachan@gmail.com>

As reported by @longjie0723 here https://answers.ros.org/question/411394/rclpy-action-server-seems-slowing-down-and-consuming-memory-in-long-term/ ,Python `ActionServer` could keep `Future` objects while it's running, which causes memory consumption increase and the performance issue.
It seems that it's because `ServerGoalHandler` [registers `Future`](https://github.com/ros2/rclpy/blob/fb1058935f25f20a5ba9552994b9b63a3edd36f9/rclpy/rclpy/action/server.py#L74) when it is constructed and unregisters when `destroy()` is called, but `destroy()` is not called when the object is removed [here](https://github.com/ros2/rclpy/blob/fb1058935f25f20a5ba9552994b9b63a3edd36f9/rclpy/rclpy/action/server.py#L408) .

This PR calls `destroy()` before `ServerGoalHandler` is deleted.

I confirmed the [the original issue](https://answers.ros.org/question/411394/rclpy-action-server-seems-slowing-down-and-consuming-memory-in-long-term/) is resolved by this PR.