### PR TITLE
Implement logging service

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -181,6 +181,7 @@ if(BUILD_TESTING)
       test/test_init_shutdown.py
       test/test_logging.py
       test/test_logging_rosout.py
+      test/test_logging_service.py
       test/test_messages.py
       test/test_node.py
       test/test_parameter.py

--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -143,7 +143,8 @@ def create_node(
     start_parameter_services: bool = True,
     parameter_overrides: List[Parameter] = None,
     allow_undeclared_parameters: bool = False,
-    automatically_declare_parameters_from_overrides: bool = False
+    automatically_declare_parameters_from_overrides: bool = False,
+    enable_logger_service: bool = False
 ) -> 'Node':
     """
     Create an instance of :class:`.Node`.
@@ -165,6 +166,9 @@ def create_node(
         This option doesn't affect `parameter_overrides`.
     :param automatically_declare_parameters_from_overrides: If True, the "parameter overrides" will
         be used to implicitly declare parameters on the node during creation, default False.
+    :param enable_logger_service: ``True`` if ROS2 services are created to allow external nodes
+        to get and set logger levels of this node. Otherwise, loggers are only configured locally.
+        That is, logger levels cannot be changed remotely..
     :return: An instance of the newly created node.
     """
     # imported locally to avoid loading extensions on module import
@@ -178,7 +182,9 @@ def create_node(
         allow_undeclared_parameters=allow_undeclared_parameters,
         automatically_declare_parameters_from_overrides=(
             automatically_declare_parameters_from_overrides
-        ))
+        ),
+        enable_logger_service=enable_logger_service
+        )
 
 
 def spin_once(node: 'Node', *, executor: 'Executor' = None, timeout_sec: float = None) -> None:

--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -43,13 +43,18 @@ def clear_config():
     initialize()
 
 
-def set_logger_level(name, level):
+def set_logger_level(name, level, detailed_error=False):
     level = LoggingSeverity(level)
-    return _rclpy.rclpy_logging_set_logger_level(name, level)
+    return _rclpy.rclpy_logging_set_logger_level(name, level, detailed_error)
 
 
 def get_logger_effective_level(name):
     logger_level = _rclpy.rclpy_logging_get_logger_effective_level(name)
+    return LoggingSeverity(logger_level)
+
+
+def get_logger_level(name):
+    logger_level = _rclpy.rclpy_logging_get_logger_level(name)
     return LoggingSeverity(logger_level)
 
 

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -1,0 +1,66 @@
+# Copyright 2023 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult
+from rcl_interfaces.srv import GetLoggerLevels
+from rcl_interfaces.srv import SetLoggerLevels
+import rclpy
+from rclpy.qos import qos_profile_services_default
+from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
+
+
+class LoggingService:
+
+    def __init__(self, node):
+        node_name = node.get_name()
+
+        get_logger_name_service_name = \
+            TOPIC_SEPARATOR_STRING.join((node_name, 'get_logger_levels'))
+        node.create_service(
+            GetLoggerLevels, get_logger_name_service_name,
+            self._get_logger_levels, qos_profile=qos_profile_services_default
+        )
+
+        set_logger_name_service_name = \
+            TOPIC_SEPARATOR_STRING.join((node_name, 'set_logger_levels'))
+        node.create_service(
+            SetLoggerLevels, set_logger_name_service_name,
+            self._set_logger_levels, qos_profile=qos_profile_services_default
+        )
+
+    def _get_logger_levels(self, request, response):
+        for name in request.names:
+            logger_level = LoggerLevel()
+            logger_level.name = name
+            try:
+                ret_level = rclpy.logging.get_logger_level(name)
+            except RuntimeError:
+                ret_level = 0
+            logger_level.level = ret_level
+            response.levels.append(logger_level)
+        return response
+
+    def _set_logger_levels(self, request, response):
+        for level in request.levels:
+            result = SetLoggerLevelsResult()
+            result.successful = False
+            try:
+                rclpy.logging.set_logger_level(level.name, level.level, detailed_error=True)
+                result.successful = True
+            except ValueError:
+                result.reason = 'Failed reason: Invaild logger level.'
+            except RuntimeError as e:
+                result.reason = str(e)
+            response.results.append(result)
+        return response

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -63,6 +63,7 @@ from rclpy.expand_topic_name import expand_topic_name
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.logging import get_logger
+from rclpy.logging_service import LoggingService
 from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
 from rclpy.parameter_service import ParameterService
 from rclpy.publisher import Publisher
