### PR TITLE
Update Clock Types

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -58,7 +58,7 @@ from rclpy.signals import uninstall_signal_handlers
 from rclpy.task import Future
 from rclpy.utilities import get_default_context
 from rclpy.utilities import get_rmw_implementation_identifier  # noqa: F401
-from rclpy.utilities import ok  # noqa: F401 forwarding to this module
+from rclpy.utilities import ok as ok  # noqa: F401 forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
 from rclpy.utilities import try_shutdown as _try_shutdown
 

--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import IntEnum
 from types import TracebackType
-from typing import Callable, Optional, Type, TYPE_CHECKING, TypedDict, Union
+from typing import Callable, Literal, Optional, overload, Type, TYPE_CHECKING, TypedDict
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from typing_extensions import TypeAlias
@@ -27,11 +26,7 @@ from .time import Time
 from .utilities import get_default_context
 
 
-class ClockChange(IntEnum):
-    ROS_TIME_NO_CHANGE = _rclpy.ClockChange.ROS_TIME_NO_CHANGE
-    ROS_TIME_ACTIVATED = _rclpy.ClockChange.ROS_TIME_ACTIVATED
-    ROS_TIME_DEACTIVATED = _rclpy.ClockChange.ROS_TIME_DEACTIVATED
-    SYSTEM_TIME_NO_CHANGE = _rclpy.ClockChange.SYSTEM_TIME_NO_CHANGE
+ClockChange: TypeAlias = _rclpy.ClockChange
 
 
 class JumpThreshold:
@@ -146,11 +141,25 @@ class Clock:
 
     if TYPE_CHECKING:
         __clock: _rclpy.Clock
-        _clock_type: Union[ClockType, _rclpy.ClockType]
+        _clock_type: ClockType
+
+    @overload
+    def __new__(
+        cls,
+        *,
+        clock_type: Literal[ClockType.ROS_TIME]
+    ) -> 'ROSClock': ...
+
+    @overload
+    def __new__(
+        cls,
+        *,
+        clock_type: ClockType = ClockType.SYSTEM_TIME
+    ) -> 'Clock': ...
 
     def __new__(cls, *,
-                clock_type: Union[ClockType, _rclpy.ClockType] = ClockType.SYSTEM_TIME) -> 'Clock':
-        if not isinstance(clock_type, (ClockType, _rclpy.ClockType)):
+                clock_type: ClockType = ClockType.SYSTEM_TIME) -> 'Clock':
+        if not isinstance(clock_type, ClockType):
             raise TypeError('Clock type must be a ClockType enum')
         if clock_type is ClockType.ROS_TIME:
             self: 'Clock' = super().__new__(ROSClock)
@@ -161,7 +170,7 @@ class Clock:
         return self
 
     @property
-    def clock_type(self) -> Union[ClockType, _rclpy.ClockType]:
+    def clock_type(self) -> ClockType:
         return self._clock_type
 
     @property

--- a/rclpy/rclpy/clock_type.py
+++ b/rclpy/rclpy/clock_type.py
@@ -12,19 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import IntEnum
-
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from typing_extensions import TypeAlias
 
-
-class ClockType(IntEnum):
-    """
-    Enum for clock type.
-
-    This enum must match the one defined in rclpy/_rclpy_pybind11.cpp.
-    """
-
-    UNINITIALIZED = _rclpy.ClockType.UNINITIALIZED
-    ROS_TIME = _rclpy.ClockType.ROS_TIME
-    SYSTEM_TIME = _rclpy.ClockType.SYSTEM_TIME
-    STEADY_TIME = _rclpy.ClockType.STEADY_TIME
+ClockType: TypeAlias = _rclpy.ClockType

--- a/rclpy/rclpy/duration.py
+++ b/rclpy/rclpy/duration.py
@@ -22,7 +22,7 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 class Duration:
     """A period between two time points, with nanosecond precision."""
 
