### PR TITLE
Fix a bad bug in fetching the lifecycle transitions.

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -180,6 +180,7 @@ if(BUILD_TESTING)
       test/test_expand_topic_name.py
       test/test_guard_condition.py
       test/test_init_shutdown.py
+      test/test_lifecycle.py
       test/test_logging.py
       test/test_logging_rosout.py
       test/test_logging_service.py

--- a/rclpy/src/rclpy/lifecycle.cpp
+++ b/rclpy/src/rclpy/lifecycle.cpp
@@ -182,7 +182,7 @@ public:
   {
     std::vector<std::tuple<uint8_t, std::string>> ret;
     ret.reserve(state_machine_->transition_map.states_size);
-    for (size_t i = 0; i <= state_machine_->transition_map.states_size; ++i) {
+    for (size_t i = 0; i < state_machine_->transition_map.states_size; ++i) {
       ret.emplace_back(
         std::make_tuple(
           state_machine_->transition_map.states[i].id,

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -176,7 +176,7 @@ def test_lifecycle_services(request):
     states_labels = {state.label for state in resp.available_states}
     assert states_labels == {
         'unknown', 'unconfigured', 'inactive', 'active', 'finalized', 'configuring', 'cleaningup',
-        'shuttingdown', 'activating', 'deactivating', 'errorprocessing', ''
+        'shuttingdown', 'activating', 'deactivating', 'errorprocessing'
     }
     req = lifecycle_msgs.srv.GetAvailableTransitions.Request()
     resp = get_available_transitions_cli.call(req)


### PR DESCRIPTION
We were fetching one more lifecycle transition than existed in the source list (i.e. we should use < instead of <=).

In turn, this allows us to enable the test_lifecycle.py test, and to fix the spurious "empty" string in the expected states.

This supersedes #1318.  @fujitatomoya FYI.