### PR TITLE
GetTypeDescription service

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -102,6 +102,7 @@ pybind11_add_module(_rclpy_pybind11 SHARED
   src/rclpy/subscription.cpp
   src/rclpy/time_point.cpp
   src/rclpy/timer.cpp
+  src/rclpy/type_description_service.cpp
   src/rclpy/utils.cpp
   src/rclpy/wait_set.cpp
 )

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1890,6 +1890,7 @@ class Node:
             self.destroy_timer(self._timers[0])
         while self._guards:
             self.destroy_guard_condition(self._guards[0])
+        self._type_description_service.destroy()
         self.__node.destroy_when_not_in_use()
         self._wake_executor()
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -78,6 +78,7 @@ from rclpy.time_source import TimeSource
 from rclpy.timer import Rate
 from rclpy.timer import Timer
 from rclpy.topic_endpoint_info import TopicEndpointInfo
+from rclpy.type_description_service import TypeDescriptionService
 from rclpy.type_support import check_is_valid_msg_type
 from rclpy.type_support import check_is_valid_srv_type
 from rclpy.utilities import get_default_context
@@ -238,6 +239,8 @@ class Node:
 
         if enable_logger_service:
             self._logger_service = LoggingService(self)
+
+        self._type_description_service = TypeDescriptionService(self)
 
     @property
     def publishers(self) -> Iterator[Publisher]:

--- a/rclpy/rclpy/type_description_service.py
+++ b/rclpy/rclpy/type_description_service.py
@@ -1,0 +1,64 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.parameter import Parameter
+from rclpy.qos import qos_profile_services_default
+from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
+from rclpy.service import Service
+from type_description_interfaces.srv import GetTypeDescription
+
+START_TYPE_DESCRIPTION_SERVICE_PARAM = 'start_type_description_service'
+
+
+class TypeDescriptionService:
+    """
+    """
+
+    def __init__(self, node):
+        node_name = node.get_name()
+        self.service_name = TOPIC_SEPARATOR_STRING.join((node_name, 'get_type_description'))
+
+        self.enabled = False
+        if not node.has_parameter(START_TYPE_DESCRIPTION_SERVICE_PARAM):
+            descriptor = ParameterDescriptor(
+                name=START_TYPE_DESCRIPTION_SERVICE_PARAM,
+                type=ParameterType.PARAMETER_BOOL,
+                description='If enabled, start the ~/get_type_description service.',
+                read_only=True)
+            node.declare_parameter(
+                START_TYPE_DESCRIPTION_SERVICE_PARAM,
+                True,
+                descriptor)
+        param = node.get_parameter(START_TYPE_DESCRIPTION_SERVICE_PARAM)
+        if param.type_ != Parameter.Type.NOT_SET:
+            if param.type_ == Parameter.Type.BOOL:
+                self.enabled = param.value
+            else:
+                node.get_logger().error(
+                    "Invalid type for parameter '{}' {!r} should be bool"
+                    .format(START_TYPE_DESCRIPTION_SERVICE_PARAM, param.type_))
+        else:
+            node.get_logger().debug(
+                'Parameter {} not set, defaulting to true.'
+                .format(START_TYPE_DESCRIPTION_SERVICE_PARAM))
+
+        if self.enabled:
+            self.start_service(node)
+
+    def start_service(self, node):
+        self._service_impl = _rclpy.TypeDescriptionService(node.handle)
+
+    def _service_callback(self, request, response):
+        self._service_impl.handle_request(request, response)

--- a/rclpy/rclpy/type_description_service.py
+++ b/rclpy/rclpy/type_description_service.py
@@ -18,9 +18,9 @@ from rcl_interfaces.msg import ParameterType
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_services_default
-from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 from rclpy.service import Service
 from rclpy.type_support import check_is_valid_srv_type
+from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 from type_description_interfaces.srv import GetTypeDescription
 
@@ -63,18 +63,17 @@ class TypeDescriptionService:
             self.start_service(node)
 
     def start_service(self, node):
-        print("Starting service")  # TODO
         self._tdsrv = _rclpy.TypeDescriptionService(node.handle)
         check_is_valid_srv_type(GetTypeDescription)
