### PR TITLE
(NumberOfEntities) improve performance

### DIFF
--- a/rclpy/rclpy/waitable.py
+++ b/rclpy/rclpy/waitable.py
@@ -42,6 +42,15 @@ class NumberOfEntities:
             setattr(result, attr, left + right)
         return result
 
+    def __iadd__(self, other):
+        self.num_subscriptions += other.num_subscriptions
+        self.num_guard_conditions += other.num_guard_conditions
+        self.num_timers += other.num_timers
+        self.num_clients += other.num_clients
+        self.num_services += other.num_services
+        self.num_events += other.num_events
+        return self
+
     def __repr__(self):
         return '<{0}({1}, {2}, {3}, {4}, {5}, {6})>'.format(
             self.__class__.__name__, self.num_subscriptions,

--- a/rclpy/rclpy/waitable.py
+++ b/rclpy/rclpy/waitable.py
@@ -36,10 +36,12 @@ class NumberOfEntities:
 
     def __add__(self, other):
         result = self.__class__()
-        for attr in result.__slots__:
-            left = getattr(self, attr)
-            right = getattr(other, attr)
-            setattr(result, attr, left + right)
+        result.num_subscriptions = self.num_subscriptions + other.num_subscriptions
+        result.num_guard_conditions = self.num_guard_conditions + other.num_guard_conditions
+        result.num_timers = self.num_timers + other.num_timers
+        result.num_clients = self.num_clients + other.num_clients
+        result.num_services = self.num_services + other.num_services
+        result.num_events = self.num_events + other.num_events
         return result
 
     def __iadd__(self, other):


### PR DESCRIPTION
The MultiThreadedExecutor has very bad performance, see https://github.com/ros2/rclpy/issues/1223.
Refactoring it, not easy task. So first fixing some low hanging fruit. By improving performance.

These changes are not compatible for classes inheriting from this class. But the __repr__ wasn't compatible either. I don't see any class inheriting from this class any time.