@@ -126,7 +127,8 @@ class Node:
         start_parameter_services: bool = True,
         parameter_overrides: List[Parameter] = None,
         allow_undeclared_parameters: bool = False,
-        automatically_declare_parameters_from_overrides: bool = False
+        automatically_declare_parameters_from_overrides: bool = False,
+        enable_logger_service: bool = False
     ) -> None:
         """
         Create a Node.
@@ -150,6 +152,9 @@ class Node:
             This flag affects the behavior of parameter-related operations.
         :param automatically_declare_parameters_from_overrides: If True, the "parameter overrides"
             will be used to implicitly declare parameters on the node during creation.
+        :param enable_logger_service: ``True`` if ROS2 services are created to allow external nodes
+            to get and set logger levels of this node. Otherwise, loggers are only configured
+            locally. That is, logger levels cannot be changed remotely..
         """
         self.__handle = None
         self._context = get_default_context() if context is None else context
@@ -230,6 +235,9 @@ class Node:
 
         if start_parameter_services:
             self._parameter_service = ParameterService(self)
+
+        if enable_logger_service:
+            self._logger_service = LoggingService(self)
 
     @property
     def publishers(self) -> Iterator[Publisher]:

--- a/rclpy/src/rclpy/_rclpy_logging.cpp
+++ b/rclpy/src/rclpy/_rclpy_logging.cpp
@@ -26,6 +26,7 @@ namespace py = pybind11;
 #include <stdexcept>
 #include <string>
 
+#include "exceptions.hpp"
 #include "logging.hpp"
 #include "logging_api.hpp"
 
@@ -63,15 +64,20 @@ rclpy_logging_shutdown()
  *
  * \param[in] name Fully-qualified name of logger.
  * \param[in] level to set
+ * \param[in] detailed_error True for reporting detailed rcutils error.
  * \return None
  */
 void
-rclpy_logging_set_logger_level(const char * name, int level)
+rclpy_logging_set_logger_level(const char * name, int level, bool detailed_error = false)
 {
   rcutils_ret_t ret = rcutils_logging_set_logger_level(name, level);
   if (ret != RCUTILS_RET_OK) {
-    rcutils_reset_error();
-    throw std::runtime_error("Failed to set level for logger");
+    if (detailed_error) {
+      throw std::runtime_error(rclpy::append_rcutils_error("Failed reason"));
+    } else {
+      rcutils_reset_error();
+      throw std::runtime_error("Failed to set level for logger");
+    }
   }
 }
 
@@ -92,6 +98,25 @@ rclpy_logging_get_logger_effective_level(const char * name)
   if (logger_level < 0) {
     rcutils_reset_error();
     throw std::runtime_error("Failed to get effective level for logger");
+  }
+  return logger_level;
+}
+
+/// Get the level of a logger
+/**
+ * This considers the severity level of the specifed logger only.
+ *
+ * \param[in] name Fully-qualified name of logger.
+ * \return The level of the logger
+ */
+int
+rclpy_logging_get_logger_level(const char * name)
+{
+  int logger_level = rcutils_logging_get_logger_level(name);
+
+  if (logger_level < 0) {
+    rcutils_reset_error();
+    throw std::runtime_error("Failed to get level for logger");
   }
   return logger_level;
 }
