### PR TITLE
Minor Typing Updates to Service/Client

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1677,7 +1677,7 @@ class Node:
 
     def create_client(
         self,
-        srv_type: Srv[SrvRequestT, SrvResponseT, SrvEventT],
+        srv_type: Type[Srv[SrvRequestT, SrvResponseT, SrvEventT]],
         srv_name: str,
         *,
         qos_profile: QoSProfile = qos_profile_services_default,
@@ -1719,7 +1719,7 @@ class Node:
 
     def create_service(
         self,
-        srv_type: Srv[SrvRequestT, SrvResponseT, SrvEventT],
+        srv_type: Type[Srv[SrvRequestT, SrvResponseT, SrvEventT]],
         srv_name: str,
         callback: Callable[[SrvRequestT, SrvResponseT], SrvResponseT],
         *,

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -36,7 +36,7 @@ class Service(Generic[SrvRequestT, SrvResponseT, SrvEventT]):
     def __init__(
         self,
         service_impl: _rclpy.Service,
-        srv_type: Srv[SrvRequestT, SrvResponseT, SrvEventT],
+        srv_type: Type[Srv[SrvRequestT, SrvResponseT, SrvEventT]],
         srv_name: str,
         callback: Callable[[SrvRequestT, SrvResponseT], SrvResponseT],
         callback_group: CallbackGroup,
@@ -112,7 +112,7 @@ class Service(Generic[SrvRequestT, SrvResponseT, SrvEventT]):
         with self.handle:
             return self.__service.name
 
-    def destroy(self):
+    def destroy(self) -> None:
         """
         Destroy a container for a ROS service server.
 
@@ -121,7 +121,7 @@ class Service(Generic[SrvRequestT, SrvResponseT, SrvEventT]):
         """
         self.__service.destroy_when_not_in_use()
 
-    def __enter__(self) -> 'Service':
+    def __enter__(self) -> 'Service[SrvRequestT, SrvResponseT, SrvEventT]':
         return self
 
     def __exit__(

--- a/rclpy/rclpy/type_support.py
+++ b/rclpy/rclpy/type_support.py
@@ -66,8 +66,7 @@ class Srv(Protocol[SrvRequestT, SrvResponseT, SrvEventT], metaclass=CommonMsgSrv
     Response: Type[SrvResponseT]
     Event: Type[SrvEventT]
 
-    def __init__(self) -> NoReturn:
-        ...
+    def __init__(self) -> NoReturn: ...
 
 
 # Can be used if https://github.com/python/typing/issues/548 ever gets approved.


### PR DESCRIPTION
Building off of https://github.com/ros2/rclpy/pull/1275 and #1254, Uses the new Futures inside client.py and update srv_type to be `Type[Srv[...]]` rather than `Srv[...]`.