### PR TITLE
Fix Task constructor type bug

### DIFF
--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -16,21 +16,16 @@ from enum import Enum
 import inspect
 import sys
 import threading
-from types import CoroutineType
 from typing import (Any, Callable, cast, Coroutine, Dict, Generator, Generic, List,
-                    Optional, Tuple, TYPE_CHECKING, TypeVar, Union)
+                    Optional, overload, Tuple, TYPE_CHECKING, TypeVar, Union)
 import warnings
 import weakref
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
 
     from rclpy.executors import Executor
 
 T = TypeVar('T')
-
-FunctionOrCoroutineFunction: 'TypeAlias' = Union[Callable[..., T],
-                                                 Callable[..., Coroutine[None, None, T]]]
 
 
 def _fake_weakref() -> None:
@@ -223,8 +218,22 @@ class Task(Future[T]):
     This class should only be instantiated by :class:`rclpy.executors.Executor`.
     """
 
+    @overload
     def __init__(self,
-                 handler: FunctionOrCoroutineFunction[T],
+                 handler: Callable[..., Coroutine[Any, Any, T]],
+                 args: Optional[Tuple[Any, ...]] = None,
+                 kwargs: Optional[Dict[str, Any]] = None,
+                 executor: Optional['Executor'] = None) -> None: ...
+
+    @overload
+    def __init__(self,
+                 handler: Callable[..., T],
+                 args: Optional[Tuple[Any, ...]] = None,
+                 kwargs: Optional[Dict[str, Any]] = None,
+                 executor: Optional['Executor'] = None) -> None: ...
+
+    def __init__(self,
+                 handler: Callable[..., Any],
                  args: Optional[Tuple[Any, ...]] = None,
                  kwargs: Optional[Dict[str, Any]] = None,
                  executor: Optional['Executor'] = None) -> None:
@@ -240,10 +249,10 @@ class Task(Future[T]):
         # _handler is either a normal function or a coroutine
         if inspect.iscoroutinefunction(handler):
             self._handler: Union[
-                Coroutine[None, None, T],
+                Coroutine[Any, Any, T],
                 Callable[[], T],
                 None
-             ] = handler(*args, **kwargs)
+             ] = cast(Coroutine[Any, Any, T], handler(*args, **kwargs))
             self._args = None
             self._kwargs = None
         else:
@@ -276,7 +285,7 @@ class Task(Future[T]):
 
             if inspect.iscoroutine(self._handler):
                 # Execute a coroutine
-                handler: CoroutineType[None, None, T] = self._handler
+                handler = self._handler
                 try:
                     handler.send(None)
                 except StopIteration as e:

--- a/rclpy/test/test_callback_group.py
+++ b/rclpy/test/test_callback_group.py
@@ -60,8 +60,8 @@ class TestCallbackGroup(unittest.TestCase):
             received_short_callback_in_long_callback = False
 
             # Setup two future objects that control the executor
-            future_up = Future()
-            future_down = Future()
+            future_up: Future[None] = Future()
+            future_down: Future[None] = Future()
 
             # This callback is used to check if a callback can be received while another
             # long running callback is being executed

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 import threading
 import time
+from typing import Any
 import unittest
 import warnings
 
@@ -454,7 +455,7 @@ class TestExecutor(unittest.TestCase):
         timer = self.node.create_timer(0.003, timer_callback)
 
         # Timeout
-        future = Future()
+        future: Future[Any] = Future()
         self.assertFalse(future.done())
         start = time.monotonic()
         executor.spin_until_future_complete(future=future, timeout_sec=0.1)
@@ -475,11 +476,11 @@ class TestExecutor(unittest.TestCase):
             pass
         timer = self.node.create_timer(0.003, timer_callback)
 
-        def set_future_result(future):
+        def set_future_result(future: Future[str]) -> None:
             future.set_result('finished')
 
         # Future complete timeout_sec > 0
-        future = Future()
+        future: Future[str] = Future()
         self.assertFalse(future.done())
         t = threading.Thread(target=lambda: set_future_result(future))
         t.start()
@@ -517,7 +518,7 @@ class TestExecutor(unittest.TestCase):
         timer = self.node.create_timer(0.003, timer_callback)
 
         # Do not wait timeout_sec = 0
-        future = Future()
+        future: Future[Any] = Future()
         self.assertFalse(future.done())
         executor.spin_until_future_complete(future=future, timeout_sec=0)
         self.assertFalse(future.done())
@@ -591,7 +592,7 @@ class TestExecutor(unittest.TestCase):
         self.assertIsNotNone(self.node.handle)
         executor = SingleThreadedExecutor(context=self.context)
 
-        future = Future(executor=executor)
+        future: Future[bool] = Future(executor=executor)
 
         # Setup a thread to spin_once_until_future_complete, which will spin
         # for a maximum of 10 seconds.
@@ -619,7 +620,7 @@ class TestExecutor(unittest.TestCase):
         self.assertIsNotNone(self.node.handle)
         executor = MultiThreadedExecutor(context=self.context)
 
-        future = Future(executor=executor)
+        future: Future[bool] = Future(executor=executor)
 
         # Setup a thread to spin_once_until_future_complete, which will spin
         # for a maximum of 10 seconds.
@@ -666,7 +667,7 @@ class TestExecutor(unittest.TestCase):
         timer2 = self.node.create_timer(1.5, timer2_callback, callback_group)
 
         executor.add_node(self.node)
-        future = Future(executor=executor)
+        future: Future[Any] = Future(executor=executor)
         executor.spin_until_future_complete(future, 4)
 
         assert count == 2

--- a/rclpy/test/test_qos_event.py
+++ b/rclpy/test/test_qos_event.py
@@ -148,7 +148,7 @@ class TestQoSEvent(unittest.TestCase):
 
         pub_log_msg = None
         sub_log_msg = None
-        log_msgs_future = Future()
+        log_msgs_future: Future[bool] = Future()
 
         class MockLogger:
 

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -141,7 +141,8 @@ class TestTask(unittest.TestCase):
         t = Task(func)
         t()
         self.assertTrue(t.done())
-        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)  # type: ignore[union-attr]
+        self.assertEqual('Sentinel Exception',
+                         t.exception().sentinel_value)  # type: ignore[union-attr]
         with self.assertRaises(Exception):
             t.result()
 
@@ -155,7 +156,8 @@ class TestTask(unittest.TestCase):
         t = Task(coro)
         t()
         self.assertTrue(t.done())
-        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)  # type: ignore[union-attr]
+        self.assertEqual('Sentinel Exception',
+                         t.exception().sentinel_value)  # type: ignore[union-attr]
         with self.assertRaises(Exception):
             t.result()
 

--- a/rclpy/test/test_task.py
+++ b/rclpy/test/test_task.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 import asyncio
+from typing import Any
+from typing import Callable
+from typing import List
+from typing import Tuple
 import unittest
 
 from rclpy.task import Future
@@ -22,9 +26,9 @@ from rclpy.task import Task
 class DummyExecutor:
 
     def __init__(self) -> None:
-        self.done_callbacks = []
+        self.done_callbacks: List[Tuple[Callable[..., Any], Any]] = []
 
-    def create_task(self, cb, *args):
+    def create_task(self, cb: Callable[..., Any], *args: Any) -> None:
         self.done_callbacks.append((cb, args))
 
 
@@ -32,7 +36,7 @@ class TestTask(unittest.TestCase):
 
     def test_task_normal_callable(self) -> None:
 
-        def func():
+        def func() -> str:
             return 'Sentinel Result'
 
         t = Task(func)
@@ -42,7 +46,7 @@ class TestTask(unittest.TestCase):
 
     def test_task_lambda(self) -> None:
 
-        def func():
+        def func() -> str:
             return 'Sentinel Result'
 
         t = Task(lambda: func())
@@ -54,7 +58,7 @@ class TestTask(unittest.TestCase):
         called1 = False
         called2 = False
 
-        async def coro():
+        async def coro() -> str:
             nonlocal called1
             nonlocal called2
             called1 = True
@@ -77,7 +81,7 @@ class TestTask(unittest.TestCase):
     def test_done_callback_scheduled(self) -> None:
         executor = DummyExecutor()
 
-        t = Task(lambda: None, executor=executor)
+        t = Task(lambda: None, executor=executor)  # type: ignore[call-overload]
         t.add_done_callback('Sentinel Value')
         t()
         self.assertTrue(t.done())
@@ -90,7 +94,7 @@ class TestTask(unittest.TestCase):
     def test_done_task_done_callback_scheduled(self) -> None:
         executor = DummyExecutor()
 
-        t = Task(lambda: None, executor=executor)
+        t = Task(lambda: None, executor=executor)  # type: ignore[call-overload]
         t()
         self.assertTrue(t.done())
         t.add_done_callback('Sentinel Value')
@@ -131,13 +135,13 @@ class TestTask(unittest.TestCase):
 
         def func() -> None:
             e = Exception()
-            e.sentinel_value = 'Sentinel Exception'
+            e.sentinel_value = 'Sentinel Exception'  # type: ignore[attr-defined]
             raise e
 
         t = Task(func)
         t()
         self.assertTrue(t.done())
-        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)
+        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)  # type: ignore[union-attr]
         with self.assertRaises(Exception):
             t.result()
 
@@ -145,20 +149,20 @@ class TestTask(unittest.TestCase):
 
         async def coro() -> None:
             e = Exception()
-            e.sentinel_value = 'Sentinel Exception'
+            e.sentinel_value = 'Sentinel Exception'  # type: ignore[attr-defined]
             raise e
 
         t = Task(coro)
         t()
         self.assertTrue(t.done())
-        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)
+        self.assertEqual('Sentinel Exception', t.exception().sentinel_value)  # type: ignore[union-attr]
         with self.assertRaises(Exception):
             t.result()
 
     def test_task_normal_callable_args(self) -> None:
         arg_in = 'Sentinel Arg'
 
-        def func(arg):
+        def func(arg: Any) -> Any:
             return arg
 
         t = Task(func, args=(arg_in,))
@@ -168,7 +172,7 @@ class TestTask(unittest.TestCase):
     def test_coroutine_args(self) -> None:
         arg_in = 'Sentinel Arg'
 
-        async def coro(arg):
+        async def coro(arg: Any) -> Any:
             return arg
 
         t = Task(coro, args=(arg_in,))
@@ -178,7 +182,7 @@ class TestTask(unittest.TestCase):
     def test_task_normal_callable_kwargs(self) -> None:
         arg_in = 'Sentinel Arg'
 
-        def func(kwarg=None):
+        def func(kwarg: Any = None) -> Any:
             return kwarg
 
         t = Task(func, kwargs={'kwarg': arg_in})
@@ -188,7 +192,7 @@ class TestTask(unittest.TestCase):
     def test_coroutine_kwargs(self) -> None:
         arg_in = 'Sentinel Arg'
 
-        async def coro(kwarg=None):
+        async def coro(kwarg: Any = None) -> Any:
             return kwarg
 
         t = Task(coro, kwargs={'kwarg': arg_in})
@@ -203,32 +207,32 @@ class TestTask(unittest.TestCase):
 class TestFuture(unittest.TestCase):
 
     def test_cancelled(self) -> None:
-        f = Future()
+        f: Future[Any] = Future()
         f.cancel()
         self.assertTrue(f.cancelled())
 
     def test_done(self) -> None:
-        f = Future()
+        f: Future[None] = Future()
         self.assertFalse(f.done())
         f.set_result(None)
         self.assertTrue(f.done())
 
     def test_set_result(self) -> None:
-        f = Future()
+        f: Future[str] = Future()
         f.set_result('Sentinel Result')
         self.assertEqual('Sentinel Result', f.result())
         self.assertTrue(f.done())
 
     def test_set_exception(self) -> None:
-        f = Future()
-        f.set_exception('Sentinel Exception')
+        f: Future[Any] = Future()
+        f.set_exception('Sentinel Exception')   # type: ignore[arg-type]
         self.assertEqual('Sentinel Exception', f.exception())
         self.assertTrue(f.done())
 
     def test_await(self) -> None:
-        f = Future()
+        f: Future[str] = Future()
 
-        async def coro():
+        async def coro() -> Any:
             nonlocal f
             return await f
 
@@ -241,9 +245,9 @@ class TestFuture(unittest.TestCase):
             self.assertEqual('Sentinel Result', e.value)
 
     def test_await_exception(self) -> None:
-        f = Future()
+        f: Future[Any] = Future()
 
-        async def coro():
+        async def coro() -> Any:
             nonlocal f
             return await f
 
@@ -255,33 +259,33 @@ class TestFuture(unittest.TestCase):
 
     def test_cancel_schedules_callbacks(self) -> None:
         executor = DummyExecutor()
-        f = Future(executor=executor)
+        f: Future[Any] = Future(executor=executor)  # type: ignore[arg-type]
         f.add_done_callback(lambda f: None)
         f.cancel()
         self.assertTrue(executor.done_callbacks)
 
     def test_set_result_schedules_callbacks(self) -> None:
         executor = DummyExecutor()
-        f = Future(executor=executor)
+        f: Future[str] = Future(executor=executor)  # type: ignore[arg-type]
         f.add_done_callback(lambda f: None)
         f.set_result('Anything')
         self.assertTrue(executor.done_callbacks)
 
     def test_set_exception_schedules_callbacks(self) -> None:
         executor = DummyExecutor()
-        f = Future(executor=executor)
+        f: Future[Any] = Future(executor=executor)  # type: ignore[arg-type]
         f.add_done_callback(lambda f: None)
-        f.set_exception('Anything')
+        f.set_exception(Exception('Anything'))
         self.assertTrue(executor.done_callbacks)
 
     def test_cancel_invokes_callbacks(self) -> None:
         called = False
 
-        def cb(fut):
+        def cb(fut: Future[Any]) -> None:
             nonlocal called
             called = True
 
-        f = Future()
+        f: Future[Any] = Future()
         f.add_done_callback(cb)
         f.cancel()
         assert called
@@ -289,11 +293,11 @@ class TestFuture(unittest.TestCase):
     def test_set_result_invokes_callbacks(self) -> None:
         called = False
 
-        def cb(fut):
+        def cb(fut: Future[Any]) -> None:
             nonlocal called
             called = True
 
-        f = Future()
+        f: Future[str] = Future()
         f.add_done_callback(cb)
         f.set_result('Anything')
         assert called
@@ -301,29 +305,29 @@ class TestFuture(unittest.TestCase):
     def test_set_exception_invokes_callbacks(self) -> None:
         called = False
 
-        def cb(fut):
+        def cb(fut: Future[Any]) -> None:
             nonlocal called
             called = True
 
-        f = Future()
+        f: Future[Any] = Future()
         f.add_done_callback(cb)
-        f.set_exception('Anything')
+        f.set_exception(Exception('Anything'))
         assert called
 
     def test_add_done_callback_invokes_callback(self) -> None:
         called = False
 
-        def cb(fut):
+        def cb(fut: Future[Any]) -> None:
             nonlocal called
             called = True
 
-        f = Future()
+        f: Future[str] = Future()
         f.set_result('Anything')
         f.add_done_callback(cb)
         assert called
 
     def test_set_result_on_done_future_without_exception(self) -> None:
-        f = Future()
+        f: Future[None] = Future()
         f.set_result(None)
         self.assertTrue(f.done())
         self.assertFalse(f.cancelled())
@@ -332,7 +336,7 @@ class TestFuture(unittest.TestCase):
         self.assertFalse(f.cancelled())
 
     def test_set_result_on_cancelled_future_without_exception(self) -> None:
-        f = Future()
+        f: Future[None] = Future()
         f.cancel()
         self.assertTrue(f.cancelled())
         self.assertFalse(f.done())
@@ -340,7 +344,7 @@ class TestFuture(unittest.TestCase):
         self.assertTrue(f.done())
 
     def test_set_exception_on_done_future_without_exception(self) -> None:
-        f = Future()
+        f: Future[None] = Future()
         f.set_result(None)
         self.assertIsNone(f.exception())
         f.set_exception(Exception())
@@ -348,7 +352,7 @@ class TestFuture(unittest.TestCase):
         self.assertIsNotNone(f.exception())
 
     def test_set_exception_on_cancelled_future_without_exception(self) -> None:
-        f = Future()
+        f: Future[Any] = Future()
         f.cancel()
         self.assertTrue(f.cancelled())
         self.assertIsNone(f.exception())


### PR DESCRIPTION
Uses overload of constructor instead of Union since the narrower Coroutine type was getting hidden inside the TypeVar T.

Split up from #1420 