### PR TITLE
Fix Duration, Clock, and QoS Docs

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -55,13 +55,6 @@
 
   <doc_depend>python3-sphinx</doc_depend>
   <doc_depend>python3-sphinx-rtd-theme</doc_depend>
-  <!-- We add these modules as doc_depends in order to include them into the
-  autodoc_mock_imports list. This prevents TypeErrors from being thrown
-  when these modules import constants from rclpy C modules.
-  TODO: Remove these depends once a better solution is found.-->
-  <doc_depend>rclpy.duration</doc_depend>
-  <doc_depend>rclpy.qos</doc_depend>
-  <doc_depend>rclpy.clock</doc_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Closes #1419.

Adding the following to autodock_mock_imports causes it to be blank on the documentation.

I can build it locally with sphinx and rosdoc2. I believe the addition of `_rclpy_pybind11.pyi` is what resolved previous errors with underlying c objects.

Note: `rclpy.qos_event` is supposed to be empty since it is deprecated and `rclpy.event_handlers` should be used instead.