### PR TITLE
Fix spin_once_until_future_complete to quit when the future finishes.

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -745,8 +745,6 @@ class SingleThreadedExecutor(Executor):
     def __init__(self, *, context: Optional[Context] = None) -> None:
         super().__init__(context=context)
 
-        self._futures = []
-
     def _spin_once_impl(
         self,
         timeout_sec: Optional[float] = None,
@@ -766,13 +764,7 @@ class SingleThreadedExecutor(Executor):
             if handler.exception() is not None:
                 raise handler.exception()
 
-            self._futures.append(handler)
-            # make a copy of the list that we iterate over while modifying it
-            # (https://stackoverflow.com/q/1207406/3753684)
-            for future in self._futures[:]:
-                if future.done():
-                    self._futures.remove(future)
-                    future.result()  # raise any exceptions
+            handler.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         self._spin_once_impl(timeout_sec)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -772,7 +772,7 @@ class SingleThreadedExecutor(Executor):
             for future in self._futures[:]:
                 if future.done():
                     self._futures.remove(future)
-                    future.result()  # re-raise any exceptions
+                    future.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         self._spin_once_impl(timeout_sec)
@@ -844,7 +844,7 @@ class MultiThreadedExecutor(Executor):
             for future in self._futures[:]:
                 if future.done():
                     self._futures.remove(future)
-                    future.result()  # re-raise any exceptions
+                    future.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         self._spin_once_impl(timeout_sec)


### PR DESCRIPTION
This makes it match the function name much more closely. While we are in here, also fix a bug where the multi-threaded version would not quit immediately after the future completes. And also add tests for both of these situations.

This should fix #989 