### PR TITLE
Remove `SHARED` from `pybind11_add_module` (take two) to avoid segfaults on macOS with Python statically linked with libpython

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -78,7 +78,7 @@ function(configure_build_install_location _library_name)
 endfunction()
 
 # Split from main extension and converted to pybind11
-pybind11_add_module(_rclpy_pybind11 SHARED
+pybind11_add_module(_rclpy_pybind11
   src/rclpy/_rclpy_logging.cpp
   src/rclpy/_rclpy_pybind11.cpp
   src/rclpy/action_client.cpp


### PR DESCRIPTION
This PR rebases https://github.com/ros2/rclpy/pull/1305 on top of the latest rolling. https://github.com/ros2/rclpy/pull/1305 was blocked on some kind of CI failure on Windows, I want to understand if this is still the case or not.

To give a bit more of context, removing `SHARED` from `pybind11_add_module` ensures that the built extension is compiled as `MODULE` (default setting for `pybind11_add_module`) and that can be loaded fine (i.e. without segfaults) on macOS with Python versions that statically linked libpython. `conda-forge` is an example of distribution that provides a Python version that statically links libpython for performance reasons, and other distributions are also considering switching to statically linking libpython for performance reasons (see https://github.com/astral-sh/python-build-standalone/pull/540 for example).

As already mentioned in https://github.com/ros2/rclpy/pull/1305, there should be no downside in building `_rclpy_pybind11` as `MODULE`, unless somewhere  `_rclpy_pybind11` is linked as a shared libraries via `target_link_libraries` instead of `dlopen`-ed by python, but I don't think there is any use case for which that make sense, and I could not find any such usage of `_rclpy_pybind11` in public repos.