### PR TITLE
Throw CancelledException into cancelled tasks

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -155,3 +155,6 @@ class ROSInterruptException(Exception):
 
     def __init__(self) -> None:
         Exception.__init__(self, 'rclpy.shutdown() has been called')
+
+class CancelledException(BaseException):
+    """The Future or Task was cancelled."""

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -620,8 +620,6 @@ class Executor(ContextManager['Executor']):
                 with self._tasks_lock:
                     # Get rid of any tasks that are done
                     self._tasks = list(filter(lambda t_e_n: not t_e_n[0].done(), self._tasks))
-                    # Get rid of any tasks that are cancelled
-                    self._tasks = list(filter(lambda t_e_n: not t_e_n[0].cancelled(), self._tasks))
 
             # Gather entities that can be waited on
             subscriptions: List[Subscription] = []

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -86,7 +86,7 @@ class Future(Generic[T]):
 
         :return: True if the task was cancelled
         """
-        return self._state != FutureState.CANCELLED
+        return self._state == FutureState.CANCELLED
 
     def done(self) -> bool:
         """

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -68,7 +68,7 @@ class Future(Generic[T]):
 
     def __await__(self) -> Generator[None, None, Optional[T]]:
         # Yield if the task is not finished
-        while self._state == FutureState.PENDING:
+        while not self.done():
             yield
         return self.result()
 
@@ -104,7 +104,7 @@ class Future(Generic[T]):
 
         :return: The result set by the task, or None if no result was set.
         """
-        exception = self.exception()
+        exception = CancelledException() if self.cancelled() else self.exception()
         if exception:
             raise exception
         return self._result

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -15,7 +15,6 @@
 import inspect
 import sys
 import threading
-from tkinter import E
 from typing import (Callable, cast, Coroutine, Dict, Generator, Generic, List,
                     Optional, TYPE_CHECKING, TypeVar, Union)
 import warnings

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -19,7 +19,7 @@ from typing import (Callable, cast, Coroutine, Dict, Generator, Generic, List,
                     Optional, TYPE_CHECKING, TypeVar, Union)
 import warnings
 import weakref
-
+from enum import StrEnum, auto
 if TYPE_CHECKING:
     from rclpy.executors import Executor
 
@@ -31,14 +31,18 @@ def _fake_weakref() -> None:
     return None
 
 
+class FutureState(StrEnum):
+    """States defining the lifecycle of a future"""
+    PENDING = auto()
+    CANCELLED = auto()
+    FINISHED = auto()
+
+
 class Future(Generic[T]):
     """Represent the outcome of a task in the future."""
 
     def __init__(self, *, executor: Optional['Executor'] = None) -> None:
-        # true if the task is done or cancelled
-        self._done = False
-        # true if the task is cancelled
-        self._cancelled = False
+        self._state = FutureState.PENDING
         # the final return value of the handler
         self._result: Optional[T] = None
         # An exception raised by the handler when called
@@ -61,15 +65,15 @@ class Future(Generic[T]):
 
     def __await__(self) -> Generator[None, None, Optional[T]]:
         # Yield if the task is not finished
-        while not self._done and not self._cancelled:
+        while self._state == FutureState.PENDING:
             yield
         return self.result()
 
     def cancel(self) -> None:
         """Request cancellation of the running task if it is not done already."""
         with self._lock:
-            if not self._done:
-                self._cancelled = True
+            if not self.done():
+                self._state = FutureState.CANCELLED
         self._schedule_or_invoke_done_callbacks()
 
     def cancelled(self) -> bool:
@@ -78,7 +82,7 @@ class Future(Generic[T]):
 
         :return: True if the task was cancelled
         """
-        return self._cancelled
+        return self._state != FutureState.CANCELLED
 
     def done(self) -> bool:
         """
@@ -86,7 +90,7 @@ class Future(Generic[T]):
 
         :return: True if the task is finished or raised while it was executing
         """
-        return self._done
+        return self._state != FutureState.PENDING
 
     def result(self) -> Optional[T]:
         """
@@ -118,8 +122,7 @@ class Future(Generic[T]):
         """
         with self._lock:
             self._result = result
-            self._done = True
-            self._cancelled = False
+            self._state = FutureState.FINISHED
         self._schedule_or_invoke_done_callbacks()
 
     def set_exception(self, exception: Exception) -> None:
@@ -131,8 +134,7 @@ class Future(Generic[T]):
         with self._lock:
             self._exception = exception
             self._exception_fetched = False
-            self._done = True
-            self._cancelled = False
+            self._state = FutureState.FINISHED
         self._schedule_or_invoke_done_callbacks()
 
     def _schedule_or_invoke_done_callbacks(self) -> None:
@@ -181,7 +183,7 @@ class Future(Generic[T]):
         """
         invoke = False
         with self._lock:
-            if self._done:
+            if self.done():
                 assert self._executor is not None
                 executor = self._executor()
                 if executor is not None:
@@ -240,14 +242,13 @@ class Task(Future[T]):
         The return value of the handler is stored as the task result.
         """
         if (
-            self._done or
-            self._cancelled or
+            self._state != FutureState.PENDING or
             self._executing or
             not self._task_lock.acquire(blocking=False)
         ):
             return
         try:
-            if self._done:
+            if self.done():
                 return
             self._executing = True
 


### PR DESCRIPTION
PR #1377 addresses issue #1099 by filtering out cancelled tasks. The original attempt encountered issues where cancelled coroutines were not closed properly. This is resolved by throwing CancelledException into the coroutine, similar to the behavior of asyncio.

The solution is not ready yet, as the current implementation raises CancelledException when calling task.result(), which crashes the executor due to the way exceptions in tasks are currently treated: https://github.com/ros2/rclpy/blob/4e8b071127228d5dace5aebf61d02260ecb91253/rclpy/rclpy/executors.py#L853-L855

Potential Solutions
1. Change Executor Behavior to Log Exceptions: Modify the executor to log exceptions instead of crashing, aligning with asyncio behavior. This approach would also resolve issue #1098.
2. Ignore Cancelled Tasks in `task.result()`: Prevent `CancelledException` from being set in `self._exception`. Users would need to call `task.cancelled()` to check cancellation status instead.
3. Executor Ignores `CancelledException`: Allow the exception to be raised but modify the executor to prevent it from crashing.
4. Introduce a Flag (`is_awaited`): The flag is set upon entering `__await__`, causing the executor to ignore or log any exception.

Would love to hear from you :)
@weber-niklas @fujitatomoya  @haudren-woven @sloretz