@@ -214,7 +239,9 @@ define_logging_api(py::module m)
   m.def("rclpy_logging_get_separator_string", []() {return RCUTILS_LOGGING_SEPARATOR_STRING;});
   m.def("rclpy_logging_initialize", &rclpy_logging_initialize);
   m.def("rclpy_logging_shutdown", &rclpy_logging_shutdown);
-  m.def("rclpy_logging_set_logger_level", &rclpy_logging_set_logger_level);
+  m.def(
+    "rclpy_logging_set_logger_level", &rclpy_logging_set_logger_level,
+    py::arg("name"), py::arg("level"), py::arg("detailed_error") = false);
   m.def("rclpy_logging_get_logger_effective_level", &rclpy_logging_get_logger_effective_level);
   m.def("rclpy_logging_logger_is_enabled_for", &rclpy_logging_logger_is_enabled_for);
   m.def("rclpy_logging_rcutils_log", &rclpy_logging_rcutils_log);
@@ -222,5 +249,6 @@ define_logging_api(py::module m)
   m.def("rclpy_logging_get_logging_directory", &rclpy_logging_get_logging_directory);
   m.def("rclpy_logging_rosout_add_sublogger", &rclpy_logging_rosout_add_sublogger);
   m.def("rclpy_logging_rosout_remove_sublogger", &rclpy_logging_rosout_remove_sublogger);
+  m.def("rclpy_logging_get_logger_level", &rclpy_logging_get_logger_level);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/_rclpy_logging.cpp
+++ b/rclpy/src/rclpy/_rclpy_logging.cpp
@@ -23,12 +23,15 @@ namespace py = pybind11;
 #include <rcl_logging_interface/rcl_logging_interface.h>
 #include <rcl/logging_rosout.h>
 
+#include <mutex>
 #include <stdexcept>
 #include <string>
 
 #include "exceptions.hpp"
 #include "logging.hpp"
 #include "logging_api.hpp"
