### PR TITLE
Add an optional timeout_sec input to Client.call() to fix issue https://github.com/ros2/rclpy/issues/1181

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -69,7 +69,11 @@ class Client:
 
         self._lock = threading.Lock()
 
-    def call(self, request: SrvTypeRequest, timeout_sec: Optional[float] = None) -> SrvTypeResponse:
+    def call(
+        self,
+        request: SrvTypeRequest,
+        timeout_sec: Optional[float] = None
+    ) -> Optional[SrvTypeResponse]:
         """
         Make a service request and wait for the result.
 

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -98,6 +98,7 @@ class Client:
         # resulting in the event never being set.
         if not future.done():
             if not event.wait(timeout_sec):
+                # Timed out. remove_pending_request() to free resources
                 self.remove_pending_request(future)
         if future.exception() is not None:
             raise future.exception()

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -76,6 +76,7 @@ class Client:
         .. warning:: Do not call this method in a callback, or a deadlock or timeout may occur.
 
         :param request: The service request.
+        :param timeout_sec: Seconds to wait. If ``None``, then wait forever.
         :return: The service response, or None if timed out.
         :raises: TypeError if the type of the passed request isn't an instance
           of the Request type of the provided service when the client was

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import platform
-import time
 import threading
+import time
 import traceback
 import unittest
 

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -15,9 +15,11 @@
 import platform
 import time
 import unittest
+import threading
 
 from rcl_interfaces.srv import GetParameters
 import rclpy
+import rclpy.node
 import rclpy.executors
 from rclpy.utilities import get_rmw_implementation_identifier
 from test_msgs.srv import Empty
@@ -55,6 +57,18 @@ class TestClient(unittest.TestCase):
             assert client.service_name == target_service_name
             client.destroy()
             node.destroy_node()
+
+    @staticmethod
+    def _spin_rclpy_node(rclpy_node: rclpy.node.Node, rclpy_executor: rclpy.executors.SingleThreadedExecutor) -> None:
+        try:
+            rclpy_executor.spin()
+        except rclpy.executors.ExternalShutdownException:
+            pass
+        except Exception as err:
+            traceback.print_exc()
+            print(rclpy_node.get_name() + ': ' + str(err))
+        print(rclpy_node.get_name() + ': rclpy_node exit')
+#        rclpy_node.destroy_node()
 
     def test_wait_for_service_5sec(self):
         cli = self.node.create_client(GetParameters, 'get/parameters')
@@ -182,6 +196,68 @@ class TestClient(unittest.TestCase):
              '/ns/new_service')
         ]
         TestClient.do_test_service_name(test_service_name_list)
+
+    def test_sync_call(self):
+        def _service(request, response):
+            return response
+        cli = self.node.create_client(GetParameters, 'get/parameters')
+        srv = self.node.create_service(GetParameters, 'get/parameters', _service)
+        try:
+            self.assertTrue(cli.wait_for_service(timeout_sec=20))
+            executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
+            executor.add_node(self.node)
+            executor_thread = threading.Thread(
+                target=TestClient._spin_rclpy_node, args=(self.node, executor))
+            executor_thread.start()
+            result = cli.call(GetParameters.Request(), 5)
+            self.assertTrue(result is not None)
+            executor.shutdown()
+            executor_thread.join()
+        finally:
+            self.node.destroy_client(cli)
+            self.node.destroy_service(srv)
+
+    def test_sync_call_slow(self):
+        def _service(request, response):
+            time.sleep(5)
+            return response
+        cli = self.node.create_client(GetParameters, 'get/parameters')
+        srv = self.node.create_service(GetParameters, 'get/parameters', _service)
+        try:
+            self.assertTrue(cli.wait_for_service(timeout_sec=20))
+            executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
+            executor.add_node(self.node)
+            executor_thread = threading.Thread(
+                target=TestClient._spin_rclpy_node, args=(self.node, executor))
+            executor_thread.start()
+            result = cli.call(GetParameters.Request(), 10)
+            self.assertTrue(result is not None)
+            executor.shutdown()
+            executor_thread.join()
+        finally:
+            self.node.destroy_client(cli)
+            self.node.destroy_service(srv)
+
+    def test_sync_call_timeout(self):
+        def _service(request, response):
+            time.sleep(10)
+            return response
+        cli = self.node.create_client(GetParameters, 'get/parameters')
+        srv = self.node.create_service(GetParameters, 'get/parameters', _service)
+        try:
+            self.assertTrue(cli.wait_for_service(timeout_sec=20))
+            executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
+            executor.add_node(self.node)
+            executor_thread = threading.Thread(
+                target=TestClient._spin_rclpy_node, args=(self.node, executor))
+            executor_thread.start()
+            result = cli.call(GetParameters.Request(), 5)
+            self.assertTrue(result is None)
+            executor.shutdown()
+            executor_thread.join()
+        finally:
+            self.node.destroy_client(cli)
+            self.node.destroy_service(srv)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add an optional timeout_sec input so that the `call()` function can break away from the deadlock if RMW fails to response. The `call()` function returns future.result() which is `None`.

Another approach of adding timeout to the future returned by `call_async()` is much more difficult to implement, requiring changes from the `Future` class and upward. Also there is no timeout input for the rclcpp version of `async_send_request()`. So I would prefer not taking this approach instead.