### PR TITLE
Add in python3-dev build dependency.

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>pybind11_vendor</build_depend>
+  <build_depend>python3-dev</build_depend>
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>


### PR DESCRIPTION
We need this because we call find_package(Python3 Development) in our CMakeLists.txt here.

Also see https://github.com/ros2/ros2_tracing/pull/146#issuecomment-2492724725 for a long explanation of why we need this.