### PR TITLE
Fix small flake8 error in rclpy.

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -986,7 +986,7 @@ class Node:
         result = ListParametersResult()
 
         separator_less_than_depth: Callable[[str], bool] = \
-            lambda str: str.count(PARAMETER_SEPARATOR_STRING) < depth
+            lambda s: s.count(PARAMETER_SEPARATOR_STRING) < depth
 
         recursive: bool = \
             (len(prefixes) == 0) and (depth == ListParameters.Request.DEPTH_RECURSIVE)


### PR DESCRIPTION
Newer versions of flake8 complain that using 'str' as a variable shadows a builtin.  Just make it 's'.