### PR TITLE
Remove `SHARED` from `pybind11_add_module`

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -78,7 +78,7 @@ function(configure_build_install_location _library_name)
 endfunction()
 
 # Split from main extension and converted to pybind11
-pybind11_add_module(_rclpy_pybind11 SHARED
+pybind11_add_module(_rclpy_pybind11
   src/rclpy/_rclpy_logging.cpp
   src/rclpy/_rclpy_pybind11.cpp
   src/rclpy/action_client.cpp


### PR DESCRIPTION
When the module is compiled with `MODULE` (the default), the proper linker flags are added on macOS (specifically `-undefined dynamic_lookup`). Otherwise, `rclpy` segfaults when linked on conda. 

Is the `SHARED` really necessary? The `pybind11` documentation says:

> Specifying `SHARED` will create a more traditional dynamic library which can also be linked from elsewhere. 

Is anyone linking against this library as a "traditional dynamic library"?