+
+std::mutex g_logging_lock;
 
 /// Initialize the logging system.
 /**
@@ -70,6 +73,7 @@ rclpy_logging_shutdown()
 void
 rclpy_logging_set_logger_level(const char * name, int level, bool detailed_error = false)
 {
+  std::lock_guard<std::mutex> lock(g_logging_lock);
   rcutils_ret_t ret = rcutils_logging_set_logger_level(name, level);
   if (ret != RCUTILS_RET_OK) {
     if (detailed_error) {
@@ -93,6 +97,7 @@ rclpy_logging_set_logger_level(const char * name, int level, bool detailed_error
 int
 rclpy_logging_get_logger_effective_level(const char * name)
 {
+  std::lock_guard<std::mutex> lock(g_logging_lock);
   int logger_level = rcutils_logging_get_logger_effective_level(name);
 
   if (logger_level < 0) {
@@ -112,6 +117,7 @@ rclpy_logging_get_logger_effective_level(const char * name)
 int
 rclpy_logging_get_logger_level(const char * name)
 {
+  std::lock_guard<std::mutex> lock(g_logging_lock);
   int logger_level = rcutils_logging_get_logger_level(name);
 
   if (logger_level < 0) {

--- a/rclpy/test/test_logging_service.py
+++ b/rclpy/test/test_logging_service.py
@@ -1,0 +1,238 @@
+# Copyright 2023 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+
+import unittest
+
+from rcl_interfaces.msg import LoggerLevel
+from rcl_interfaces.srv import GetLoggerLevels
+from rcl_interfaces.srv import SetLoggerLevels
+import rclpy
+import rclpy.context
+from rclpy.executors import SingleThreadedExecutor
+
+
+class TestLoggingService(unittest.TestCase):
+
+    def setUp(self):
+        self.context = rclpy.context.Context()
+        rclpy.init(context=self.context)
+        self.test_node_with_logger_service = rclpy.create_node(
+            'test_node_with_logger_service_enabled',
+            namespace='/rclpy',
+            context=self.context,
+            enable_logger_service=True)
+
+        self.test_node = rclpy.create_node(
+            'test_logger_service',
+            namespace='/rclpy',
+            context=self.context)
+
+        self.executor1 = SingleThreadedExecutor(context=self.context)
+        self.executor1.add_node(self.test_node_with_logger_service)
+
+        self.executor2 = SingleThreadedExecutor(context=self.context)
+        self.executor2.add_node(self.test_node)
+
+        self.thread = threading.Thread(target=self.executor1.spin, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.executor1.shutdown()
+        self.thread.join()
+        self.executor2.shutdown()
+        self.test_node.destroy_node()
+        self.test_node_with_logger_service.destroy_node()
+        rclpy.shutdown(context=self.context)
+
+    def test_connect_get_logging_service(self):
+        client = self.test_node.create_client(
+            GetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/get_logger_levels')
+        try:
+            self.assertTrue(client.wait_for_service(2))
+        finally:
+            self.test_node.destroy_client(client)
+
+    def test_connect_set_logging_service(self):
+        client = self.test_node.create_client(
+            SetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/set_logger_levels'
+        )
+        try:
+            self.assertTrue(client.wait_for_service(2))
+        finally:
+            self.test_node.destroy_client(client)
+
+    def test_set_and_get_one_logging_level(self):
+        test_log_name = 'rcl'
+        test_log_level = 10
+
+        # Set debug level
+        set_client = self.test_node.create_client(
+            SetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/set_logger_levels')
+        self.assertTrue(set_client.wait_for_service(2))
+        request = SetLoggerLevels.Request()
+        set_level = LoggerLevel()
+        set_level.name = test_log_name
+        set_level.level = test_log_level
+        request.levels.append(set_level)
+        future = set_client.call_async(request)
+        self.executor2.spin_until_future_complete(future, 10)
+        self.assertTrue(future.done())
+        response = future.result()
+        self.assertEqual(len(response.results), 1)
+        self.assertTrue(response.results[0].successful)
+        self.assertEqual(response.results[0].reason, '')  # reason should be empty if successful
+        self.test_node.destroy_client(set_client)
+
+        # Get set level
+        get_client = self.test_node.create_client(
+            GetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/get_logger_levels')
+        self.assertTrue(get_client.wait_for_service(2))
+        request = GetLoggerLevels.Request()
+        request.names = [test_log_name]
+        future = get_client.call_async(request)
+        self.executor2.spin_until_future_complete(future, 10)
+        self.assertTrue(future.done())
+        response = future.result()
+        self.assertEqual(len(response.levels), 1)
+        self.assertEqual(response.levels[0].name, test_log_name)
+        self.assertEqual(response.levels[0].level, test_log_level)
+        self.test_node.destroy_client(get_client)
+
+    def test_set_and_get_multi_logging_level(self):
+        test_log_name1 = 'rcl'
+        test_log_level1 = 20
+
+        test_log_name2 = 'rclpy'
+        test_log_level2 = 30
+
+        test_log_name3 = 'test_node_with_logger_service_enabled'
+        test_log_level3 = 40
+
+        # Set multi log levels
+        request = SetLoggerLevels.Request()
+        set_level = LoggerLevel()
+        set_level.name = test_log_name1
+        set_level.level = test_log_level1
+        request.levels.append(set_level)
+        set_level = LoggerLevel()
+        set_level.name = test_log_name2
+        set_level.level = test_log_level2
+        request.levels.append(set_level)
+        set_level = LoggerLevel()
+        set_level.name = test_log_name3
+        set_level.level = test_log_level3
+        request.levels.append(set_level)
+
+        set_client = self.test_node.create_client(
+            SetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/set_logger_levels')
+        self.assertTrue(set_client.wait_for_service(2))
+
+        future = set_client.call_async(request)
+        self.executor2.spin_until_future_complete(future, 10)
+        self.assertTrue(future.done())
+        response = future.result()
+        self.assertEqual(len(response.results), 3)
+        for result in response.results:
+            self.assertTrue(result.successful)
+            self.assertEqual(result.reason, str())
+        self.test_node.destroy_client(set_client)
+
+        # Get multi log levels
+        get_client = self.test_node.create_client(
+            GetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/get_logger_levels')
+        self.assertTrue(get_client.wait_for_service(2))
+        request = GetLoggerLevels.Request()
+        request.names = [test_log_name1, test_log_name2, test_log_name3]
+        future = get_client.call_async(request)
+        self.executor2.spin_until_future_complete(future, 10)
+        self.assertTrue(future.done())
+        response = future.result()
+        self.assertEqual(len(response.levels), 3)
+        self.assertEqual(response.levels[0].name, test_log_name1)
+        self.assertEqual(response.levels[0].level, test_log_level1)
+        self.assertEqual(response.levels[1].name, test_log_name2)
+        self.assertEqual(response.levels[1].level, test_log_level2)
+        self.assertEqual(response.levels[2].name, test_log_name3)
+        self.assertEqual(response.levels[2].level, test_log_level3)
+        self.test_node.destroy_client(get_client)
+
+    def test_set_logging_level_with_invalid_param(self):
+        set_client = self.test_node.create_client(
+            SetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/set_logger_levels')
+        self.assertTrue(set_client.wait_for_service(2))
+
+        request = SetLoggerLevels.Request()
+        set_level = LoggerLevel()
+        set_level.name = 'test_node_with_logger_service_enabled'
+        set_level.level = 22
+        request.levels.append(set_level)
+        set_level = LoggerLevel()
+        set_level.name = 'rcl'
+        set_level.level = 12
+        request.levels.append(set_level)
+        future = set_client.call_async(request)
+        self.executor2.spin_until_future_complete(future, 10)
+        self.assertTrue(future.done())
+        response = future.result()
+        self.assertEqual(len(response.results), 2)
+        self.assertFalse(response.results[0].successful)
+        self.assertEqual(response.results[0].reason, 'Failed reason: Invaild logger level.')
+        self.assertFalse(response.results[1].successful)
+        self.assertEqual(response.results[1].reason, 'Failed reason: Invaild logger level.')
+        self.test_node.destroy_client(set_client)
+
+    def test_set_logging_level_with_partial_invalid_param(self):
+        set_client = self.test_node.create_client(
+            SetLoggerLevels,
+            '/rclpy/test_node_with_logger_service_enabled/set_logger_levels')
+        self.assertTrue(set_client.wait_for_service(2))
+
+        request = SetLoggerLevels.Request()
+        set_level = LoggerLevel()
+        set_level.name = 'rcl'
+        set_level.level = 10
+        request.levels.append(set_level)
+        set_level = LoggerLevel()
+        set_level.name = 'rclpy'
+        set_level.level = 22  # Invalid logger level
+        request.levels.append(set_level)
+        set_level = LoggerLevel()
+        set_level.name = 'test_node_with_logger_service_enabled'
+        set_level.level = 30
+        request.levels.append(set_level)
+        future = set_client.call_async(request)
+        self.executor2.spin_until_future_complete(future, 10)
+        self.assertTrue(future.done())
+        response = future.result()
+        self.assertEqual(len(response.results), 3)
+        self.assertTrue(response.results[0].successful)
+        self.assertEqual(response.results[0].reason, '')
+        self.assertFalse(response.results[1].successful)
+        self.assertEqual(response.results[1].reason, 'Failed reason: Invaild logger level.')
+        self.assertTrue(response.results[2].successful)
+        self.assertEqual(response.results[2].reason, '')
+        self.test_node.destroy_client(set_client)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Address ros2/ros2#1355

The commit `Add the lock for get/set logger` (732853b1a9d5cb90ba383eea0bdd3596d0559713) can be reverted after ros2/rcutils#397 is implemented.