### PR TITLE
Fix incorrect comparsion on whether parameter type is NOT_SET (#1032)

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -449,7 +449,7 @@ class Node:
                 descriptor.dynamic_typing = True
 
             if isinstance(second_arg, Parameter.Type):
-                if second_arg.value == Parameter.Type.NOT_SET:
+                if second_arg == Parameter.Type.NOT_SET:
                     raise ValueError(
                         f'Cannot declare parameter {{{name}}} as statically typed of type NOT_SET')
                 if descriptor.dynamic_typing is True:

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -773,6 +773,11 @@ class TestNode(unittest.TestCase):
                 )]
             )
 
+        # Declare a parameter with parameter type 'Not Set'
+        with self.assertRaises(ValueError):
+            self.node.declare_parameter(
+                'wrong_parameter_value_type_not_set', Parameter.Type.NOT_SET)
+
     def reject_parameter_callback(self, parameter_list):
         rejected_parameters = (param for param in parameter_list if 'reject' in param.name)
         return SetParametersResult(successful=(not any(rejected_parameters)))


### PR DESCRIPTION
Same as [c3af8a](https://github.com/ros2/rclpy/commit/c3af8a72fa1f81e5dcd384a9d2912ea244950cfb) , but for `humble`.


