### PR TITLE
TestClient.test_service_timestamps failing consistently.

### DIFF
--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -141,7 +141,7 @@ class TestClient(unittest.TestCase):
             for i in range(5):
                 with srv.handle:
                     result = srv.handle.service_take_request(srv.srv_type.Request)
-                if result is not None:
+                if result != (None, None):
                     request, header = result
                     self.assertTrue(header is not None)
                     self.assertNotEqual(0, header.source_timestamp)


### PR DESCRIPTION
closes https://github.com/ros2/rclpy/issues/1347

note: backport all distros.