### PR TITLE
Ignore exceptions raised in user created tasks

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -851,10 +851,9 @@ class SingleThreadedExecutor(Executor):
             pass
         else:
             handler()
-            if handler.exception() is not None:
-                raise handler.exception()
-
-            handler.result()  # raise any exceptions
+            if entity is not None:
+                # if the task was not created by the user
+                handler.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         self._spin_once_impl(timeout_sec)


### PR DESCRIPTION
Addresses #1098.
Currently exceptions raised in user created tasks crash the executor. In my project I had to catch the exception and return it to allow communicating exceptions from the task to the main code.
This pull request mimics the behavior of asyncio, in which exceptions in tasks are ignored and logged upon garbage collection.
The logging part is already implemented, although this code is currently unreachable.
It was only necessary to add a line in the SingleThreadedExecutor to check if the task is related to an entity, since user created tasks are not bounded to any entity.
https://github.com/ros2/rclpy/blob/4e8b071127228d5dace5aebf61d02260ecb91253/rclpy/rclpy/task.py#L56-L60

@fujitatomoya 