### PR TITLE
Force C++17 support on.

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -5,6 +5,7 @@ project(rclpy)
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 # Default to C11
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
This is so we can use clang static analysis to be used with rclpy.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>