### PR TITLE
Fix a bug when using multiple rclpy.init context managers.

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -100,7 +100,12 @@ class InitContextManager:
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:
-        try_shutdown(context=self.context, uninstall_handlers=self.installed_signal_handlers)
+        # The Context class can only be initialized once.  Thus when using the default context,
+        # we have to destroy it every time we are done using it and create a new one.
+        # utilities.try_shutdown will only replace the default context if we pass 'None', so make
+        # sure to do that for the default context.
+        shutdown_context = None if self.context is get_default_context() else self.context
+        try_shutdown(context=shutdown_context, uninstall_handlers=self.installed_signal_handlers)
 
 
 def init(


### PR DESCRIPTION
That is, if you call rclpy.init as a context manager within the same process, and using the default context, it currently fails.  That is because you cannot reinitialize (call init) on a Context object once it has been shutdown.  Instead, force try_shutdown to replace the global context object with a new one on rclpy.init shutdown by passing a None.

This should fix some failing tests on the repeated jobs, like https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/3516/testReport/junit/test_launch_ros.test.test_launch_ros.actions/test_ros_timer/test_timer_uses_sim_time_2_3_/

@Crola1702 FYI