### PR TITLE
Make rcl_interfaces a build and exec dependency.

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(ament_cmake_python REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcl_action REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rcl_lifecycle REQUIRED)
 find_package(rcl_logging_interface REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
@@ -117,6 +118,7 @@ target_link_libraries(_rclpy_pybind11 PRIVATE
   lifecycle_msgs::lifecycle_msgs__rosidl_typesupport_c
   rcl::rcl
   rcl_action::rcl_action
+  ${rcl_interfaces_TARGETS}
   rcl_lifecycle::rcl_lifecycle
   rcl_logging_interface::rcl_logging_interface
   rcpputils::rcpputils

--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -24,6 +24,7 @@
   <build_depend>rmw_implementation_cmake</build_depend>
 
   <depend>rcl</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rcl_lifecycle</depend>
   <depend>rcl_logging_interface</depend>
   <depend>rcl_action</depend>
@@ -35,7 +36,6 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>
   <exec_depend>rpyutils</exec_depend>
 


### PR DESCRIPTION
It is required for both, so set it for both and find it in the CMakeLists.txt as appropriate.