### PR TITLE
Use timeout object to avoid callback losing in wait_for_ready_callbacks

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -551,8 +551,7 @@ class Executor(ContextManager['Executor']):
         """
         timeout_timer = None
         timeout_nsec = timeout_sec_to_nsec(
-            timeout_sec.timeout if timeout_sec and isinstance(timeout_sec, TimeoutObject)
-            else timeout_sec)
+            timeout_sec.timeout if isinstance(timeout_sec, TimeoutObject) else timeout_sec)
         if timeout_nsec > 0:
             timeout_timer = Timer(None, None, timeout_nsec, self._clock, context=self._context)
 

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -135,6 +135,21 @@ class ConditionReachedException(Exception):
     pass
 
 
+class TimeoutObject:
+    """Use timeout object to save timeout."""
+
+    def __init__(self, timeout: float):
+        self._timeout = timeout
+
+    @property
+    def timeout(self):
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, timeout):
+        self._timeout = timeout
+
+
 class Executor(ContextManager['Executor']):
     """
     The base class for an executor.
@@ -307,7 +322,7 @@ class Executor(ContextManager['Executor']):
         else:
             start = time.monotonic()
             end = start + timeout_sec
-            timeout_left = timeout_sec
+            timeout_left = TimeoutObject(timeout_sec)
 
             while self._context.ok() and not future.done() and not self._is_shutdown:
                 self.spin_once_until_future_complete(future, timeout_left)
@@ -316,7 +331,7 @@ class Executor(ContextManager['Executor']):
                 if now >= end:
                     return
 
-                timeout_left = end - now
+                timeout_left.timeout = end - now
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         """
@@ -332,7 +347,7 @@ class Executor(ContextManager['Executor']):
     def spin_once_until_future_complete(
         self,
         future: Future,
-        timeout_sec: Optional[float] = None
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None
     ) -> None:
         """
         Wait for and execute a single callback.
@@ -518,7 +533,7 @@ class Executor(ContextManager['Executor']):
 
     def _wait_for_ready_callbacks(
         self,
-        timeout_sec: Optional[float] = None,
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None,
         nodes: Optional[List['Node']] = None,
         condition: Callable[[], bool] = lambda: False,
     ) -> Generator[Tuple[Task, WaitableEntityType, 'Node'], None, None]:
@@ -535,7 +550,9 @@ class Executor(ContextManager['Executor']):
             to True.
         """
         timeout_timer = None
-        timeout_nsec = timeout_sec_to_nsec(timeout_sec)
+        timeout_nsec = timeout_sec_to_nsec(
+            timeout_sec.timeout if timeout_sec and isinstance(timeout_sec, TimeoutObject)
+            else timeout_sec)
         if timeout_nsec > 0:
             timeout_timer = Timer(None, None, timeout_nsec, self._clock, context=self._context)
 
@@ -786,7 +803,7 @@ class SingleThreadedExecutor(Executor):
 
     def _spin_once_impl(
         self,
-        timeout_sec: Optional[float] = None,
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None,
         wait_condition: Callable[[], bool] = lambda: False
     ) -> None:
         try:
@@ -811,7 +828,7 @@ class SingleThreadedExecutor(Executor):
     def spin_once_until_future_complete(
         self,
         future: Future,
-        timeout_sec: Optional[float] = None
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None
     ) -> None:
         future.add_done_callback(lambda x: self.wake())
         self._spin_once_impl(timeout_sec, future.done)
@@ -853,7 +870,7 @@ class MultiThreadedExecutor(Executor):
 
     def _spin_once_impl(
         self,
-        timeout_sec: Optional[float] = None,
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None,
         wait_condition: Callable[[], bool] = lambda: False
     ) -> None:
         try:
@@ -883,7 +900,7 @@ class MultiThreadedExecutor(Executor):
     def spin_once_until_future_complete(
         self,
         future: Future,
-        timeout_sec: Optional[float] = None
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None
     ) -> None:
         future.add_done_callback(lambda x: self.wake())
         self._spin_once_impl(timeout_sec, future.done)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -607,7 +607,6 @@ class TestExecutor(unittest.TestCase):
         future = Future(executor=executor)
         executor.spin_until_future_complete(future, 4)
 
-        print(count)
         assert count == 2
 
         executor.shutdown()

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -20,11 +20,13 @@ import unittest
 import warnings
 
 import rclpy
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import Executor
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.executors import ShutdownException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.task import Future
+from test_msgs.srv import Empty
 
 
 class TestExecutor(unittest.TestCase):
@@ -576,6 +578,42 @@ class TestExecutor(unittest.TestCase):
         assert time_spent < 10
 
         executor.shutdown()
+
+    def test_not_lose_callback(self):
+        # This test is from issue https://github.com/ros2/rclpy/issues/1159
+
+        self.assertIsNotNone(self.node.handle)
+        executor = SingleThreadedExecutor(context=self.context)
+
+        callback_group = ReentrantCallbackGroup()
+
+        cli = self.node.create_client(
+            srv_type=Empty, srv_name='test_service', callback_group=callback_group)
+
+        async def timer1_callback():
+            timer1.cancel()
+            await cli.call_async(Empty.Request())
+
+        timer1 = self.node.create_timer(0.5, timer1_callback, callback_group)
+
+        count = 0
+
+        def timer2_callback():
+            nonlocal count
+            count += 1
+        timer2 = self.node.create_timer(1.5, timer2_callback, callback_group)
+
+        executor.add_node(self.node)
+        future = Future(executor=executor)
+        executor.spin_until_future_complete(future, 4)
+
+        print(count)
+        assert count == 2
+
+        executor.shutdown()
+        timer2.destroy()
+        timer1.destroy()
+        cli.destroy()
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -580,8 +580,6 @@ class TestExecutor(unittest.TestCase):
         executor.shutdown()
 
     def test_not_lose_callback(self):
-        # This test is from issue https://github.com/ros2/rclpy/issues/1159
-
         self.assertIsNotNone(self.node.handle)
         executor = SingleThreadedExecutor(context=self.context)
 


### PR DESCRIPTION
Address #1159

The solution was mentioned at https://github.com/ros2/rclpy/issues/1159#issuecomment-1709622820. But I optimized code to avoid changing wait_for_ready_callbacks().  