### PR TITLE
Stub type hash value line in TopicEndpointInfo string

### DIFF
--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -167,6 +167,7 @@ class TopicEndpointInfo:
             f'Node name: {self.node_name}',
             f'Node namespace: {self.node_namespace}',
             f'Topic type: {self.topic_type}',
+            'Topic type hash: UNKNOWN',
             f'Endpoint type: {self.endpoint_type.name}',
             f'GID: {gid}',
             'QoS profile:',

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -93,6 +93,7 @@ class TestQosProfile(unittest.TestCase):
         expected_info_str = 'Node name: \n' \
             'Node namespace: \n' \
             'Topic type: \n' \
+            'Topic type hash: UNKNOWN\n' \
             'Endpoint type: INVALID\n' \
             'GID: \n' \
             'QoS profile:\n' \


### PR DESCRIPTION
Part of ros2/ros2#1159

Enables https://github.com/ros2/rclpy/pull/1104 and https://github.com/ros2/ros2cli/pull/816 as backports for first Iron sync (post-release). 

Adds extra line for "Topic type hash:" to string representation of  `TopicEndpointInfo`, in case any parsers expect specific format from that string.