### PR TITLE
Add in subscription.get_publisher_count()

### DIFF
--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -76,6 +76,11 @@ class Subscription:
         self.event_handlers: QoSEventHandler = event_callbacks.create_event_handlers(
             callback_group, subscription_impl, topic)
 
+    def get_publisher_count(self) -> int:
+        """Get the number of publishers that this subscription has."""
+        with self.handle:
+            return self.__subscription.get_publisher_count()
+
     @property
     def handle(self):
         return self.__subscription

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -148,7 +148,7 @@ Subscription::take_message(py::object pymsg_type, bool raw)
 }
 
 const char *
-Subscription::get_logger_name()
+Subscription::get_logger_name() const
 {
   const char * node_logger_name = rcl_node_get_logger_name(node_.rcl_ptr());
   if (!node_logger_name) {
@@ -159,7 +159,7 @@ Subscription::get_logger_name()
 }
 
 std::string
-Subscription::get_topic_name()
+Subscription::get_topic_name() const
 {
   const char * subscription_name = rcl_subscription_get_topic_name(rcl_subscription_.get());
   if (nullptr == subscription_name) {
@@ -168,6 +168,19 @@ Subscription::get_topic_name()
 
   return std::string(subscription_name);
 }
+
+size_t
+Subscription::get_publisher_count() const
+{
+  size_t count = 0;
+  rcl_ret_t ret = rcl_subscription_get_publisher_count(rcl_subscription_.get(), &count);
+  if (RCL_RET_OK != ret) {
+    throw RCLError("failed to get publisher count");
+  }
+
+  return count;
+}
+
 void
 define_subscription(py::object module)
 {
@@ -186,6 +199,9 @@ define_subscription(py::object module)
     "Get the name of the logger associated with the node of the subscription.")
   .def(
     "get_topic_name", &Subscription::get_topic_name,
-    "Return the resolved topic name of a subscription.");
+    "Return the resolved topic name of a subscription.")
+  .def(
+    "get_publisher_count", &Subscription::get_publisher_count,
+    "Count the publishers from a subscription.");
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -72,7 +72,7 @@ public:
    * \return None on failure
    */
   const char *
-  get_logger_name();
+  get_logger_name() const;
 
   /// Return the resolved topic name of a subscription.
   /**
@@ -83,7 +83,16 @@ public:
    * \return a string with the topic name
    */
   std::string
-  get_topic_name();
+  get_topic_name() const;
+
+  /// Count publishers from a subscriber.
+  /**
+   * Raises RCLError if the publisher count cannot be determined
+   *
+   * \return number of publishers
+   */
+  size_t
+  get_publisher_count() const;
 
   /// Get rcl_subscription_t pointer
   rcl_subscription_t *

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import pytest
 
 import rclpy
@@ -49,6 +51,10 @@ def test_get_subscription_topic_name(topic_name, namespace, expected):
     )
     assert sub.topic_name == expected
 
+    sub.destroy()
+
+    node.destroy_node()
+
 
 @pytest.mark.parametrize('topic_name, namespace, cli_args, expected', [
     ('topic', None, ['--ros-args', '--remap', 'topic:=new_topic'], '/new_topic'),
@@ -68,6 +74,10 @@ def test_get_subscription_topic_name_after_remapping(topic_name, namespace, cli_
     )
     assert sub.topic_name == expected
 
+    sub.destroy()
+
+    node.destroy_node()
+
 
 def test_subscription_callback_type():
     node = Node('test_node', namespace='test_subscription/test_subscription_callback_type')
@@ -77,15 +87,48 @@ def test_subscription_callback_type():
         qos_profile=10,
         callback=lambda _: None)
     assert sub._callback_type == Subscription.CallbackType.MessageOnly
+    sub.destroy()
+
     sub = node.create_subscription(
         msg_type=Empty,
         topic='test_subscription/test_subscription_callback_type/topic',
         qos_profile=10,
         callback=lambda _, _2: None)
     assert sub._callback_type == Subscription.CallbackType.WithMessageInfo
+    sub.destroy()
+
     with pytest.raises(RuntimeError):
         node.create_subscription(
             msg_type=Empty,
             topic='test_subscription/test_subscription_callback_type/topic',
             qos_profile=10,
             callback=lambda _, _2, _3: None)
+
+    node.destroy_node()
+
+
+def test_subscription_publisher_count():
+    topic_name = 'test_subscription/test_subscription_publisher_count/topic'
+    node = Node('test_node', namespace='test_subscription/test_subscription_publisher_count')
+    sub = node.create_subscription(
+        msg_type=Empty,
+        topic=topic_name,
+        qos_profile=10,
+        callback=lambda _: None)
+
+    assert sub.get_publisher_count() == 0
+
+    pub = node.create_publisher(Empty, topic_name, 10)
+
+    max_seconds_to_wait = 5
+    end_time = time.time() + max_seconds_to_wait
+    while sub.get_publisher_count() != 1:
+        time.sleep(0.05)
+        assert time.time() <= end_time  # timeout waiting for pub/sub to discover each other
+
+    assert sub.get_publisher_count() == 1
+
+    pub.destroy()
+    sub.destroy()
+
+    node.destroy_node()


### PR DESCRIPTION
This is available in the rcl and rclcpp layers, just seems like an oversight that it wasn't available here. I'll also be using this in some upcoming work.