### PR TITLE
ServerGoalHandle should be destroyed before removing.

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -70,8 +70,6 @@ class ServerGoalHandle:
         self._goal_info = goal_info
         self._goal_request = goal_request
         self._cancel_requested = False
-        self._result_future = Future()
-        action_server.add_future(self._result_future)
         self._lock = threading.Lock()
 
     def __eq__(self, other):
@@ -163,8 +161,6 @@ class ServerGoalHandle:
                 return
             self._goal_handle.destroy_when_not_in_use()
             self._goal_handle = None
-
-        self._action_server.remove_future(self._result_future)
 
 
 def default_handle_accepted_callback(goal_handle):
@@ -260,6 +256,9 @@ class ActionServer(Waitable):
         # key: UUID in bytes, value: GoalHandle
         self._goal_handles = {}
 
+        # key: UUID in bytes, value: Future
+        self._result_futures = {}
+
         callback_group.add_entity(self)
         self._node.add_waitable(self)
         self._logger = self._node.get_logger().get_child('action_server')
@@ -300,6 +299,8 @@ class ActionServer(Waitable):
                 accepted = False
             else:
                 self._goal_handles[bytes(goal_uuid.uuid)] = goal_handle
+                self._result_futures[bytes(goal_uuid.uuid)] = Future()
+                self.add_future(self._result_futures[bytes(goal_uuid.uuid)])
 
         # Send response
         response_msg = self._action_type.Impl.SendGoalService.Response()
@@ -342,7 +343,7 @@ class ActionServer(Waitable):
         result_response = self._action_type.Impl.GetResultService.Response()
         result_response.status = goal_handle.status
         result_response.result = execute_result
-        goal_handle._result_future.set_result(result_response)
+        self._result_futures[bytes(goal_uuid)].set_result(result_response)
 
     async def _execute_cancel_request(self, request_header_and_message):
         request_header, cancel_request = request_header_and_message
@@ -399,13 +400,16 @@ class ActionServer(Waitable):
 
         # There is an accepted goal matching the goal ID, register a callback to send the
         # response as soon as it's ready
-        self._goal_handles[bytes(goal_uuid)]._result_future.add_done_callback(
+        self._result_futures[bytes(goal_uuid)].add_done_callback(
             functools.partial(self._send_result_response, request_header))
 
     async def _execute_expire_goals(self, expired_goals):
         for goal in expired_goals:
             goal_uuid = bytes(goal.goal_id.uuid)
+            self._goal_handles[goal_uuid].destroy()
             del self._goal_handles[goal_uuid]
+            self.remove_future(self._result_futures[goal_uuid])
+            del self._result_futures[goal_uuid]
 
     def _send_result_response(self, request_header, future):
         self._handle.send_result_response(request_header, future.result())
@@ -599,6 +603,10 @@ class ActionServer(Waitable):
         """Destroy the underlying action server handle."""
         for goal_handle in self._goal_handles.values():
             goal_handle.destroy()
+
+        """Remove the underlying result future."""
+        for result_future in self._result_futures.values():
+            self.remove_future(result_future)
 
         self._handle.destroy_when_not_in_use()
         self._node.remove_waitable(self)


### PR DESCRIPTION
replace https://github.com/ros2/rclpy/pull/1070.

This PR addresses the following two issues.

1. memory leak. It should call destroy() before removing `ServerGoalHandle`. (original issue https://answers.ros.org/question/411394/rclpy-action-server-seems-slowing-down-and-consuming-memory-in-long-term/)
2. `ActionServer` should own the `result_future`, but `ServerGoalHandle`. (see https://github.com/ros2/rclpy/pull/1070#discussion_r1080592437) 

@otamachan i borrowed your code from https://github.com/ros2/rclpy/pull/1070, so added you as Co-Author.
