### PR TITLE
Update executors.py - Check for _sigint_gc attribute in __del__ function

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -239,7 +239,7 @@ class Executor(ContextManager['Executor']):
         return True
 
     def __del__(self):
-        if self._sigint_gc is not None:
+        if hasattr(self, '_sigint_gc') and self._sigint_gc is not None:
             self._sigint_gc.destroy()
 
     def add_node(self, node: 'Node') -> bool:


### PR DESCRIPTION
Avoid the following error: AttributeError: 'SingleThreadedExecutor' object has no attribute '_sigint_gc'