-    def __init__(self, *, seconds: Union[int, float] = 0, nanoseconds: int = 0):
+    def __init__(self, *, seconds: Union[int, float] = 0, nanoseconds: Union[int, float] = 0):
         """
         Create an instance of :class:`Duration`, combined from given seconds and nanoseconds.
 

--- a/rclpy/rclpy/time.py
+++ b/rclpy/rclpy/time.py
@@ -36,10 +36,10 @@ class Time:
     def __init__(
         self, *,
         seconds: Union[int, float] = 0,
-        nanoseconds: int = 0,
-        clock_type: Union[ClockType, _rclpy.ClockType] = ClockType.SYSTEM_TIME,
+        nanoseconds: Union[int, float] = 0,
+        clock_type: ClockType = ClockType.SYSTEM_TIME,
     ) -> None:
-        if not isinstance(clock_type, (ClockType, _rclpy.ClockType)):
+        if not isinstance(clock_type, ClockType):
             raise TypeError('Clock type must be a ClockType enum')
         if seconds < 0:
             raise ValueError('Seconds value must not be negative')

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -41,9 +41,9 @@ class TimerInfo:
         self, *,
         expected_call_time: int = 0,
         actual_call_time: int = 0,
-        clock_type: Union[ClockType, _rclpy.ClockType] = ClockType.SYSTEM_TIME,
+        clock_type: ClockType = ClockType.SYSTEM_TIME,
     ) -> None:
-        if not isinstance(clock_type, (ClockType, _rclpy.ClockType)):
+        if not isinstance(clock_type, ClockType):
             raise TypeError('Clock type must be a ClockType enum')
         if expected_call_time < 0 or actual_call_time < 0:
             raise ValueError('call time values must not be negative')

--- a/rclpy/test/test_clock.py
+++ b/rclpy/test/test_clock.py
@@ -14,6 +14,7 @@
 
 import threading
 import time
+from typing import Generator
 import unittest
 from unittest.mock import Mock
 
@@ -68,7 +69,7 @@ class TestClock(unittest.TestCase):
         clock = Clock()
 
         with self.assertRaises(TypeError):
-            clock = Clock(clock_type='STEADY_TIME')
+            clock = Clock(clock_type='STEADY_TIME')  # type: ignore[call-overload]
 
         clock = Clock(clock_type=ClockType.STEADY_TIME)
         assert clock.clock_type == ClockType.STEADY_TIME
@@ -218,32 +219,32 @@ class TestClock(unittest.TestCase):
 
 
 @pytest.fixture()
-def default_context():
+def default_context() -> Generator[Context, None, None]:
     rclpy.init()
     yield get_default_context()
     rclpy.shutdown()
 
 
 @pytest.fixture()
-def non_default_context():
+def non_default_context() -> Generator[Context, None, None]:
     context = Context()
     context.init()
     yield context
     context.try_shutdown()
 
 
-def test_sleep_until_mismatched_clock_type(default_context):
+def test_sleep_until_mismatched_clock_type(default_context: Context) -> None:
     clock = Clock(clock_type=ClockType.SYSTEM_TIME)
     with pytest.raises(ValueError, match='.*clock type does not match.*'):
         clock.sleep_until(Time(clock_type=ClockType.STEADY_TIME))
 
 
-def test_sleep_until_non_default_context(non_default_context):
+def test_sleep_until_non_default_context(non_default_context: Context) -> None:
     clock = Clock()
     assert clock.sleep_until(clock.now() + Duration(seconds=0.1), context=non_default_context)
 
 
-def test_sleep_for_non_default_context(non_default_context):
+def test_sleep_for_non_default_context(non_default_context: Context) -> None:
     clock = Clock()
     assert clock.sleep_for(Duration(seconds=0.1), context=non_default_context)
 
@@ -262,7 +263,7 @@ def test_sleep_for_invalid_context() -> None:
 
 @pytest.mark.parametrize(
     'clock_type', (ClockType.SYSTEM_TIME, ClockType.STEADY_TIME, ClockType.ROS_TIME))
-def test_sleep_until_basic(default_context, clock_type):
+def test_sleep_until_basic(default_context: Context, clock_type: ClockType) -> None:
     clock = Clock(clock_type=clock_type)
     sleep_duration = Duration(seconds=0.1)
     start = clock.now()
@@ -273,7 +274,7 @@ def test_sleep_until_basic(default_context, clock_type):
 
 @pytest.mark.parametrize(
     'clock_type', (ClockType.SYSTEM_TIME, ClockType.STEADY_TIME, ClockType.ROS_TIME))
-def test_sleep_for_basic(default_context, clock_type):
+def test_sleep_for_basic(default_context: Context, clock_type: ClockType) -> None:
     clock = Clock(clock_type=clock_type)
     sleep_duration = Duration(seconds=0.1)
     start = clock.now()
@@ -284,7 +285,7 @@ def test_sleep_for_basic(default_context, clock_type):
 
 @pytest.mark.parametrize(
     'clock_type', (ClockType.SYSTEM_TIME, ClockType.STEADY_TIME, ClockType.ROS_TIME))
-def test_sleep_until_time_in_past(default_context, clock_type):
+def test_sleep_until_time_in_past(default_context: Context, clock_type: ClockType) -> None:
     clock = Clock(clock_type=clock_type)
     sleep_duration = Duration(seconds=-1)
     start = clock.now()
@@ -295,7 +296,7 @@ def test_sleep_until_time_in_past(default_context, clock_type):
 
 @pytest.mark.parametrize(
     'clock_type', (ClockType.SYSTEM_TIME, ClockType.STEADY_TIME, ClockType.ROS_TIME))
-def test_sleep_for_negative_duration(default_context, clock_type):
+def test_sleep_for_negative_duration(default_context: Context, clock_type: ClockType) -> None:
     clock = Clock(clock_type=clock_type)
     sleep_duration = Duration(seconds=-1)
     start = clock.now()
@@ -305,7 +306,7 @@ def test_sleep_for_negative_duration(default_context, clock_type):
 
 
 @pytest.mark.parametrize('ros_time_enabled', (True, False))
-def test_sleep_until_ros_time_toggled(default_context, ros_time_enabled):
+def test_sleep_until_ros_time_toggled(default_context: Context, ros_time_enabled: bool) -> None:
     clock = ROSClock()
     clock._set_ros_time_is_active(not ros_time_enabled)
 
@@ -333,7 +334,7 @@ def test_sleep_until_ros_time_toggled(default_context, ros_time_enabled):
 
 
 @pytest.mark.parametrize('ros_time_enabled', (True, False))
-def test_sleep_for_ros_time_toggled(default_context, ros_time_enabled):
+def test_sleep_for_ros_time_toggled(default_context: Context, ros_time_enabled: bool) -> None:
     clock = ROSClock()
     clock._set_ros_time_is_active(not ros_time_enabled)
 
@@ -360,7 +361,7 @@ def test_sleep_for_ros_time_toggled(default_context, ros_time_enabled):
     assert retval is False
 
 
-def test_sleep_until_context_shut_down(non_default_context):
+def test_sleep_until_context_shut_down(non_default_context: Context) -> None:
     clock = Clock()
     retval = None
 
@@ -386,7 +387,7 @@ def test_sleep_until_context_shut_down(non_default_context):
     assert retval is False
 
 
-def test_sleep_for_context_shut_down(non_default_context):
+def test_sleep_for_context_shut_down(non_default_context: Context) -> None:
     clock = Clock()
     retval = None
 
@@ -411,7 +412,7 @@ def test_sleep_for_context_shut_down(non_default_context):
     assert retval is False
 
 
-def test_sleep_until_ros_time_enabled(default_context):
+def test_sleep_until_ros_time_enabled(default_context: Context) -> None:
     clock = ROSClock()
     clock._set_ros_time_is_active(True)
 
@@ -442,7 +443,7 @@ def test_sleep_until_ros_time_enabled(default_context):
     assert retval
 
 
-def test_sleep_for_ros_time_enabled(default_context):
+def test_sleep_for_ros_time_enabled(default_context: Context) -> None:
     clock = ROSClock()
     clock._set_ros_time_is_active(True)
 

--- a/rclpy/test/test_time.py
+++ b/rclpy/test/test_time.py
@@ -43,7 +43,7 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(ValueError):
             time = Time(nanoseconds=-1)
         with self.assertRaises(TypeError):
-            time = Time(clock_type='SYSTEM_TIME')
+            time = Time(clock_type='SYSTEM_TIME')  # type: ignore[arg-type]
 
     def test_duration_construction(self) -> None:
         duration = Duration()
@@ -121,9 +121,9 @@ class TestTime(unittest.TestCase):
 
         # Invalid arithmetic combinations
         with self.assertRaises(TypeError):
-            time1 + time2
+            time1 + time2  # type: ignore[operator]
         with self.assertRaises(TypeError):
-            duration - time1
+            duration - time1  # type: ignore[operator]
 
     def test_time_comparators(self) -> None:
         # Times with the same clock type

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -91,10 +91,12 @@ class TestTimeSource(unittest.TestCase):
 
         # Other clock types are not supported.
         with self.assertRaises(ValueError):
-            time_source.attach_clock(Clock(clock_type=ClockType.SYSTEM_TIME))
+            time_source.attach_clock(
+                Clock(clock_type=ClockType.SYSTEM_TIME))  # type: ignore[arg-type]
 
         with self.assertRaises(ValueError):
-            time_source.attach_clock(Clock(clock_type=ClockType.STEADY_TIME))
+            time_source.attach_clock(
+                Clock(clock_type=ClockType.STEADY_TIME))  # type: ignore[arg-type]
 
     def test_time_source_not_using_sim_time(self) -> None:
         time_source = TimeSource(node=self.node)

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -68,13 +68,13 @@ class TestTimeSource(unittest.TestCase):
             rclpy.spin_once(self.node, timeout_sec=1, executor=executor)
             time.sleep(1)
 
-    def set_use_sim_time_parameter(self, value):
+    def set_use_sim_time_parameter(self, value: bool) -> bool:
         self.node.set_parameters(
             [Parameter('use_sim_time', Parameter.Type.BOOL, value)])
         executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
         cycle_count = 0
         while rclpy.ok(context=self.context) and cycle_count < 5:
-            use_sim_time_param = self.node.get_parameter('use_sim_time')
+            use_sim_time_param: Parameter[bool] = self.node.get_parameter('use_sim_time')
             cycle_count += 1
             if use_sim_time_param.type_ == Parameter.Type.BOOL:
                 break

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -19,7 +19,7 @@ import time
 
 import pytest
 import rclpy
-from rclpy.clock import ClockType
+from rclpy.clock_type import ClockType
 from rclpy.constants import S_TO_NS
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.timer import TimerInfo

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -16,6 +16,8 @@ import functools
 import os
 import platform
 import time
+from typing import List
+from typing import Optional
 
 import pytest
 import rclpy
@@ -44,7 +46,7 @@ TEST_PERIODS = (
 
 
 @pytest.mark.parametrize('period', TEST_PERIODS)
-def test_zero_callback(period):
+def test_zero_callback(period: float) -> None:
     context = rclpy.context.Context()
     rclpy.init(context=context)
     try:
@@ -56,7 +58,7 @@ def test_zero_callback(period):
                 # The first spin_once() takes long enough for 1ms timer tests to fail
                 executor.spin_once(timeout_sec=0)
 
-                callbacks = []
+                callbacks: List[int] = []
                 timer = node.create_timer(period, lambda: callbacks.append(len(callbacks)))
                 try:
                     executor.spin_once(timeout_sec=(period / 2))
@@ -73,7 +75,7 @@ def test_zero_callback(period):
 
 
 @pytest.mark.parametrize('period', TEST_PERIODS)
-def test_number_callbacks(period):
+def test_number_callbacks(period: float) -> None:
     context = rclpy.context.Context()
     rclpy.init(context=context)
     try:
@@ -85,7 +87,7 @@ def test_number_callbacks(period):
                 # The first spin_once() takes long enough for 1ms timer tests to fail
                 executor.spin_once(timeout_sec=0)
 
-                callbacks = []
+                callbacks: List[int] = []
                 timer = node.create_timer(period, lambda: callbacks.append(len(callbacks)))
                 try:
                     begin_time = time.time()
@@ -105,7 +107,7 @@ def test_number_callbacks(period):
 
 
 @pytest.mark.parametrize('period', TEST_PERIODS)
-def test_cancel_reset(period):
+def test_cancel_reset(period: float) -> None:
     context = rclpy.context.Context()
     rclpy.init(context=context)
     try:
@@ -117,7 +119,7 @@ def test_cancel_reset(period):
                 # The first spin_once() takes long enough for 1ms timer tests to fail
                 executor.spin_once(timeout_sec=0)
 
-                callbacks = []
+                callbacks: List[int] = []
                 timer = node.create_timer(period, lambda: callbacks.append(len(callbacks)))
                 try:
                     # Make sure callbacks can be received
@@ -168,19 +170,23 @@ def test_time_until_next_call() -> None:
         timer = node.create_timer(1, lambda: None)
         assert not timer.is_canceled()
         executor.spin_once(0.1)
-        assert timer.time_until_next_call() <= (1 * S_TO_NS)
+        time_until_next_call = timer.time_until_next_call()
+        assert time_until_next_call is not None
+        assert time_until_next_call <= (1 * S_TO_NS)
         timer.reset()
         assert not timer.is_canceled()
-        assert timer.time_until_next_call() <= (1 * S_TO_NS)
+        time_until_next_call = timer.time_until_next_call()
+        assert time_until_next_call is not None
+        assert time_until_next_call <= (1 * S_TO_NS)
         timer.cancel()
         assert timer.is_canceled()
         assert timer.time_until_next_call() is None
     finally:
-        if timer is not None:
-            node.destroy_timer(timer)
         if executor is not None:
             executor.shutdown()
         if node is not None:
+            if timer is not None:
+                node.destroy_timer(timer)
             node.destroy_node()
         rclpy.shutdown(context=context)
 
@@ -200,9 +206,9 @@ def test_timer_without_autostart() -> None:
         timer.cancel()
         assert timer.is_canceled()
     finally:
-        if timer is not None:
-            node.destroy_timer(timer)
         if node is not None:
+            if timer is not None:
+                node.destroy_timer(timer)
             node.destroy_node()
         rclpy.shutdown()
 
@@ -251,7 +257,7 @@ def test_timer_with_info() -> None:
     node = None
     executor = None
     timer = None
-    timer_info: TimerInfo = None
+    timer_info: Optional[TimerInfo] = None
     context = rclpy.context.Context()
     rclpy.init(context=context)
     try:
@@ -260,7 +266,7 @@ def test_timer_with_info() -> None:
         executor.add_node(node)
         executor.spin_once(timeout_sec=0)
 
-        def timer_callback(info: TimerInfo):
+        def timer_callback(info: TimerInfo) -> None:
             nonlocal timer_info
             timer_info = info
         timer = node.create_timer(1, timer_callback)
@@ -274,11 +280,11 @@ def test_timer_with_info() -> None:
         assert timer_info.actual_call_time.nanoseconds > 0
         assert timer_info.expected_call_time.nanoseconds > 0
     finally:
-        if timer is not None:
-            node.destroy_timer(timer)
         if executor is not None:
             executor.shutdown()
         if node is not None:
+            if timer is not None:
+                node.destroy_timer(timer)
             node.destroy_node()
         rclpy.shutdown(context=context)
 
@@ -287,7 +293,7 @@ def test_timer_info_with_partial() -> None:
     node = None
     executor = None
     timer = None
-    timer_info: TimerInfo = None
+    timer_info: Optional[TimerInfo] = None
     timer_called = False
     context = rclpy.context.Context()
     rclpy.init(context=context)
@@ -297,7 +303,7 @@ def test_timer_info_with_partial() -> None:
         executor.add_node(node)
         executor.spin_once(timeout_sec=0)
 
-        def timer_callback(info: TimerInfo):
+        def timer_callback(info: TimerInfo) -> None:
             nonlocal timer_info
             timer_info = info
             nonlocal timer_called
@@ -315,10 +321,10 @@ def test_timer_info_with_partial() -> None:
         assert timer_info.actual_call_time.nanoseconds > 0
         assert timer_info.expected_call_time.nanoseconds > 0
     finally:
-        if timer is not None:
-            node.destroy_timer(timer)
         if executor is not None:
             executor.shutdown()
         if node is not None:
+            if timer is not None:
+                node.destroy_timer(timer)
             node.destroy_node()
         rclpy.shutdown(context=context)


### PR DESCRIPTION
Updates Clock constructor types. Also replaces `ClockType` being a duplicate enum to being a type alias of `_rclpy.ClockType`