### PR TITLE
Make rclpy initialization context-manager aware.

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -40,6 +40,8 @@ all ROS nodes associated with the context), the :func:`shutdown` function should
 This will invalidate all entities derived from the context.
 """
 
+import contextlib
+
 from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -86,7 +88,35 @@ def init(
         else:
             signal_handler_options = SignalHandlerOptions.NO
     install_signal_handlers(signal_handler_options)
-    return context.init(args, domain_id=domain_id)
+    context.init(args, domain_id=domain_id)
+
+
+@contextlib.contextmanager
+def managed_init(
+    *,
+    args: Optional[List[str]] = None,
+    context: Optional[Context] = None,
+    domain_id: Optional[int] = None,
+    signal_handler_options: Optional[SignalHandlerOptions] = None,
+) -> None:
+    """
+    Initialize ROS communications for a given context, in a Python context-manager aware way.
+
+    :param args: List of command line arguments.
+    :param context: The context to initialize. If ``None``, then the default context is used
+        (see :func:`.get_default_context`).
+    :param domain_id: ROS domain id.
+    :param signal_handler_options: Indicate which signal handlers to install.
+        If `None`, SIGINT and SIGTERM will be installed when initializing the default context.
+    """
+    init(args=args, context=context, domain_id=domain_id,
+         signal_handler_options=signal_handler_options)
+
+    context = get_default_context() if context is None else context
+    try:
+        yield context
+    finally:
+        context.try_shutdown()
 
 
 # The global spin functions need an executor to do the work

--- a/rclpy/rclpy/context.py
+++ b/rclpy/rclpy/context.py
@@ -187,9 +187,11 @@ class Context(ContextManager['Context']):
             return self.__context.get_domain_id()
 
     def __enter__(self) -> 'Context':
-        # We do not accept parameters here. If one wants to customize the init() call,
-        # they would have to call it manually and not use the ContextManager convenience
-        self.init()
+        if self.__context is None:
+            # This object hasn't been initialized yet, so we can't use a context manager
+            raise RuntimeError(
+                'init() must be called on this Context before using it with a context manager')
+
         return self
 
     def __exit__(

--- a/rclpy/test/test_context.py
+++ b/rclpy/test/test_context.py
@@ -61,6 +61,8 @@ def test_context_manager():
 
     assert not context.ok(), 'the context should not be ok() before init() is called'
 
+    context.init()
+
     with context as the_context:
         # Make sure the correct instance is returned
         assert the_context is context

--- a/rclpy/test/test_init_shutdown.py
+++ b/rclpy/test/test_init_shutdown.py
@@ -109,3 +109,9 @@ def test_signal_handlers():
 def test_init_with_invalid_domain_id():
     with pytest.raises(RuntimeError):
         rclpy.init(domain_id=-1)
+
+
+def test_managed_init():
+    with rclpy.managed_init(domain_id=123) as context:
+        assert context.get_domain_id() == 123
+        assert context.ok()


### PR DESCRIPTION
This PR does two somewhat controversial things:

1.  It adds in a new "rclpy.managed_init" method to rclpy, which would be used with a context manager instead of rclpy.init.  I had to do things this way because there is no way (as far as I know) for the callee to know whether it was called within a context manager or not, and I don't think we can reasonably change the semantics of rclpy.init() at this point.

2.  It changes the context manager implementation of Context so that it does *not* call init() within itself. This definitely changes the semantics, but as it stands that initialization doesn't make sense because it can't take arguments.  I think this change is warranted, though we may have to search through documentation and examples to make sure this doesn't break anything.

@sloretz I particularly am interested in your feedback on these changes.