### PR TITLE
Include type hash in topic endpoint info (rep2011)

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -203,6 +203,7 @@ if(BUILD_TESTING)
       test/test_topic_or_service_is_hidden.py
       test/test_topic_endpoint_info.py
       test/test_type_support.py
+      test/test_type_hash.py
       test/test_utilities.py
       test/test_validate_full_topic_name.py
       test/test_validate_namespace.py

--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -15,6 +15,7 @@
 from enum import IntEnum
 
 from rclpy.qos import QoSHistoryPolicy, QoSPresetProfiles, QoSProfile
+from rclpy.type_hash import TypeHash
 
 
 class TopicEndpointTypeEnum(IntEnum):
@@ -36,6 +37,7 @@ class TopicEndpointInfo:
         '_node_name',
         '_node_namespace',
         '_topic_type',
+        '_topic_type_hash',
         '_endpoint_type',
         '_endpoint_gid',
         '_qos_profile'
@@ -48,6 +50,7 @@ class TopicEndpointInfo:
         self.node_name = kwargs.get('node_name', '')
         self.node_namespace = kwargs.get('node_namespace', '')
         self.topic_type = kwargs.get('topic_type', '')
+        self.topic_type_hash = kwargs.get('topic_type_hash', TypeHash())
         self.endpoint_type = kwargs.get('endpoint_type', TopicEndpointTypeEnum.INVALID)
         self.endpoint_gid = kwargs.get('endpoint_gid', [])
         self.qos_profile = kwargs.get('qos_profile', QoSPresetProfiles.UNKNOWN.value)
@@ -96,6 +99,25 @@ class TopicEndpointInfo:
     def topic_type(self, value):
         assert isinstance(value, str)
         self._topic_type = value
+
+    @property
+    def topic_type_hash(self):
+        """
+        Get field 'topic_type_hash'.
+
+        :returns: topic_type_hash attribute
+        :rtype: TypeHash
+        """
+        return self._topic_type_hash
+
+    @topic_type_hash.setter
+    def topic_type_hash(self, value):
+        if isinstance(value, TypeHash):
+            self._topic_type_hash = value
+        elif isinstance(value, dict):
+            self._topic_type_hash = TypeHash(**value)
+        else:
+            assert False
 
     @property
     def endpoint_type(self):
@@ -167,7 +189,7 @@ class TopicEndpointInfo:
             f'Node name: {self.node_name}',
             f'Node namespace: {self.node_namespace}',
             f'Topic type: {self.topic_type}',
-            'Topic type hash: UNKNOWN',
+            f'Topic type hash: {self.topic_type_hash}',
             f'Endpoint type: {self.endpoint_type.name}',
             f'GID: {gid}',
             'QoS profile:',

