### PR TITLE
Make service servers context-manager aware.

### DIFF
--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import TracebackType
 from typing import Callable
+from typing import Optional
+from typing import Type
 from typing import TypeVar
 
 from rclpy.callback_groups import CallbackGroup
@@ -115,3 +118,14 @@ class Service:
            should call :meth:`.Node.destroy_service`.
         """
         self.__service.destroy_when_not_in_use()
+
+    def __enter__(self) -> 'Service':
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.destroy()

--- a/rclpy/test/test_service.py
+++ b/rclpy/test/test_service.py
@@ -78,3 +78,10 @@ def test_get_service_name_after_remapping(service_name, namespace, cli_args, exp
 
     srv.destroy()
     node.destroy_node()
+
+
+def test_service_context_manager():
+    with rclpy.create_node('ctx_mgr_test') as node:
+        with node.create_service(
+                srv_type=Empty, srv_name='empty_service', callback=lambda _: None) as srv:
+            assert srv.service_name == '/empty_service'


### PR DESCRIPTION
This way it is much easier to create examples that properly clean up after themselves.

This partially fixes #1280, but we'll need additional PRs to do so.