### PR TITLE
Fix unnecessary list comprehension flake8

### DIFF
--- a/rclpy/test/test_parameter_client.py
+++ b/rclpy/test/test_parameter_client.py
@@ -146,7 +146,7 @@ class TestParameterClient(unittest.TestCase):
             result = future.result()
             assert result is not None
             assert len(result.results) == 2
-            assert all([i.successful for i in result.results])
+            assert all(i.successful for i in result.results)
         finally:
             if os.path.exists(f.name):
                 os.unlink(f.name)


### PR DESCRIPTION
Fixes recent CI failure: https://ci.ros2.org/job/ci_linux/18542/testReport/junit/rclpy/flake8/C419____test_test_parameter_client_py_149_20_/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18550)](http://ci.ros2.org/job/ci_linux/18550/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13094)](http://ci.ros2.org/job/ci_linux-aarch64/13094/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=19284)](http://ci.ros2.org/job/ci_windows/19284/)