-        self._service = Service(
+        service = Service(
             service_impl=self._tdsrv.impl,
             srv_type=GetTypeDescription,
             srv_name=self.service_name,
             callback=self._service_callback,
             callback_group=node.default_callback_group,
             qos_profile=qos_profile_services_default)
-        node.default_callback_group.add_entity(self._service)
-        node._services.append(self._service)
+        node.default_callback_group.add_entity(service)
+        node._services.append(service)
         node._wake_executor()
 
     def _service_callback(self, request, response):

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -50,6 +50,7 @@
 #include "subscription.hpp"
 #include "time_point.hpp"
 #include "timer.hpp"
+#include "type_description_service.hpp"
 #include "utils.hpp"
 #include "wait_set.hpp"
 
@@ -132,6 +133,8 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
   rclpy::define_publisher(m);
 
   rclpy::define_service(m);
+
+  rclpy::define_type_description_service(m);
 
   rclpy::define_service_info(m);
 

--- a/rclpy/src/rclpy/type_description_service.hpp
+++ b/rclpy/src/rclpy/type_description_service.hpp
@@ -30,10 +30,10 @@ namespace rclpy
 {
 
 class TypeDescriptionService
-: public Destroyable, public std::enable_shared_from_this<TypeDescriptionService>
+  : public Destroyable, public std::enable_shared_from_this<TypeDescriptionService>
 {
 public:
-  TypeDescriptionService(Node & node);
+  explicit TypeDescriptionService(Node & node);
 
   virtual ~TypeDescriptionService();
 

--- a/rclpy/src/rclpy/type_description_service.hpp
+++ b/rclpy/src/rclpy/type_description_service.hpp
@@ -33,15 +33,36 @@ class TypeDescriptionService
   : public Destroyable, public std::enable_shared_from_this<TypeDescriptionService>
 {
 public:
+  /// Initialize and contain the rcl implementation of ~/get_type_description
+  /**
+   * \param[in] node Node to add the service to
+   */
   explicit TypeDescriptionService(Node & node);
 
-  virtual ~TypeDescriptionService();
+  ~TypeDescriptionService() = default;
 
-  Service get_impl();
-  py::object handle_request(py::object pyrequest, py::object pyresponse_type);
+  /// Return the wrapped rcl service, so that it can be added to the node waitsets
+  /**
+   * \return The capsule containing the Service
+   */
+  Service
+  get_impl();
+
+  /// Handle an incoming request to the service
+  /**
+   * \param[in] pyrequest incoming request to handle
+   * \param[in] pyresponse_type Python type of the response object to wrap the C message in
+   * \param[in] node The node that this service belongs to
+   * \return response message to send
+   */
+  py::object
+  handle_request(py::object pyrequest, py::object pyresponse_type, Node & node);
+
+  /// Force early cleanup of object
+  void
+  destroy() override;
 
 private:
-  Node node_;
   std::shared_ptr<Service> service_;
 };
 

--- a/rclpy/src/rclpy/type_description_service.hpp
+++ b/rclpy/src/rclpy/type_description_service.hpp
@@ -1,0 +1,52 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__TYPE_DESCRIPTION_SERVICE_HPP_
+#define RCLPY__TYPE_DESCRIPTION_SERVICE_HPP_
+
+#include <pybind11/pybind11.h>
+
+#include <rmw/types.h>
+
+#include <memory>
+
+#include "destroyable.hpp"
+#include "service.hpp"
+
+namespace py = pybind11;
+
+namespace rclpy
+{
+
+class TypeDescriptionService
+: public Destroyable, public std::enable_shared_from_this<TypeDescriptionService>
+{
+public:
+  TypeDescriptionService(Node & node);
+
+  virtual ~TypeDescriptionService();
+
+  void handle_request(rmw_request_id_t * header, py::object pyrequest, py::object pyresponse);
+
+private:
+  Node node_;
+  std::shared_ptr<Service> service_;
+};
+
+/// Define a pybind11 wrapper for an rclpy::TypeDescriptionService
+void
+define_type_description_service(py::object module);
+}  // namespace rclpy
+
+#endif  // RCLPY__TYPE_DESCRIPTION_SERVICE_HPP_

--- a/rclpy/src/rclpy/type_description_service.hpp
+++ b/rclpy/src/rclpy/type_description_service.hpp
@@ -37,7 +37,8 @@ public:
 
   virtual ~TypeDescriptionService();
 
-  void handle_request(rmw_request_id_t * header, py::object pyrequest, py::object pyresponse);
+  Service get_impl();
+  py::object handle_request(py::object pyrequest, py::object pyresponse_type);
 
 private:
   Node node_;

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -50,6 +50,7 @@ from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.time_source import USE_SIM_TIME_NAME
+from rclpy.type_description_service import START_TYPE_DESCRIPTION_SERVICE_PARAM
 from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.msg import BasicTypes
 
@@ -997,7 +998,9 @@ class TestNode(unittest.TestCase):
                 'bar_prefix.foo': self.node.get_parameter('bar_prefix.foo'),
                 'bar_prefix.bar': self.node.get_parameter('bar_prefix.bar'),
                 'bar_prefix.baz': self.node.get_parameter('bar_prefix.baz'),
-                USE_SIM_TIME_NAME: self.node.get_parameter(USE_SIM_TIME_NAME)
+                USE_SIM_TIME_NAME: self.node.get_parameter(USE_SIM_TIME_NAME),
+                START_TYPE_DESCRIPTION_SERVICE_PARAM: self.node.get_parameter(
+                    START_TYPE_DESCRIPTION_SERVICE_PARAM),
             }
         )
 


### PR DESCRIPTION
Part of ros2/ros2#1159

Depends on https://github.com/ros2/rcl/pull/1052
Equivalent to https://github.com/ros2/rclcpp/pull/2224
Defines and implements a new component of `rclpy.Node` that initializes and handles requests for the `~/get_type_description` service.