### PR TITLE
Fix _list_parameters_callback & test

### DIFF
--- a/rclpy/rclpy/parameter_service.py
+++ b/rclpy/rclpy/parameter_service.py
@@ -15,10 +15,11 @@
 import weakref
 
 from rcl_interfaces.msg import SetParametersResult
+from rcl_interfaces.msg import ListParametersResult
 from rcl_interfaces.srv import DescribeParameters, GetParameters, GetParameterTypes
 from rcl_interfaces.srv import ListParameters, SetParameters, SetParametersAtomically
 from rclpy.exceptions import ParameterNotDeclaredException, ParameterUninitializedException
-from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
+from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_parameters
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
@@ -98,45 +99,11 @@ class ParameterService:
         return response
 
     def _list_parameters_callback(self, request, response):
-        names_with_prefixes = []
         node = self._get_node()
-        for name in node._parameters.keys():
-            if PARAMETER_SEPARATOR_STRING in name:
-                names_with_prefixes.append(name)
-                continue
-            elif request.prefixes:
-                for prefix in request.prefixes:
-                    if name.startswith(prefix):
-                        response.result.names.append(name)
-                continue
-            else:
-                response.result.names.append(name)
-        if 1 == request.depth:
-            return response
-
-        if not request.DEPTH_RECURSIVE == request.depth:
-            names_with_prefixes = filter(
-                lambda name:
-                    name.count(PARAMETER_SEPARATOR_STRING) < request.depth, names_with_prefixes
-            )
-        for name in names_with_prefixes:
-            if request.prefixes:
-                for prefix in request.prefixes:
-                    if name.startswith(prefix + PARAMETER_SEPARATOR_STRING):
-                        response.result.names.append(name)
-                        full_prefix = PARAMETER_SEPARATOR_STRING.join(
-                            name.split(PARAMETER_SEPARATOR_STRING)[0:-1])
-                        if full_prefix not in response.result.prefixes:
-                            response.result.prefixes.append(full_prefix)
-                        if prefix not in response.result.prefixes:
-                            response.result.prefixes.append(prefix)
-            else:
-                prefix = PARAMETER_SEPARATOR_STRING.join(
-                    name.split(PARAMETER_SEPARATOR_STRING)[0:-1])
-                if prefix not in response.result.prefixes:
-                    response.result.prefixes.append(prefix)
-                response.result.names.append(name)
-
+        try:
+            response.result = node.list_parameters(request.prefixes, request.depth)
+        except (TypeError, ValueError):
+            response.result = ListParametersResult()
         return response
 
     def _set_parameters_callback(self, request, response):

--- a/rclpy/test/test_parameter_client.py
+++ b/rclpy/test/test_parameter_client.py
@@ -83,6 +83,14 @@ class TestParameterClient(unittest.TestCase):
         assert 'int_arr_param' in results.result.names
         assert 'float.param..' in results.result.names
 
+        future = self.client.list_parameters(['float.param.'], 1)
+        self.executor.spin_until_future_complete(future)
+        results = future.result()
+        assert results is not None
+        assert 'int_arr_param' not in results.result.names
+        assert 'float.param..' in results.result.names
+        assert 'float.param.' in results.result.prefixes
+
     def test_describe_parameters(self):
         future = self.client.describe_parameters(['int_arr_param'])
         self.executor.spin_until_future_complete(future)


### PR DESCRIPTION
The [service callbacks of ParameterService ](https://github.com/ros2/rclpy/blob/rolling/rclpy/rclpy/parameter_service.py#L67#L166)mostly directly call the functions owned by the node, except for [_list_parameters_callback](https://github.com/ros2/rclpy/blob/rolling/rclpy/rclpy/parameter_service.py#L100#L140). It should also referred to the function the node owns for consistency and maintainability.

related to: https://github.com/ros2/rclpy/pull/1124#issuecomment-1699568321