### PR TITLE
Support wait for message backport humble

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -196,6 +196,7 @@ if(BUILD_TESTING)
       test/test_validate_node_name.py
       test/test_validate_topic_name.py
       test/test_waitable.py
+      test/test_wait_for_message.py
     )
 
     foreach(_test_path ${_rclpy_pytest_tests})

--- a/rclpy/rclpy/wait_for_message.py
+++ b/rclpy/rclpy/wait_for_message.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.node import Node
+from rclpy.signals import SignalHandlerGuardCondition
+from rclpy.utilities import timeout_sec_to_nsec
+
+
+def wait_for_message(
+    msg_type,
+    node: 'Node',
+    topic: str,
+    time_to_wait=-1
+):
+    """
+    Wait for the next incoming message.
+
+    :param msg_type: message type
+    :param node: node to initialize the subscription on
+    :param topic: topic name to wait for message
+    :time_to_wait: seconds to wait before returning
+    :return (True, msg) if a message was successfully received, (False, ()) if message
+        could not be obtained or shutdown was triggered asynchronously on the context.
+    """
+    context = node.context
+    wait_set = _rclpy.WaitSet(1, 1, 0, 0, 0, 0, context.handle)
+    wait_set.clear_entities()
+
+    sub = node.create_subscription(msg_type, topic, lambda _: None, 1)
+    wait_set.add_subscription(sub.handle)
+    sigint_gc = SignalHandlerGuardCondition(context=context)
+    wait_set.add_guard_condition(sigint_gc.handle)
+
+    timeout_nsec = timeout_sec_to_nsec(time_to_wait)
+    wait_set.wait(timeout_nsec)
+
+    subs_ready = wait_set.get_ready_entities('subscription')
+    guards_ready = wait_set.get_ready_entities('guard_condition')
+
+    if guards_ready:
+        if sigint_gc.handle.pointer in guards_ready:
+            return (False, None)
+
+    if subs_ready:
+        if sub.handle.pointer in subs_ready:
+            msg_info = sub.handle.take_message(sub.msg_type, sub.raw)
+            return (True, msg_info[0])
+
+    return (False, None)

--- a/rclpy/rclpy/wait_for_message.py
+++ b/rclpy/rclpy/wait_for_message.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile
 from rclpy.signals import SignalHandlerGuardCondition
 from rclpy.utilities import timeout_sec_to_nsec
 
@@ -22,6 +25,8 @@ def wait_for_message(
     msg_type,
     node: 'Node',
     topic: str,
+    *,
+    qos_profile: Union[QoSProfile, int] = 1,
     time_to_wait=-1
 ):
     """
@@ -30,15 +35,16 @@ def wait_for_message(
     :param msg_type: message type
     :param node: node to initialize the subscription on
     :param topic: topic name to wait for message
-    :time_to_wait: seconds to wait before returning
-    :return (True, msg) if a message was successfully received, (False, ()) if message
+    :param qos_profile: QoS profile to use for the subscription
+    :param time_to_wait: seconds to wait before returning
+    :returns: (True, msg) if a message was successfully received, (False, None) if message
         could not be obtained or shutdown was triggered asynchronously on the context.
     """
     context = node.context
     wait_set = _rclpy.WaitSet(1, 1, 0, 0, 0, 0, context.handle)
     wait_set.clear_entities()
 
-    sub = node.create_subscription(msg_type, topic, lambda _: None, 1)
+    sub = node.create_subscription(msg_type, topic, lambda _: None, qos_profile=qos_profile)
     try:
         wait_set.add_subscription(sub.handle)
         sigint_gc = SignalHandlerGuardCondition(context=context)

--- a/rclpy/test/test_wait_for_message.py
+++ b/rclpy/test/test_wait_for_message.py
@@ -1,0 +1,65 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+import unittest
+
+import rclpy
+from rclpy.wait_for_message import wait_for_message
+from test_msgs.msg import BasicTypes
+
+MSG_DATA = 100
+TOPIC_NAME = 'wait_for_message_topic'
+
+
+class TestWaitForMessage(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node('publisher_node', context=cls.context)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown(context=cls.context)
+
+    def _publish_message(self):
+        pub = self.node.create_publisher(BasicTypes, TOPIC_NAME, 1)
+        msg = BasicTypes()
+        msg.int32_value = MSG_DATA
+        while True:
+            if self.node.count_subscribers(TOPIC_NAME) > 0:
+                pub.publish(msg)
+                break
+            time.sleep(1)
+        pub.destroy()
+
+    def test_wait_for_message(self):
+        t = threading.Thread(target=self._publish_message)
+        t.start()
+        ret, msg = wait_for_message(BasicTypes, self.node, TOPIC_NAME)
+        self.assertTrue(ret)
+        self.assertEqual(msg.int32_value, MSG_DATA)
+        t.join()
+
+    def test_wait_for_message_timeout(self):
+        ret, _ = wait_for_message(BasicTypes, self.node, TOPIC_NAME, 1)
+        self.assertFalse(ret)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/rclpy/test/test_wait_for_message.py
+++ b/rclpy/test/test_wait_for_message.py
@@ -17,6 +17,7 @@ import time
 import unittest
 
 import rclpy
+from rclpy.qos import QoSProfile
 from rclpy.wait_for_message import wait_for_message
 from test_msgs.msg import BasicTypes
 
@@ -51,13 +52,22 @@ class TestWaitForMessage(unittest.TestCase):
     def test_wait_for_message(self):
         t = threading.Thread(target=self._publish_message)
         t.start()
-        ret, msg = wait_for_message(BasicTypes, self.node, TOPIC_NAME)
+        ret, msg = wait_for_message(BasicTypes, self.node, TOPIC_NAME, qos_profile=1)
+        self.assertTrue(ret)
+        self.assertEqual(msg.int32_value, MSG_DATA)
+        t.join()
+
+    def test_wait_for_message_qos(self):
+        t = threading.Thread(target=self._publish_message)
+        t.start()
+        ret, msg = wait_for_message(
+            BasicTypes, self.node, TOPIC_NAME, qos_profile=QoSProfile(depth=1))
         self.assertTrue(ret)
         self.assertEqual(msg.int32_value, MSG_DATA)
         t.join()
 
     def test_wait_for_message_timeout(self):
-        ret, _ = wait_for_message(BasicTypes, self.node, TOPIC_NAME, 1)
+        ret, _ = wait_for_message(BasicTypes, self.node, TOPIC_NAME, time_to_wait=1)
         self.assertFalse(ret)
 
 


### PR DESCRIPTION
This is the backport of the following PRs. (conflicts are resolved already)

- https://github.com/ros2/rclpy/pull/960
- https://github.com/ros2/rclpy/pull/1180

backport is originally requested here, https://github.com/ros2/rclpy/issues/1179

note, this is purely adding a new method, this does not break API nor user application behavior.