### PR TITLE
Add doc-string warnings for destroy() methods

### DIFF
--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -88,6 +88,12 @@ class Publisher:
         return self.__publisher
 
     def destroy(self):
+        """
+        Destroy a container for a ROS publisher.
+
+        .. warning:: Users should not destroy a publisher with this method, instead they should
+           call :meth:`.Node.destroy_publisher`.
+        """
         for handler in self.event_handlers:
             handler.destroy()
         self.__publisher.destroy_when_not_in_use()

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -86,6 +86,12 @@ class Subscription:
         return self.__subscription
 
     def destroy(self):
+        """
+        Destroy a container for a ROS subscription.
+
+        .. warning:: Users should not destroy a subscription with this method, instead they
+           should call :meth:`.Node.destroy_subscription`.
+        """
         for handler in self.event_handlers:
             handler.destroy()
         self.handle.destroy_when_not_in_use()


### PR DESCRIPTION
The constructors for publisher.py and subscription.py have warnings in their doc-string that they should not be used directly to create Publisher or Subscription objects (see [API documentation](https://docs.ros2.org/latest/api/rclpy/api/topics.html)), but that the `create_publisher` or `create_subscription` methods from a node should be called instead. I believe the same warning applies to the `destroy()` method for these classes, and that `destroy_publisher` / `destroy_subscription` should be called from a node instead of calling `destroy()` on these objects directly, so I've added a warning to the doc-string for these `destroy()` methods.