### PR TITLE
Add types to logging.py

### DIFF
--- a/rclpy/rclpy/logging.py
+++ b/rclpy/rclpy/logging.py
@@ -23,7 +23,7 @@ import rclpy.impl.rcutils_logger
 _root_logger = rclpy.impl.rcutils_logger.RcutilsLogger()
 
 
-def get_logger(name):
+def get_logger(name: str):
     if not name:
         raise ValueError('Logger name must not be empty.')
     return _root_logger.get_child(name)
@@ -43,22 +43,22 @@ def clear_config():
     initialize()
 
 
-def set_logger_level(name, level, detailed_error=False):
+def set_logger_level(name: str, level: int, detailed_error: bool = False):
     level = LoggingSeverity(level)
     return _rclpy.rclpy_logging_set_logger_level(name, level, detailed_error)
 
 
-def get_logger_effective_level(name):
+def get_logger_effective_level(name: str):
     logger_level = _rclpy.rclpy_logging_get_logger_effective_level(name)
     return LoggingSeverity(logger_level)
 
 
-def get_logger_level(name):
+def get_logger_level(name: str):
     logger_level = _rclpy.rclpy_logging_get_logger_level(name)
     return LoggingSeverity(logger_level)
 
 
-def get_logging_severity_from_string(log_severity):
+def get_logging_severity_from_string(log_severity: str):
     return LoggingSeverity(
         _rclpy.rclpy_logging_severity_level_from_string(log_severity))
 


### PR DESCRIPTION
I was running mypy on my repository and it was complaining about get_logger() not  being typed. So I added static typing to logging.py. Look at previous issues and pull requests.  This change was already done similarly in #979 in response to issue #976. @clalancette mentioned that it should be split up into smaller pull requests. 