### PR TITLE
Add types to topic_or_service_is_hidden.py

### DIFF
--- a/rclpy/rclpy/topic_or_service_is_hidden.py
+++ b/rclpy/rclpy/topic_or_service_is_hidden.py
@@ -15,7 +15,7 @@
 HIDDEN_TOPIC_PREFIX = '_'
 
 
-def topic_or_service_is_hidden(name):
+def topic_or_service_is_hidden(name: str) -> bool:
     """
     Return True if a given topic or service name is hidden, otherwise False.
 


### PR DESCRIPTION
Added static typing to  topic_or_service_is_hidden.py. This change was already done similarly in https://github.com/ros2/rclpy/pull/979 in response to issue https://github.com/ros2/rclpy/issues/976.