### PR TITLE
Fix #983 by saving future and checking for + raising any exceptions

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -777,13 +777,10 @@ class MultiThreadedExecutor(Executor):
         else:
             self._executor.submit(handler)
             self.futures.append(handler)
-            # check for any exceptions
-            for future in self.futures:
+            for future in self.futures:  # check for any exceptions
                 if future.done():
-                    if future._exception:
-                        self.futures.remove(future)
-                        raise future._exception
                     self.futures.remove(future)
+                    future.result()
 
     def spin_once(self, timeout_sec: float = None) -> None:
         self._spin_once_impl(timeout_sec)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -755,7 +755,7 @@ class MultiThreadedExecutor(Executor):
             warnings.warn(
                 'MultiThreadedExecutor is used with a single thread.\n'
                 'Use the SingleThreadedExecutor instead.')
-        self.futures = []
+        self._futures = []
         self._executor = ThreadPoolExecutor(num_threads)
 
     def _spin_once_impl(
@@ -776,10 +776,10 @@ class MultiThreadedExecutor(Executor):
             pass
         else:
             self._executor.submit(handler)
-            self.futures.append(handler)
-            for future in self.futures:  # check for any exceptions
+            self._futures.append(handler)
+            for future in self._futures:  # check for any exceptions
                 if future.done():
-                    self.futures.remove(future)
+                    self._futures.remove(future)
                     future.result()
 
     def spin_once(self, timeout_sec: float = None) -> None:


### PR DESCRIPTION
Fixes #983 while preserving functionality as reported in #1016 

Implementation follows @fujitatomoya 's [recommendation](https://github.com/ros2/rclpy/issues/983#issuecomment-1271782711). Rather than save the executor's returned future, I save the handler since the future doesn't seem to have access to the exception.