### PR TITLE
Subscription types

### DIFF
--- a/rclpy/rclpy/event_handler.py
+++ b/rclpy/rclpy/event_handler.py
@@ -16,6 +16,7 @@ from enum import IntEnum
 from typing import Callable
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 import warnings
 
 import rclpy
@@ -25,6 +26,10 @@ from rclpy.logging import get_logger
 from rclpy.qos import qos_policy_name_from_kind
 from rclpy.waitable import NumberOfEntities
 from rclpy.waitable import Waitable
+
+
+if TYPE_CHECKING:
+    from rclpy.subscription import SubscriptionHandle
 
 
 QoSPublisherEventType = _rclpy.rcl_publisher_event_type_t
@@ -189,8 +194,8 @@ class SubscriptionEventCallbacks:
         self.use_default_callbacks = use_default_callbacks
 
     def create_event_handlers(
-        self, callback_group: CallbackGroup, subscription: _rclpy.Subscription, topic_name: str,
-    ) -> List[EventHandler]:
+        self, callback_group: CallbackGroup, subscription: 'SubscriptionHandle',
+            topic_name: str) -> List[EventHandler]:
         with subscription:
             logger = get_logger(subscription.get_logger_name())
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -76,8 +76,8 @@ from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import Service
 from rclpy.subscription import Subscription
-from rclpy.subscription import SubscriptionHandle
 from rclpy.subscription import MessageInfo
+from rclpy.subscription import SubscriptionHandle
 from rclpy.time_source import TimeSource
 from rclpy.timer import Rate
 from rclpy.timer import Timer

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -75,8 +75,8 @@ from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import Service
-from rclpy.subscription import Subscription
 from rclpy.subscription import MessageInfo
+from rclpy.subscription import Subscription
 from rclpy.subscription import SubscriptionHandle
 from rclpy.time_source import TimeSource
 from rclpy.timer import Rate

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -76,6 +76,8 @@ from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import Service
 from rclpy.subscription import Subscription
+from rclpy.subscription import SubscriptionHandle
+from rclpy.subscription import MessageInfo
 from rclpy.time_source import TimeSource
 from rclpy.timer import Rate
 from rclpy.timer import Timer
@@ -1577,7 +1579,7 @@ class Node:
         self,
         msg_type: Type[MsgT],
         topic: str,
-        callback: Callable[[MsgT], None],
+        callback: Union[Callable[[MsgT], None], Callable[[MsgT, MessageInfo], None]],
         qos_profile: Union[QoSProfile, int],
         *,
         callback_group: Optional[CallbackGroup] = None,
@@ -1627,7 +1629,7 @@ class Node:
         check_is_valid_msg_type(msg_type)
         try:
             with self.handle:
