### PR TITLE
Added more Static typing for Node Class and for RcutilsLogger

### DIFF
--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -334,19 +334,19 @@ class RcutilsLogger:
             caller_id.function_name, caller_id.file_path, caller_id.line_number)
         return True
 
-    def debug(self, message, **kwargs):
+    def debug(self, message, **kwargs) -> bool:
         """Log a message with `DEBUG` severity via :py:classmethod:RcutilsLogger.log:."""
         return self.log(message, LoggingSeverity.DEBUG, **kwargs)
 
-    def info(self, message, **kwargs):
+    def info(self, message, **kwargs) -> bool:
         """Log a message with `INFO` severity via :py:classmethod:RcutilsLogger.log:."""
         return self.log(message, LoggingSeverity.INFO, **kwargs)
 
-    def warning(self, message, **kwargs):
+    def warning(self, message, **kwargs) -> bool:
         """Log a message with `WARN` severity via :py:classmethod:RcutilsLogger.log:."""
         return self.log(message, LoggingSeverity.WARN, **kwargs)
 
-    def warn(self, message, **kwargs):
+    def warn(self, message, **kwargs) -> bool:
         """
         Log a message with `WARN` severity via :py:classmethod:RcutilsLogger.log:.
 
@@ -354,10 +354,10 @@ class RcutilsLogger:
         """
         return self.warning(message, **kwargs)
 
-    def error(self, message, **kwargs):
+    def error(self, message, **kwargs) -> bool:
         """Log a message with `ERROR` severity via :py:classmethod:RcutilsLogger.log:."""
         return self.log(message, LoggingSeverity.ERROR, **kwargs)
 
-    def fatal(self, message, **kwargs):
+    def fatal(self, message, **kwargs) -> bool:
         """Log a message with `FATAL` severity via :py:classmethod:RcutilsLogger.log:."""
         return self.log(message, LoggingSeverity.FATAL, **kwargs)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -90,6 +90,7 @@ from rclpy.validate_node_name import validate_node_name
 from rclpy.validate_parameter_name import validate_parameter_name
 from rclpy.validate_topic_name import validate_topic_name
 from rclpy.waitable import Waitable
+from rclpy.impl.rcutils_logger import RcutilsLogger
 
 HIDDEN_NODE_PREFIX = '_'
 
@@ -349,7 +350,7 @@ class Node:
         """Get the clock used by the node."""
         return self._clock
 
-    def get_logger(self):
+    def get_logger(self) -> RcutilsLogger:
         """Get the nodes logger."""
         return self._logger
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -64,6 +64,7 @@ from rclpy.executors import Executor
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.logging import get_logger
 from rclpy.logging_service import LoggingService
 from rclpy.parameter import Parameter, PARAMETER_SEPARATOR_STRING
@@ -90,7 +91,6 @@ from rclpy.validate_node_name import validate_node_name
 from rclpy.validate_parameter_name import validate_parameter_name
 from rclpy.validate_topic_name import validate_topic_name
 from rclpy.waitable import Waitable
-from rclpy.impl.rcutils_logger import RcutilsLogger
 
 HIDDEN_NODE_PREFIX = '_'
 


### PR DESCRIPTION
Hello there.

I added some explicit return types to functions in the Node and RCutilsLogger Classes.  I updated the Node one because the other properties seemed to have return types. For RCutilsLogger I simply added return types to the most common functions being the logging functions. If there any requests or problems I should fix please let me know.