### PR TITLE
Client:call generates TimeoutError exception when it is timed out.

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -85,10 +85,11 @@ class Client(Generic[SrvRequestT, SrvResponseT, SrvEventT]):
 
         :param request: The service request.
         :param timeout_sec: Seconds to wait. If ``None``, then wait forever.
-        :return: The service response, or None if timed out.
+        :return: The service response.
         :raises: TypeError if the type of the passed request isn't an instance
           of the Request type of the provided service when the client was
           constructed.
+        :raises: TimeoutError if the response is not available within the timeout.
         """
         if not isinstance(request, self.srv_type.Request):
             raise TypeError()
@@ -109,6 +110,7 @@ class Client(Generic[SrvRequestT, SrvResponseT, SrvEventT]):
             if not event.wait(timeout_sec):
                 # Timed out. remove_pending_request() to free resources
                 self.remove_pending_request(future)
+                raise TimeoutError()
 
         exception = future.exception()
         if exception is not None:

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -234,11 +234,11 @@ class TestClient(unittest.TestCase):
             executor_thread = threading.Thread(
                 target=TestClient._spin_rclpy_node, args=(self.node, executor))
             executor_thread.start()
-            result = cli.call(GetParameters.Request(), 0.5)
-            self.assertTrue(result is None)
+            with self.assertRaises(TimeoutError):
+                cli.call(GetParameters.Request(), 0.5)
+        finally:
             executor.shutdown()
             executor_thread.join()
-        finally:
             self.node.destroy_client(cli)
             self.node.destroy_service(srv)
 

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -213,6 +213,8 @@ class TestClient(unittest.TestCase):
             executor_thread = threading.Thread(
                 target=TestClient._spin_rclpy_node, args=(self.node, executor))
             executor_thread.start()
+            # make sure thread has started to avoid exception via join()
+            self.assertTrue(executor_thread.is_alive())
             result = cli.call(GetParameters.Request(), 0.5)
             self.assertTrue(result is not None)
             executor.shutdown()
@@ -234,6 +236,8 @@ class TestClient(unittest.TestCase):
             executor_thread = threading.Thread(
                 target=TestClient._spin_rclpy_node, args=(self.node, executor))
             executor_thread.start()
+            # make sure thread has started to avoid exception via join()
+            self.assertTrue(executor_thread.is_alive())
             with self.assertRaises(TimeoutError):
                 cli.call(GetParameters.Request(), 0.5)
         finally:
@@ -253,6 +257,8 @@ class TestClient(unittest.TestCase):
                 executor_thread = threading.Thread(
                     target=TestClient._spin_rclpy_node, args=(self.node, executor))
                 executor_thread.start()
+                # make sure thread has started to avoid exception via join()
+                self.assertTrue(executor_thread.is_alive())
                 result = cli.call(GetParameters.Request(), 0.5)
                 self.assertTrue(result is not None)
                 executor.shutdown()


### PR DESCRIPTION
follow-up of https://github.com/ros2/rclpy/pull/1188 (https://github.com/ros2/rclpy/pull/1188#issuecomment-2052469167)