### PR TITLE
Avoid causing infinite loop when message is empty (#935)

### DIFF
--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -102,8 +102,7 @@ class TestClient(unittest.TestCase):
         try:
             self.assertTrue(cli.wait_for_service(timeout_sec=20))
             cli.call_async(GetParameters.Request())
-            cycle_count = 0
-            while cycle_count < 5:
+            for i in range(5):
                 with srv.handle:
                     result = srv.handle.service_take_request(srv.srv_type.Request)
                 if result is not None:
@@ -112,7 +111,7 @@ class TestClient(unittest.TestCase):
                     self.assertNotEqual(0, header.source_timestamp)
                     return
                 else:
-                    time.sleep(0.1)
+                    time.sleep(0.2)
             self.fail('Did not get a request in time')
         finally:
             self.node.destroy_client(cli)

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -157,8 +157,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             1)
         basic_types_msg = BasicTypes()
         basic_types_pub.publish(basic_types_msg)
-        cycle_count = 0
-        while cycle_count < 5:
+        for i in range(5):
             with sub.handle:
                 result = sub.handle.take_message(sub.msg_type, False)
             if result is not None:
@@ -166,7 +165,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
                 self.assertNotEqual(0, info['source_timestamp'])
                 return
             else:
-                time.sleep(0.1)
+                time.sleep(0.2)
 
     def test_create_client(self):
         self.node.create_client(GetParameters, 'get/parameters')


### PR DESCRIPTION
Same as [ad389c](https://github.com/ros2/rclpy/pull/935), but for `humble`.

* Avoid causing infinite loop when message is empty
* Extend the sleep time to 0.2