### PR TITLE
Add missing `Optional` types to `node.py` on `humble` branch

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -117,13 +117,13 @@ class Node:
         self,
         node_name: str,
         *,
-        context: Context = None,
-        cli_args: List[str] = None,
-        namespace: str = None,
+        context: Optional[Context] = None,
+        cli_args: Optional[List[str]] = None,
+        namespace: Optional[str] = None,
         use_global_arguments: bool = True,
         enable_rosout: bool = True,
         start_parameter_services: bool = True,
-        parameter_overrides: List[Parameter] = None,
+        parameter_overrides: Optional[List[Parameter]] = None,
         allow_undeclared_parameters: bool = False,
         automatically_declare_parameters_from_overrides: bool = False
     ) -> None:
@@ -1397,7 +1397,7 @@ class Node:
         srv_name: str,
         *,
         qos_profile: QoSProfile = qos_profile_services_default,
-        callback_group: CallbackGroup = None
+        callback_group: Optional[CallbackGroup] = None
     ) -> Client:
         """
         Create a new service client.
@@ -1440,7 +1440,7 @@ class Node:
         callback: Callable[[SrvTypeRequest, SrvTypeResponse], SrvTypeResponse],
         *,
         qos_profile: QoSProfile = qos_profile_services_default,
-        callback_group: CallbackGroup = None
+        callback_group: Optional[CallbackGroup] = None
     ) -> Service:
         """
         Create a new service server.
@@ -1481,8 +1481,8 @@ class Node:
         self,
         timer_period_sec: float,
         callback: Callable,
-        callback_group: CallbackGroup = None,
-        clock: Clock = None,
+        callback_group: Optional[CallbackGroup] = None,
+        clock: Optional[Clock] = None,
     ) -> Timer:
         """
         Create a new timer.
@@ -1511,7 +1511,7 @@ class Node:
     def create_guard_condition(
         self,
         callback: Callable,
-        callback_group: CallbackGroup = None
+        callback_group: Optional[CallbackGroup] = None
     ) -> GuardCondition:
         """Create a new guard condition."""
         if callback_group is None:
@@ -1526,7 +1526,7 @@ class Node:
     def create_rate(
         self,
         frequency: float,
-        clock: Clock = None,
+        clock: Optional[Clock] = None,
     ) -> Rate:
         """
         Create a Rate object.


### PR DESCRIPTION
Added `Optional` types to function declarations in `node.py` where relevant on the `humble` branch. Missing `Optional` types cause static type checking failures. Example:
```
class ExampleNode(Node):
    def __init__(self, cbg: Optional[CallbackGroup] = None) -> None:
        super().__init__("example_node")
        self.timer = self.create_timer(
            0.001,
            self.timer_callback,
            callback_group=cbg,  # fails static type checking - this field wasn't annotated as Optional[CallbackGroup]
        )
```