### PR TITLE
Reject wrong lifecycle transitions without crash (#1209)

### DIFF
--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -350,6 +350,12 @@ class LifecycleNodeMixin(ManagedEntity):
     ):
         self.__check_is_initialized()
         transition_id = req.transition.id
+        
+        available_transition_ids = [t[0] for t in self._state_machine.available_transitions]
+        if transition_id not in available_transition_ids:
+              resp.success = False
+              return resp
+        
         if req.transition.label:
             try:
                 transition_id = self._state_machine.get_transition_by_label(req.transition.label)


### PR DESCRIPTION
Fix for #1209 

Instead of attempting to do a lifecycle transition and potentially crashing the node, it is first checked if a transition is valid. If it is not, it is ignored. The service caller gets notified via `success = False`.