### PR TITLE
Close cancelled coroutine

### DIFF
--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -250,7 +250,7 @@ class Task(Future[T]):
         ):
             return
         try:
-            if self._done:
+            if self.done():
                 return
             self._executing = True
 
@@ -293,3 +293,9 @@ class Task(Future[T]):
         :return: True if the task is currently executing.
         """
         return self._executing
+
+    def cancel(self) -> None:
+        if not self.done() and inspect.iscoroutine(self._handler):
+            self._handler.close()
+
+        super().cancel()

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -290,7 +290,7 @@ class TestExecutor(unittest.TestCase):
         self.assertTrue(future.cancelled())
 
         executor.spin_until_future_complete(future)
-        self.assertFalse(future.done())
+        self.assertTrue(future.done())
         self.assertTrue(future.cancelled())
         self.assertEqual(None, future.result())
 


### PR DESCRIPTION
Fixed the issue in PR #1377 where cancelled coroutines are not closed and implemented a FutureState similar to asyncio.
The failed test is now passing.