### PR TITLE
Add back Type hash __slots__ and add test cases.

### DIFF
--- a/rclpy/rclpy/type_hash.py
+++ b/rclpy/rclpy/type_hash.py
@@ -18,6 +18,8 @@ class TypeHash:
 
     _TYPE_HASH_SIZE = 32
 
+    # ros2cli needs __slots__ to avoid API break from https://github.com/ros2/rclpy/pull/1243.
+    # __slots__ is also used improve performance of Python objects.
     __slots__ = [
         '_version',
         '_value',

--- a/rclpy/rclpy/type_hash.py
+++ b/rclpy/rclpy/type_hash.py
@@ -18,6 +18,11 @@ class TypeHash:
 
     _TYPE_HASH_SIZE = 32
 
+    __slots__ = (
+        '_version',
+        '_value',
+    )
+
     def __init__(self, version: int = -1, value: bytes = bytes(_TYPE_HASH_SIZE)):
         self.version = version
         self.value = value
@@ -53,7 +58,9 @@ class TypeHash:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TypeHash):
             return False
-        return self.__dict__ == other.__dict__
+        return all(
+            self.__getattribute__(slot) == other.__getattribute__(slot)
+            for slot in self.__slots__)
 
     def __str__(self) -> str:
         if self._version <= 0 or len(self._value) != self._TYPE_HASH_SIZE:

--- a/rclpy/rclpy/type_hash.py
+++ b/rclpy/rclpy/type_hash.py
@@ -28,7 +28,6 @@ class TypeHash:
         Get field 'version'.
 
         :returns: version attribute
-        :rtype: int
         """
         return self._version
 
@@ -43,7 +42,6 @@ class TypeHash:
         Get field 'value'.
 
         :returns: value attribute
-        :rtype: bytes
         """
         return self._value
 

--- a/rclpy/rclpy/type_hash.py
+++ b/rclpy/rclpy/type_hash.py
@@ -18,20 +18,12 @@ class TypeHash:
 
     _TYPE_HASH_SIZE = 32
 
-    __slots__ = [
-        '_version',
-        '_value',
-    ]
-
-    def __init__(self, **kwargs):
-        assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
-            'Invalid arguments passed to constructor: %r' % kwargs.keys()
-
-        self.version = kwargs.get('version', -1)
-        self.value = kwargs.get('value', bytes(self._TYPE_HASH_SIZE))
+    def __init__(self, version: int = -1, value: bytes = bytes(_TYPE_HASH_SIZE)):
+        self.version = version
+        self.value = value
 
     @property
-    def version(self):
+    def version(self) -> int:
         """
         Get field 'version'.
 
@@ -41,12 +33,12 @@ class TypeHash:
         return self._version
 
     @version.setter
-    def version(self, value):
+    def version(self, value: int) -> None:
         assert isinstance(value, int)
         self._version = value
 
     @property
-    def value(self):
+    def value(self) -> bytes:
         """
         Get field 'value'.
 
@@ -56,18 +48,16 @@ class TypeHash:
         return self._value
 
     @value.setter
-    def value(self, value):
+    def value(self, value: bytes) -> None:
         assert isinstance(value, bytes)
         self._value = value
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, TypeHash):
             return False
-        return all(
-            self.__getattribute__(slot) == other.__getattribute__(slot)
-            for slot in self.__slots__)
+        return self.__dict__ == other.__dict__
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self._version <= 0 or len(self._value) != self._TYPE_HASH_SIZE:
             return 'INVALID'
 

--- a/rclpy/test/test_type_hash.py
+++ b/rclpy/test/test_type_hash.py
@@ -30,6 +30,7 @@ class TestTypeHash(unittest.TestCase):
 
     def test_dict_constructor(self):
         type_hash = TypeHash(**STD_MSGS_STRING_TYPE_HASH_DICT)
+        self.assertTrue(hasattr(type_hash, '__slots__'))
         self.assertEqual(STD_MSGS_STRING_TYPE_HASH_DICT['version'], type_hash.version)
         self.assertEqual(STD_MSGS_STRING_TYPE_HASH_DICT['value'], type_hash.value)
 
@@ -42,3 +43,7 @@ class TestTypeHash(unittest.TestCase):
         actual_str = str(TypeHash())
         expected_str = 'INVALID'
         self.assertEqual(expected_str, actual_str)
+
+    def test_equals(self):
+        self.assertEqual(TypeHash(), TypeHash())
+        self.assertNotEqual(TypeHash(version=5), TypeHash())


### PR DESCRIPTION
Following the regression caused by #1232 this adds back the `__slots__` Also adds a test case to ensure this gets caught by CI in the future. Should probably wait until the revert in #1243 is completed.