### PR TITLE
Allow specifying qos

### DIFF
--- a/rclpy/rclpy/wait_for_message.py
+++ b/rclpy/rclpy/wait_for_message.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile
 from rclpy.signals import SignalHandlerGuardCondition
 from rclpy.utilities import timeout_sec_to_nsec
 
@@ -22,7 +25,8 @@ def wait_for_message(
     msg_type,
     node: 'Node',
     topic: str,
-    qos_profile = 1,
+    *,
+    qos_profile: Union[QoSProfile, int] = 1,
     time_to_wait=-1
 ):
     """

--- a/rclpy/rclpy/wait_for_message.py
+++ b/rclpy/rclpy/wait_for_message.py
@@ -22,6 +22,7 @@ def wait_for_message(
     msg_type,
     node: 'Node',
     topic: str,
+    qos_profile = 1,
     time_to_wait=-1
 ):
     """
@@ -30,6 +31,7 @@ def wait_for_message(
     :param msg_type: message type
     :param node: node to initialize the subscription on
     :param topic: topic name to wait for message
+    :param qos_profile: QoS profile to use for the subscription
     :param time_to_wait: seconds to wait before returning
     :returns: (True, msg) if a message was successfully received, (False, None) if message
         could not be obtained or shutdown was triggered asynchronously on the context.
@@ -38,7 +40,7 @@ def wait_for_message(
     wait_set = _rclpy.WaitSet(1, 1, 0, 0, 0, 0, context.handle)
     wait_set.clear_entities()
 
-    sub = node.create_subscription(msg_type, topic, lambda _: None, 1)
+    sub = node.create_subscription(msg_type, topic, lambda _: None, qos_profile=qos_profile)
     try:
         wait_set.add_subscription(sub.handle)
         sigint_gc = SignalHandlerGuardCondition(context=context)

--- a/rclpy/test/test_wait_for_message.py
+++ b/rclpy/test/test_wait_for_message.py
@@ -17,8 +17,8 @@ import time
 import unittest
 
 import rclpy
-from rclpy.wait_for_message import wait_for_message
 from rclpy.qos import QoSProfile
+from rclpy.wait_for_message import wait_for_message
 from test_msgs.msg import BasicTypes
 
 MSG_DATA = 100

--- a/rclpy/test/test_wait_for_message.py
+++ b/rclpy/test/test_wait_for_message.py
@@ -18,6 +18,7 @@ import unittest
 
 import rclpy
 from rclpy.wait_for_message import wait_for_message
+from rclpy.qos import QoSProfile
 from test_msgs.msg import BasicTypes
 
 MSG_DATA = 100
@@ -51,7 +52,16 @@ class TestWaitForMessage(unittest.TestCase):
     def test_wait_for_message(self):
         t = threading.Thread(target=self._publish_message)
         t.start()
-        ret, msg = wait_for_message(BasicTypes, self.node, TOPIC_NAME)
+        ret, msg = wait_for_message(BasicTypes, self.node, TOPIC_NAME, qos_profile=1)
+        self.assertTrue(ret)
+        self.assertEqual(msg.int32_value, MSG_DATA)
+        t.join()
+
+    def test_wait_for_message_qos(self):
+        t = threading.Thread(target=self._publish_message)
+        t.start()
+        ret, msg = wait_for_message(
+            BasicTypes, self.node, TOPIC_NAME, qos_profile=QoSProfile(depth=1))
         self.assertTrue(ret)
         self.assertEqual(msg.int32_value, MSG_DATA)
         t.join()

--- a/rclpy/test/test_wait_for_message.py
+++ b/rclpy/test/test_wait_for_message.py
@@ -57,7 +57,7 @@ class TestWaitForMessage(unittest.TestCase):
         t.join()
 
     def test_wait_for_message_timeout(self):
-        ret, _ = wait_for_message(BasicTypes, self.node, TOPIC_NAME, 1)
+        ret, _ = wait_for_message(BasicTypes, self.node, TOPIC_NAME, time_to_wait=1)
         self.assertFalse(ret)
 
 


### PR DESCRIPTION
This function didn't work for transient local publishers.

This is a breaking change because the argument order is changed. However with the future in mind, this order makes most sense to me as all first arguments are passed directly to the subscription.

If you like the original order I can change this.