### PR TITLE
Add types to logging_service.py

### DIFF
--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -12,17 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+from typing import Union, TYPE_CHECKING
+
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult
 from rcl_interfaces.srv import GetLoggerLevels
 from rcl_interfaces.srv import SetLoggerLevels
 import rclpy
+from rclpy.impl.logging_severity import LoggingSeverity
 from rclpy.qos import qos_profile_services_default
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
 
 
 class LoggingService:
 
-    def __init__(self, node):
+    def __init__(self, node: Node):
         node_name = node.get_name()
 
         get_logger_name_service_name = \
@@ -39,19 +46,21 @@ class LoggingService:
             self._set_logger_levels, qos_profile=qos_profile_services_default
         )
 
-    def _get_logger_levels(self, request, response):
+    def _get_logger_levels(self, request: GetLoggerLevels.Request,
+                           response: GetLoggerLevels.Response) -> GetLoggerLevels.Response:
         for name in request.names:
             logger_level = LoggerLevel()
             logger_level.name = name
             try:
-                ret_level = rclpy.logging.get_logger_level(name)
+                ret_level: Union[int, LoggingSeverity] = rclpy.logging.get_logger_level(name)
             except RuntimeError:
                 ret_level = 0
             logger_level.level = ret_level
             response.levels.append(logger_level)
         return response
 
-    def _set_logger_levels(self, request, response):
+    def _set_logger_levels(self, request: SetLoggerLevels.Request,
+                           response: SetLoggerLevels.Response) -> SetLoggerLevels.Response:
         for level in request.levels:
             result = SetLoggerLevelsResult()
             result.successful = False

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult
 from rcl_interfaces.srv import GetLoggerLevels

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -51,7 +51,7 @@ class LoggingService:
             logger_level = LoggerLevel()
             logger_level.name = name
             try:
-                ret_level: Union[LoggingSeverity] = rclpy.logging.get_logger_level(name)
+                ret_level: Union[int, LoggingSeverity] = rclpy.logging.get_logger_level(name)
             except RuntimeError:
                 ret_level = 0
             logger_level.level = ret_level

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Union
 
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING, Union
 
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult
 from rcl_interfaces.srv import GetLoggerLevels
 from rcl_interfaces.srv import SetLoggerLevels
 import rclpy
-from rclpy.impl.logging_severity import LoggingSeverity
 from rclpy.qos import qos_profile_services_default
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 if TYPE_CHECKING:
+    from rclpy.impl.logging_severity import LoggingSeverity
     from rclpy.node import Node
 
 
@@ -53,7 +51,7 @@ class LoggingService:
             logger_level = LoggerLevel()
             logger_level.name = name
             try:
-                ret_level: Union[int, LoggingSeverity] = rclpy.logging.get_logger_level(name)
+                ret_level: Union[LoggingSeverity] = rclpy.logging.get_logger_level(name)
             except RuntimeError:
                 ret_level = 0
             logger_level.level = ret_level

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult
@@ -30,7 +28,7 @@ if TYPE_CHECKING:
 
 class LoggingService:
 
-    def __init__(self, node: Node):
+    def __init__(self, node: 'Node'):
         node_name = node.get_name()
 
         get_logger_name_service_name = \

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -14,17 +14,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult
 from rcl_interfaces.srv import GetLoggerLevels
 from rcl_interfaces.srv import SetLoggerLevels
 import rclpy
+from rclpy.impl.logging_severity import LoggingSeverity
 from rclpy.qos import qos_profile_services_default
 from rclpy.validate_topic_name import TOPIC_SEPARATOR_STRING
 
 if TYPE_CHECKING:
-    from rclpy.impl.logging_severity import LoggingSeverity
     from rclpy.node import Node
 
 
@@ -53,9 +53,9 @@ class LoggingService:
             logger_level = LoggerLevel()
             logger_level.name = name
             try:
-                ret_level: Union[int, LoggingSeverity] = rclpy.logging.get_logger_level(name)
+                ret_level = rclpy.logging.get_logger_level(name)
             except RuntimeError:
-                ret_level = 0
+                ret_level = LoggingSeverity.UNSET
             logger_level.level = ret_level
             response.levels.append(logger_level)
         return response

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -68,7 +68,7 @@ class LoggingService:
                 rclpy.logging.set_logger_level(level.name, level.level, detailed_error=True)
                 result.successful = True
             except ValueError:
-                result.reason = 'Failed reason: Invaild logger level.'
+                result.reason = 'Failed reason: Invalid logger level.'
             except RuntimeError as e:
                 result.reason = str(e)
             response.results.append(result)

--- a/rclpy/rclpy/logging_service.py
+++ b/rclpy/rclpy/logging_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Union
 
 from rcl_interfaces.msg import LoggerLevel, SetLoggerLevelsResult

--- a/rclpy/test/test_logging_service.py
+++ b/rclpy/test/test_logging_service.py
@@ -196,9 +196,9 @@ class TestLoggingService(unittest.TestCase):
         response = future.result()
         self.assertEqual(len(response.results), 2)
         self.assertFalse(response.results[0].successful)
-        self.assertEqual(response.results[0].reason, 'Failed reason: Invaild logger level.')
+        self.assertEqual(response.results[0].reason, 'Failed reason: Invalid logger level.')
         self.assertFalse(response.results[1].successful)
-        self.assertEqual(response.results[1].reason, 'Failed reason: Invaild logger level.')
+        self.assertEqual(response.results[1].reason, 'Failed reason: Invalid logger level.')
         self.test_node.destroy_client(set_client)
 
     def test_set_logging_level_with_partial_invalid_param(self):
@@ -228,7 +228,7 @@ class TestLoggingService(unittest.TestCase):
         self.assertTrue(response.results[0].successful)
         self.assertEqual(response.results[0].reason, '')
         self.assertFalse(response.results[1].successful)
-        self.assertEqual(response.results[1].reason, 'Failed reason: Invaild logger level.')
+        self.assertEqual(response.results[1].reason, 'Failed reason: Invalid logger level.')
         self.assertTrue(response.results[2].successful)
         self.assertEqual(response.results[2].reason, '')
         self.test_node.destroy_client(set_client)


### PR DESCRIPTION
Added static typing to logging_service.py. This change was already done similarly in https://github.com/ros2/rclpy/pull/979 in response to issue https://github.com/ros2/rclpy/issues/976.  Also fixes a spelling error of Invaild -> Invalid.