### PR TITLE
Replace rclpyHandle with type stubs

### DIFF
--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,21 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Provide singleton access to the rclpy C modules.
+from typing import Sequence
 
-For example, you might use it like this:
 
-.. code::
+def rclpy_remove_ros_args(pycli_args: Sequence[str]) -> list[str]: ...
+"""Remove ROS-specific arguments from argument vector."""
 
-    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-
-    _rclpy.rclpy_init()
-    while _rclpy.rclpy_ok():
-        # ...
-"""
-
-from rpyutils import import_c_library
-package = 'rclpy'
-
-rclpy_implementation = import_c_library('._rclpy_pybind11', package)
+def rclpy_get_rmw_implementation_identifier() -> str: ...
+"""Retrieve the identifier for the active RMW implementation."""

--- a/rclpy/rclpy/impl/implementation_singleton.pyi
+++ b/rclpy/rclpy/impl/implementation_singleton.pyi
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,21 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Provide singleton access to the rclpy C modules.
 
-For example, you might use it like this:
+from rclpy.impl import _rclpy_pybind11
 
-.. code::
-
-    from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
-
-    _rclpy.rclpy_init()
-    while _rclpy.rclpy_ok():
-        # ...
-"""
-
-from rpyutils import import_c_library
-package = 'rclpy'
-
-rclpy_implementation = import_c_library('._rclpy_pybind11', package)
+rclpy_implementation = _rclpy_pybind11

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -70,7 +70,6 @@ def ok(*, context: Optional[Context] = None) -> bool:
     return context.ok()
 
 
-
 def shutdown(*, context: Optional[Context] = None) -> None:
     """
     Shutdown the given ``Context``.

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -70,6 +70,7 @@ def ok(*, context: Optional[Context] = None) -> bool:
     return context.ok()
 
 
+
 def shutdown(*, context: Optional[Context] = None) -> None:
     """
     Shutdown the given ``Context``.


### PR DESCRIPTION
Currently using `rclpyHandle` to mock the pybind implementation has cause some weirdness when dealing with type annotations. A better and more scalable solutions is replacing it with custom type stubs. One day in the future I would love to use stubgen to automatically generate stubs however it is still missing many features for example generics, TypeDicts, etc. Pybind has made progress in the recent years with function type annotations it however still needs work. This would also allow us to move the Various `Handle` Protocols into type stubs which is probably a better long term plan.