### PR TITLE
Make timers context-aware.

### DIFF
--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -14,8 +14,10 @@
 
 import threading
 
+from types import TracebackType
 from typing import Callable
 from typing import Optional
+from typing import Type
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.clock import Clock
@@ -113,6 +115,17 @@ class Timer:
     def time_until_next_call(self):
         with self.__timer:
             return self.__timer.time_until_next_call()
+
+    def __enter__(self) -> 'Timer':
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.destroy()
 
 
 class Rate:

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -202,3 +202,19 @@ def test_timer_without_autostart():
         if node is not None:
             node.destroy_node()
         rclpy.shutdown()
+
+
+def test_timer_context_manager():
+    rclpy.init()
+    try:
+        with rclpy.create_node('test_timer_without_autostart') as node:
+            with node.create_timer(1, lambda: None, autostart=False) as timer:
+                assert timer.is_canceled()
+
+                timer.reset()
+                assert not timer.is_canceled()
+
+                timer.cancel()
+                assert timer.is_canceled()
+    finally:
+        rclpy.shutdown()


### PR DESCRIPTION
This should make it easier to create examples and demos that properly clean up after themselves.

This partially solves #1280 , though we'll need additional PRs to complete it.