--- a/rclpy/rclpy/type_hash.py
+++ b/rclpy/rclpy/type_hash.py
@@ -1,0 +1,74 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class TypeHash:
+    """Type hash."""
+
+    _TYPE_HASH_SIZE = 32
+
+    __slots__ = [
+        '_version',
+        '_value',
+    ]
+
+    def __init__(self, **kwargs):
+        assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
+            'Invalid arguments passed to constructor: %r' % kwargs.keys()
+
+        self.version = kwargs.get('version', -1)
+        self.value = kwargs.get('value', bytes(self._TYPE_HASH_SIZE))
+
+    @property
+    def version(self):
+        """
+        Get field 'version'.
+
+        :returns: version attribute
+        :rtype: int
+        """
+        return self._version
+
+    @version.setter
+    def version(self, value):
+        assert isinstance(value, int)
+        self._version = value
+
+    @property
+    def value(self):
+        """
+        Get field 'value'.
+
+        :returns: value attribute
+        :rtype: bytes
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        assert isinstance(value, bytes)
+        self._value = value
+
+    def __eq__(self, other):
+        if not isinstance(other, TypeHash):
+            return False
+        return all(
+            self.__getattribute__(slot) == other.__getattribute__(slot)
+            for slot in self.__slots__)
+
+    def __str__(self):
+        if self._version <= 0 or len(self._value) != self._TYPE_HASH_SIZE:
+            return 'INVALID'
+
+        return f'RIHS{self._version:02}_{self._value.hex()}'

--- a/rclpy/src/rclpy/utils.cpp
+++ b/rclpy/src/rclpy/utils.cpp
@@ -306,6 +306,8 @@ _convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic_endpo
   py_endpoint_info_dict["node_name"] = py::str(topic_endpoint_info->node_name);
   py_endpoint_info_dict["node_namespace"] = py::str(topic_endpoint_info->node_namespace);
   py_endpoint_info_dict["topic_type"] = py::str(topic_endpoint_info->topic_type);
+  py_endpoint_info_dict["topic_type_hash"] =
+    convert_to_type_hash_dict(&topic_endpoint_info->topic_type_hash);
   py_endpoint_info_dict["endpoint_type"] =
     py::int_(static_cast<int>(topic_endpoint_info->endpoint_type));
   py_endpoint_info_dict["endpoint_gid"] = py_endpoint_gid;
@@ -362,5 +364,19 @@ convert_to_qos_dict(const rmw_qos_profile_t * qos_profile)
     py::bool_(qos_profile->avoid_ros_namespace_conventions);
 
   return pyqos_kwargs;
+}
+
+py::dict
+convert_to_type_hash_dict(const rosidl_type_hash_t * type_hash)
+{
+  // Create dictionary and populate arguments with type hash object
+  py::dict type_hash_kwargs;
+
+  type_hash_kwargs["version"] = py::int_(type_hash->version);
+  type_hash_kwargs["value"] = py::bytes(
+    reinterpret_cast<const char *>(type_hash->value),
+    ROSIDL_TYPE_HASH_SIZE);
+
+  return type_hash_kwargs;
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/utils.hpp
+++ b/rclpy/src/rclpy/utils.hpp
@@ -149,6 +149,14 @@ convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array_t * i
  */
 py::dict
 convert_to_qos_dict(const rmw_qos_profile_t * qos_profile);
+
+/// Convert a C rosidl_type_hash_t into a Python dictionary.
+/**
+ * \param[in] type_hash Pointer to a rosidl_type_hash_t to convert
+ * \return Python dictionary
+ */
+py::dict
+convert_to_type_hash_dict(const rosidl_type_hash_t * type_hash);
 }  // namespace rclpy
 
 #endif  // RCLPY__UTILS_HPP_

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -93,7 +93,7 @@ class TestQosProfile(unittest.TestCase):
         expected_info_str = 'Node name: \n' \
             'Node namespace: \n' \
             'Topic type: \n' \
-            'Topic type hash: UNKNOWN\n' \
+            'Topic type hash: INVALID\n' \
             'Endpoint type: INVALID\n' \
             'GID: \n' \
             'QoS profile:\n' \

--- a/rclpy/test/test_type_hash.py
+++ b/rclpy/test/test_type_hash.py
@@ -1,0 +1,44 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.type_hash import TypeHash
+
+# From std_msgs/msg/String.json
+STD_MSGS_STRING_TYPE_HASH_DICT = {
+    'version': 1,
+    'value': b'\xdf\x66\x8c\x74\x04\x82\xbb\xd4\x8f\xb3\x9d\x76\xa7\x0d\xfd\x4b'
+             b'\xd5\x9d\xb1\x28\x80\x21\x74\x35\x03\x25\x9e\x94\x8f\x6b\x1a\x18',
+}
+STD_MSGS_STRING_TYPE_HASH_STR = 'RIHS01_' \
+                                'df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18'
+
+
+class TestTypeHash(unittest.TestCase):
+
+    def test_dict_constructor(self):
+        type_hash = TypeHash(**STD_MSGS_STRING_TYPE_HASH_DICT)
+        self.assertEqual(STD_MSGS_STRING_TYPE_HASH_DICT['version'], type_hash.version)
+        self.assertEqual(STD_MSGS_STRING_TYPE_HASH_DICT['value'], type_hash.value)
+
+    def test_print_valid(self):
+        actual_str = str(TypeHash(**STD_MSGS_STRING_TYPE_HASH_DICT))
+        expected_str = STD_MSGS_STRING_TYPE_HASH_STR
+        self.assertEqual(expected_str, actual_str)
+
+    def test_print_invalid(self):
+        actual_str = str(TypeHash())
+        expected_str = 'INVALID'
+        self.assertEqual(expected_str, actual_str)


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1159

Features
- Adds the `TypeHash` class
- Adds the type hash to the `TopicEndpointInfo` class

This will print the type hash when printing out verbose topic information with `rostopic info --verbose`. Note that without the `--no-daemon` flag, https://github.com/ros2/ros2cli/pull/816 is required which adds xmlrpc marshalling support for the new `rclpy.type_hash.TypeHash` class