### PR TITLE
[rosdoc2] Use conf.py from docs

### DIFF
--- a/rclpy/docs/source/conf.py
+++ b/rclpy/docs/source/conf.py
@@ -26,9 +26,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -54,7 +54,6 @@ release = '3.2.1'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx_autodoc_typehints',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',

--- a/rclpy/docs/source/index.rst
+++ b/rclpy/docs/source/index.rst
@@ -9,6 +9,7 @@ rclpy provides the canonical Python API for interacting with ROS 2.
    about
    examples
    api
+   modules
 
 Indices and tables
 ==================

--- a/rclpy/rosdoc2.yaml
+++ b/rclpy/rosdoc2.yaml
@@ -65,6 +65,6 @@ builders:
         ## This path is relative to output staging.
         # doxygen_xml_directory: 'generated/doxygen/xml',
         # todo: Provide user sphinx_sourcedir below after warnings have been addressed.
-        # sphinx_sourcedir: 'docs/source/',
+        sphinx_sourcedir: 'docs/source/',
         output_dir: ''
     }


### PR DESCRIPTION
Document generation for `rclpy` on the buildfarm should work out of the box with https://github.com/ros-infrastructure/rosdoc2/pull/52 since we're not using the docs/source/conf.py script.

This PR aims to use the custom conf.py instead. The downside is that there are over 300 warnings now related to cross references (documentation will still generate successfully). The advantage is incorporating the toctree in the specified index.html which includes about, examples, api sections.