### PR TITLE
Solving Atomic undefined on OSX with clang

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -106,7 +106,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
 )
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
-  target_link_libraries(_rclpy_pybind11 PRIVATE atomic) 
+  target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
 endif()
 
 target_include_directories(_rclpy_pybind11 PRIVATE

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -106,7 +106,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
 )
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
-  target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
+  target_link_libraries(_rclpy_pybind11 PRIVATE atomic) 
 endif()
 
 target_include_directories(_rclpy_pybind11 PRIVATE

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -105,10 +105,6 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/wait_set.cpp
 )
 
-if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
-endif()
-
 target_include_directories(_rclpy_pybind11 PRIVATE
   src/rclpy/
 )

--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -105,6 +105,10 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/wait_set.cpp
 )
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
+  target_link_libraries(_rclpy_pybind11 PRIVATE atomic)
+endif()
+
 target_include_directories(_rclpy_pybind11 PRIVATE
   src/rclpy/
 )


### PR DESCRIPTION
This is related to issue #1095 where building ROS 2 from source would fail at this package on OSX Ventura 13.2.1 with clang. I know MacOS is a tier 3 platform, but this pull request is very minuscule and doesn't rupture the build or its times significantly, just opening up other opportunities. Apple Clang cannot process atomic early in the build process so it just can't be included in the main `CMakeLists.txt` but it doesn't cause any issues later in this package so it is included elsewhere.