### PR TITLE
Fix typing in Node init args

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -125,7 +125,7 @@ class Node:
         use_global_arguments: bool = True,
         enable_rosout: bool = True,
         start_parameter_services: bool = True,
-        parameter_overrides: List[Parameter] = None,
+        parameter_overrides: Optional[List[Parameter]] = None,
         allow_undeclared_parameters: bool = False,
         automatically_declare_parameters_from_overrides: bool = False,
         enable_logger_service: bool = False


### PR DESCRIPTION
Fixes this typing issue:

```
Argument of type "None" cannot be assigned to parameter "parameter_overrides" of type "List[Parameter]" in function "__init__"
  Type "None" cannot be assigned to type "List[Parameter]"Pylance[reportGeneralTypeIssues](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues)
```