-                subscription_object = _rclpy.Subscription(
+                subscription_object: SubscriptionHandle[MsgT] = _rclpy.Subscription(
                     self.handle, msg_type, topic, qos_profile.get_c_qos_profile())
         except ValueError:
             failed = True

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -15,13 +15,44 @@
 
 from enum import Enum
 import inspect
-from typing import Callable, Generic, List, Type, TypeVar
+from typing import Callable, Generic, Protocol, Type, TypeVar, TypedDict, Union, Tuple, Optional
 
+from rclpy.destroyable import DestroyableType
 from rclpy.callback_groups import CallbackGroup
-from rclpy.event_handler import EventHandler, SubscriptionEventCallbacks
-from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.qos import QoSProfile
 from rclpy.type_support import MsgT
+
+
+class MessageInfo(TypedDict):
+    source_timestamp: Optional[int]
+    received_timestamp: Optional[int]
+    publication_sequence_number: Optional[int]
+    reception_sequence_number: Optional[int]
+
+
+class SubscriptionHandle(DestroyableType, Protocol[MsgT]):
+
+    @property
+    def pointer(self) -> int:
+        "Get the address of the entity as an integer"
+        ...
+
+    def take_message(self, pymsg_type: Type[MsgT], raw: bool) -> Tuple[MsgT, MessageInfo]:
+        "Take a message and its metadata from a subscription."
+        ...
+
+    def get_logger_name(self) -> str:
+        "Get the name of the logger associated with the node of the subscription."
+        ...
+
+    def get_topic_name(self) -> str:
+        "Return the resolved topic name of a subscription."
+        ...
+
+    def get_publisher_count(self) -> int:
+        "Count the publishers from a subscription."
+        ...
 
 
 # Left to support Legacy TypeVars.
@@ -36,10 +67,10 @@ class Subscription(Generic[MsgT]):
 
     def __init__(
          self,
-         subscription_impl: _rclpy.Subscription,
+         subscription_impl: SubscriptionHandle[MsgT],
          msg_type: Type[MsgT],
          topic: str,
-         callback: Callable[[MsgT], None],
+         callback: Union[Callable[[MsgT], None], Callable[[MsgT, MessageInfo], None]],
          callback_group: CallbackGroup,
          qos_profile: QoSProfile,
          raw: bool,
@@ -73,7 +104,7 @@ class Subscription(Generic[MsgT]):
         self.qos_profile = qos_profile
         self.raw = raw
 
-        self.event_handlers: List[EventHandler] = event_callbacks.create_event_handlers(
+        self.event_handlers = event_callbacks.create_event_handlers(
             callback_group, subscription_impl, topic)
 
     def get_publisher_count(self) -> int:
@@ -82,10 +113,10 @@ class Subscription(Generic[MsgT]):
             return self.__subscription.get_publisher_count()
 
     @property
-    def handle(self):
+    def handle(self) -> SubscriptionHandle[MsgT]:
         return self.__subscription
 
-    def destroy(self):
+    def destroy(self) -> None:
         """
         Destroy a container for a ROS subscription.
 
@@ -97,16 +128,17 @@ class Subscription(Generic[MsgT]):
         self.handle.destroy_when_not_in_use()
 
     @property
-    def topic_name(self):
+    def topic_name(self) -> str:
         with self.handle:
             return self.__subscription.get_topic_name()
 
     @property
-    def callback(self) -> Callable[[MsgT], None]:
+    def callback(self) -> Union[Callable[[MsgT], None], Callable[[MsgT, MessageInfo], None]]:
         return self._callback
 
     @callback.setter
-    def callback(self, value: Callable[[MsgT], None]) -> None:
+    def callback(self, value: Union[Callable[[MsgT], None],
+                                    Callable[[MsgT, MessageInfo], None]]) -> None:
         self._callback = value
         self._callback_type = Subscription.CallbackType.MessageOnly
         try:

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -35,23 +35,23 @@ class SubscriptionHandle(DestroyableType, Protocol[MsgT]):
 
     @property
     def pointer(self) -> int:
-        "Get the address of the entity as an integer"
+        """Get the address of the entity as an integer."""
         ...
 
     def take_message(self, pymsg_type: Type[MsgT], raw: bool) -> Tuple[MsgT, MessageInfo]:
-        "Take a message and its metadata from a subscription."
+        """Take a message and its metadata from a subscription."""
         ...
 
     def get_logger_name(self) -> str:
-        "Get the name of the logger associated with the node of the subscription."
+        """Get the name of the logger associated with the node of the subscription."""
         ...
 
     def get_topic_name(self) -> str:
-        "Return the resolved topic name of a subscription."
+        """Return the resolved topic name of a subscription."""
         ...
 
     def get_publisher_count(self) -> int:
-        "Count the publishers from a subscription."
+        """Count the publishers from a subscription."""
         ...
 
 

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -25,8 +25,8 @@ from rclpy.type_support import MsgT
 
 
 class MessageInfo(TypedDict):
-    source_timestamp: Optional[int]
-    received_timestamp: Optional[int]
+    source_timestamp: int
+    received_timestamp: int
     publication_sequence_number: Optional[int]
     reception_sequence_number: Optional[int]
 

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -15,10 +15,10 @@
 
 from enum import Enum
 import inspect
-from typing import Callable, Generic, Protocol, Type, TypeVar, TypedDict, Union, Tuple, Optional
+from typing import Callable, Generic, Optional, Protocol, Tuple, Type, TypedDict, TypeVar, Union
 
-from rclpy.destroyable import DestroyableType
 from rclpy.callback_groups import CallbackGroup
+from rclpy.destroyable import DestroyableType
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.qos import QoSProfile
 from rclpy.type_support import MsgT


### PR DESCRIPTION
Adds types to Subscriptions. Also fixes previously incorrect callback type. Same as #1239. It needs https://github.com/ros2/rosidl_python/pull/205 or all of the generics are treated as `Any`.