### PR TITLE
Install signal handlers after context is initialized

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -88,8 +88,12 @@ class InitContextManager:
             self.installed_signal_handlers = False
         else:
             self.installed_signal_handlers = True
-        install_signal_handlers(signal_handler_options)
         self.context.init(args, domain_id=domain_id)
+        # Install signal handlers after initializing the context because the rclpy signal
+        # handler only does something if there is at least one initialized context.
+        # It is desirable for sigint or sigterm to be able to terminate the process if rcl_init
+        # takes a long time, and the default signal handlers work well for that purpose.
+        install_signal_handlers(signal_handler_options)
 
     def __enter__(self) -> 'InitContextManager':
         return self


### PR DESCRIPTION
This bug was found by @Yadunund, who also noticed [rclcpp initializes the context before installing the signal handlers]( https://github.com/ros2/rclcpp/blob/2739327ee9af0256c7edcbccb810513af0018851/rclcpp/src/rclcpp/utilities.cpp#L41-L43).

The only thing the rclcpp and rclpy signal handlers do is [notify another thread that the signal was received](https://github.com/ros2/rclpy/blob/ee79763648858bffa2a84b76e092fe0b20504aa8/rclpy/src/rclpy/signal_handler.cpp#L311). That thread [loops through the initialized contexts and shuts them down](https://github.com/ros2/rclpy/blob/ee79763648858bffa2a84b76e092fe0b20504aa8/rclpy/src/rclpy/signal_handler.cpp#L141-L144). Nothing happens if there are no initialized contexts.