### PR TITLE
Docstring specifying proper destruction and creation of Rate, Timer and GuardCondition

### DIFF
--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -19,6 +19,10 @@ from rclpy.utilities import get_default_context
 class GuardCondition:
 
     def __init__(self, callback, callback_group, context=None):
+        """
+        .. warning:: Users should not create a guard condition with this constructor, instead they
+           should call :meth:`.Node.create_guard_condition`.
+        """
         self._context = get_default_context() if context is None else context
         with self._context.handle:
             self.__gc = _rclpy.GuardCondition(self._context.handle)
@@ -38,4 +42,8 @@ class GuardCondition:
         return self.__gc
 
     def destroy(self):
+        """
+        .. warning:: Users should not destroy a guard condition with this method, instead they should
+           call :meth:`.Node.destroy_guard_condition`.
+        """
         self.handle.destroy_when_not_in_use()

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -20,6 +20,8 @@ class GuardCondition:
 
     def __init__(self, callback, callback_group, context=None):
         """
+        Create a GuardCondition.
+
         .. warning:: Users should not create a guard condition with this constructor, instead they
            should call :meth:`.Node.create_guard_condition`.
         """
@@ -43,7 +45,9 @@ class GuardCondition:
 
     def destroy(self):
         """
-        .. warning:: Users should not destroy a guard condition with this method, instead they should
-           call :meth:`.Node.destroy_guard_condition`.
+        Destroy a container for a ROS guard condition.
+
+        .. warning:: Users should not destroy a guard condition with this method, instead
+        they should call :meth:`.Node.destroy_guard_condition`.
         """
         self.handle.destroy_when_not_in_use()

--- a/rclpy/rclpy/guard_condition.py
+++ b/rclpy/rclpy/guard_condition.py
@@ -48,6 +48,6 @@ class GuardCondition:
         Destroy a container for a ROS guard condition.
 
         .. warning:: Users should not destroy a guard condition with this method, instead
-        they should call :meth:`.Node.destroy_guard_condition`.
+           they should call :meth:`.Node.destroy_guard_condition`.
         """
         self.handle.destroy_when_not_in_use()

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1784,7 +1784,7 @@ class Node:
         Create a new guard condition.
 
         .. warning:: Users should call :meth:`.Node.destroy_guard_condition` to destroy
-        the GuardCondition object.
+           the GuardCondition object.
         """
         if callback_group is None:
             callback_group = self.default_callback_group

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1780,7 +1780,10 @@ class Node:
         callback: Callable,
         callback_group: Optional[CallbackGroup] = None
     ) -> GuardCondition:
-        """Create a new guard condition."""
+        """Create a new guard condition.
+
+        .. warning:: Users should call :meth:`.Node.destroy_guard_condition` to destroy the GuardCondition object.
+        """
         if callback_group is None:
             callback_group = self.default_callback_group
         guard = GuardCondition(callback, callback_group, context=self.context)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1784,7 +1784,7 @@ class Node:
         Create a new guard condition.
 
         .. warning:: Users should call :meth:`.Node.destroy_guard_condition` to destroy
-           the GuardCondition object.
+        the GuardCondition object.
         """
         if callback_group is None:
             callback_group = self.default_callback_group

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1780,9 +1780,11 @@ class Node:
         callback: Callable,
         callback_group: Optional[CallbackGroup] = None
     ) -> GuardCondition:
-        """Create a new guard condition.
+        """
+        Create a new guard condition.
 
-        .. warning:: Users should call :meth:`.Node.destroy_guard_condition` to destroy the GuardCondition object.
+        .. warning:: Users should call :meth:`.Node.destroy_guard_condition` to destroy
+        the GuardCondition object.
         """
         if callback_group is None:
             callback_group = self.default_callback_group

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1798,6 +1798,8 @@ class Node:
         """
         Create a Rate object.
 
+        .. warning:: Users should call :meth:`.Node.destroy_rate` to destroy the Rate object.
+
         :param frequency: The frequency the Rate runs at (Hz).
         :param clock: The clock the Rate gets time from.
         """

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -74,6 +74,8 @@ class Timer:
 
     def destroy(self):
         """
+        Destroy a container for a ROS timer.
+
         .. warning:: Users should not destroy a timer with this method, instead they should
            call :meth:`.Node.destroy_timer`.
         """
@@ -127,6 +129,8 @@ class Rate:
 
     def __init__(self, timer: Timer, *, context):
         """
+        Create a Rate.
+
         .. warning:: Users should not create a rate with this constructor, instead they
            should call :meth:`.Node.create_rate`.
         """
@@ -152,6 +156,8 @@ class Rate:
 
     def destroy(self):
         """
+        Destroy a container for a ROS rate.
+
         .. warning:: Users should not destroy a rate with this method, instead they should
            call :meth:`.Node.destroy_rate`.
         """

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -126,6 +126,10 @@ class Rate:
     """A utility for sleeping at a fixed rate."""
 
     def __init__(self, timer: Timer, *, context):
+        """
+        .. warning:: Users should not create a rate with this constructor, instead they
+           should call :meth:`.Node.create_rate`.
+        """
         # Rate is a wrapper around a timer
         self._timer = timer
         self._is_shutdown = False
@@ -147,6 +151,10 @@ class Rate:
         self.destroy()
 
     def destroy(self):
+        """
+        .. warning:: Users should not destroy a rate with this method, instead they should
+           call :meth:`.Node.destroy_rate`.
+        """
         self._is_destroyed = True
         self._event.set()
 

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -45,6 +45,9 @@ class Timer:
         If autostart is ``False``, the timer will be created but not started; it can then be
         started by calling ``reset()`` on the timer object.
 
+        .. warning:: Users should not create a timer with this constructor, instead they
+           should call :meth:`.Node.create_timer`.
+
         :param callback: A user-defined callback function that is called when the timer expires.
         :param callback_group: The callback group for the timer. If ``None``, then the
             default callback group for the node is used.
@@ -70,6 +73,10 @@ class Timer:
         return self.__timer
 
     def destroy(self):
+        """
+        .. warning:: Users should not destroy a timer with this method, instead they should
+           call :meth:`.Node.destroy_timer`.
+        """
         self.__timer.destroy_when_not_in_use()
 
     @property


### PR DESCRIPTION
This commit stems from my [issue and discussion here](https://github.com/ros2/rclpy/issues/1278)

I added explanation of how the user should handle the destruction and creation of the object in the docstrings of the:
- constructor of `Rate`, `Timer` and `GuardCondition`
- .destroy methods of `Rate`, `Timer` and `GuardCondition`
- `.create_rate` and `.create_guard_condition` methods of Node

`Subscriber`, `Publisher` and other objects share the same destruction process. However they already had proper warnings in their docstrings. So no changes were required for those. I have kept my new docstring consistent with those. 

I have decided to only change `.create_rate` and `.create_guard_condition` methods of `Node` because, those are the most likely objects to be destroyed and had a very short docstrings. Adding the warning in the already long create_publisher, etc, did not seem right.