### PR TITLE
Add missing items to exec_depend so rosdoc2 shows Node

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -33,6 +33,7 @@
   <depend>rmw</depend>
   <depend>rmw_implementation</depend>
   <depend>rosidl_runtime_c</depend>
+  <depend>type_description_interfaces</depend>
   <depend>unique_identifier_msgs</depend>
 
   <exec_depend>action_msgs</exec_depend>
@@ -42,6 +43,7 @@
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>
   <exec_depend>rpyutils</exec_depend>
+  <exec_depend>service_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
A [user noted in discord](https://discord.com/channels/1077825543698927656/1080763309701210182/1335023299419308083) that the api docs for rclpy in jazzy do not have information for Node. @cottsay noted this is because of missing dependencies. Here are those missing dependencies for rolling.

For rosdoc2, all we need is ```doc_depends``` but I included it in ```exec_depends``` because I don't believe this issue is limited to rosdoc2.