### PR TITLE
Turn Executor into a ContextManager

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -147,6 +147,16 @@ class Executor(ContextManager['Executor']):
     If the executor has any cleanup then it should also define :meth:`shutdown`.
 
     :param context: The context to be associated with, or ``None`` for the default global context.
+
+    :Example:
+        >>> from rclpy.executor import Executor
+        >>> from rclpy.node import Node
+        >>> 
+        >>> with Executor() as executor:
+        >>>     executor.add_node(Node('example_node'))
+        >>>     executor.spin_once()
+        >>>     len(executor.get_nodes())
+        1
     """
 
     def __init__(self, *, context: Context = None) -> None:

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -20,14 +20,17 @@ from threading import Condition
 from threading import Lock
 from threading import RLock
 import time
+from types import TracebackType
 from typing import Any
 from typing import Callable
+from typing import ContextManager
 from typing import Coroutine
 from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
@@ -132,7 +135,7 @@ class ConditionReachedException(Exception):
     pass
 
 
-class Executor:
+class Executor(ContextManager["Executor"]):
     """
     The base class for an executor.
 
@@ -704,6 +707,18 @@ class Executor:
             except StopIteration:
                 # Generator ran out of work
                 self._cb_iter = None
+
+    def __enter__(self) -> "Executor":
+        # Nothing to do here
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.shutdown()
 
 
 class SingleThreadedExecutor(Executor):

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -135,7 +135,7 @@ class ConditionReachedException(Exception):
     pass
 
 
-class Executor(ContextManager["Executor"]):
+class Executor(ContextManager['Executor']):
     """
     The base class for an executor.
 
@@ -708,7 +708,7 @@ class Executor(ContextManager["Executor"]):
                 # Generator ran out of work
                 self._cb_iter = None
 
-    def __enter__(self) -> "Executor":
+    def __enter__(self) -> 'Executor':
         # Nothing to do here
         return self
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -151,7 +151,7 @@ class Executor(ContextManager['Executor']):
     :Example:
         >>> from rclpy.executor import Executor
         >>> from rclpy.node import Node
-        >>> 
+        >>>
         >>> with Executor() as executor:
         >>>     executor.add_node(Node('example_node'))
         >>>     executor.spin_once()

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -20,6 +20,7 @@ import unittest
 import warnings
 
 import rclpy
+from rclpy.executors import Executor
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.executors import ShutdownException
 from rclpy.executors import SingleThreadedExecutor
@@ -502,6 +503,22 @@ class TestExecutor(unittest.TestCase):
         t.start()
         self.assertTrue(shutdown_event.wait(120))
         self.node.destroy_timer(tmr)
+
+    def test_context_manager(self):
+        self.assertIsNotNone(self.node.handle)
+
+        executor: Executor = SingleThreadedExecutor(context=self.context)
+
+        with executor as the_executor:
+            # Make sure the correct instance is returned
+            assert the_executor is executor
+
+            assert not executor._is_shutdown, "the executor should not be shut down"
+
+        assert executor._is_shutdown, "the executor should now be shut down"
+
+        # Make sure it does not raise (smoke test)
+        executor.shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -513,9 +513,9 @@ class TestExecutor(unittest.TestCase):
             # Make sure the correct instance is returned
             assert the_executor is executor
 
-            assert not executor._is_shutdown, "the executor should not be shut down"
+            assert not executor._is_shutdown, 'the executor should not be shut down'
 
-        assert executor._is_shutdown, "the executor should now be shut down"
+        assert executor._is_shutdown, 'the executor should now be shut down'
 
         # Make sure it does not raise (smoke test)
         executor.shutdown()


### PR DESCRIPTION
Similar to #1117, but for `rclpy.executors.Executor`.