### PR TITLE
Use RCPPUTILS_SCOPE_EXIT to cleanup unparsed_indices_c.

### DIFF
--- a/rclpy/src/rclpy/utils.cpp
+++ b/rclpy/src/rclpy/utils.cpp
@@ -263,9 +263,7 @@ throw_if_unparsed_ros_args(py::list pyargs, const rcl_arguments_t & rcl_args)
     throw RCLError("failed to get unparsed arguments");
   }
 
-  auto deallocator = [&](int ptr[]) {allocator.deallocate(ptr, allocator.state);};
-  auto unparsed_indices = std::unique_ptr<int[], decltype(deallocator)>(
-    unparsed_indices_c, deallocator);
+  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(unparsed_indices_c, allocator.state));
 
   py::list unparsed_args;
   for (int i = 0; i < unparsed_ros_args_count; ++i) {


### PR DESCRIPTION
The unique_ptr way to do this works, but clang static analysis complains that data could be leaked if the construction of the unique_ptr fails.  Since this code is really old, switch to using RCPPUTILS_SCOPE_EXIT, which is our more modern way to deal with this problem.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>