### PR TITLE
Update parameter types

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -19,10 +19,12 @@ from types import TracebackType
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Final
 from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import overload
+from typing import Sequence
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -100,9 +102,10 @@ from rclpy.validate_parameter_name import validate_parameter_name
 from rclpy.validate_topic_name import validate_topic_name
 from rclpy.waitable import Waitable
 from typing_extensions import deprecated
+from typing_extensions import TypeAlias
 
 
-HIDDEN_NODE_PREFIX = '_'
+HIDDEN_NODE_PREFIX: Final = '_'
 
 # Left to support Legacy TypeVar.
 MsgType = TypeVar('MsgType')
@@ -113,7 +116,7 @@ SrvTypeResponse = TypeVar('SrvTypeResponse')
 
 # Re-export exception defined in _rclpy C extension.
 # `Node.get_*_names_and_types_by_node` methods may raise this error.
-NodeNameNonExistentError = _rclpy.NodeNameNonExistentError
+NodeNameNonExistentError: TypeAlias = _rclpy.NodeNameNonExistentError
 
 
 class Node:
@@ -439,6 +442,19 @@ class Node:
             args = (name, value, descriptor)
         return self.declare_parameters('', [args], ignore_override)[0]
 
+    ParameterInput: TypeAlias = Union[AllowableParameterValue, Parameter.Type, ParameterValue]
+
+    @overload
+    def declare_parameters(
+        self,
+        namespace: str,
+        parameters: Sequence[Union[
+            Tuple[str, ParameterInput],
+            Tuple[str, ParameterInput, ParameterDescriptor],
+        ]],
+        ignore_override: bool = False
+    ) -> List[Parameter[Any]]: ...
+
     @overload
     @deprecated('when declaring a parameter only providing its name is deprecated. '
                 'You have to either:\n'
@@ -449,23 +465,10 @@ class Node:
     def declare_parameters(
         self,
         namespace: str,
-        parameters: List[Union[
+        parameters: Sequence[Union[
             Tuple[str],
-            Tuple[str, Parameter.Type],
-            Tuple[str, Union[AllowableParameterValue, Parameter.Type, ParameterValue],
-                  ParameterDescriptor],
-        ]],
-        ignore_override: bool = False
-    ) -> List[Parameter[Any]]: ...
-
-    @overload
-    def declare_parameters(
-        self,
-        namespace: str,
-        parameters: List[Union[
-            Tuple[str, Parameter.Type],
-            Tuple[str, Union[AllowableParameterValue, Parameter.Type, ParameterValue],
-                  ParameterDescriptor],
+            Tuple[str, ParameterInput],
+            Tuple[str, ParameterInput, ParameterDescriptor],
         ]],
         ignore_override: bool = False
     ) -> List[Parameter[Any]]: ...
@@ -473,15 +476,13 @@ class Node:
     def declare_parameters(
         self,
         namespace: str,
-        parameters: Union[List[Union[
+        parameters: Union[Sequence[Union[
             Tuple[str],
-            Tuple[str, Parameter.Type],
-            Tuple[str, Union[AllowableParameterValue, Parameter.Type, ParameterValue],
-                  ParameterDescriptor]]],
-                  List[Union[
-            Tuple[str, Parameter.Type],
-            Tuple[str, Union[AllowableParameterValue, Parameter.Type, ParameterValue],
-                  ParameterDescriptor]]]],
+            Tuple[str, ParameterInput],
+            Tuple[str, ParameterInput, ParameterDescriptor]]],
+                  Sequence[Union[
+            Tuple[str, ParameterInput],
+            Tuple[str, ParameterInput, ParameterDescriptor]]]],
         ignore_override: bool = False
     ) -> List[Parameter[Any]]:
         """

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import array
 from enum import IntEnum
@@ -20,6 +21,7 @@ from typing import Dict
 from typing import Final
 from typing import Generic
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import overload
 from typing import Tuple
@@ -78,7 +80,7 @@ class Parameter(Generic[AllowableParameterValueT]):
         @classmethod
         def from_parameter_value(cls,
                                  parameter_value: AllowableParameterValue
-                                 ) -> 'Parameter.Type':
+                                 ) -> Parameter.Type:
             """
             Get a Parameter.Type from a given variable.
 
@@ -143,7 +145,7 @@ class Parameter(Generic[AllowableParameterValueT]):
             return False
 
     @classmethod
-    def from_parameter_msg(cls, param_msg: ParameterMsg) -> 'Parameter[Any]':
+    def from_parameter_msg(cls, param_msg: ParameterMsg) -> Parameter[Any]:
         value = None
         type_ = Parameter.Type(value=param_msg.value.type)
         if Parameter.Type.BOOL == type_:
@@ -167,17 +169,65 @@ class Parameter(Generic[AllowableParameterValueT]):
         return cls(param_msg.name, type_, value)
 
     @overload
-    def __init__(self, name: str, type_: Optional['Parameter.Type'] = None,
-                 value: None = None) -> None: ...
+    def __init__(self: Parameter[None], name: str) -> None: ...
 
     @overload
-    def __init__(self, name: str, type_: 'Parameter.Type',
-                 value: AllowableParameterValueT) -> None: ...
+    def __init__(self: Parameter[None], name: str, type_: Literal[Parameter.Type.NOT_SET]
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[bool], name: str, type_: Literal[Parameter.Type.BOOL]
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[int], name: str, type_: Literal[Parameter.Type.INTEGER]
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[float], name: str, type_: Literal[Parameter.Type.DOUBLE]
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[str], name: str, type_: Literal[Parameter.Type.STRING]
+                 ) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[Union[list[bytes], Tuple[bytes, ...]]],
+                 name: str,
+                 type_: Literal[Parameter.Type.BYTE_ARRAY]) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[Union[list[bool], Tuple[bool, ...]]],
+                 name: str,
+                 type_: Literal[Parameter.Type.BOOL_ARRAY]) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[Union[list[int], Tuple[int, ...], array.array[int]]],
+                 name: str,
+                 type_: Literal[Parameter.Type.INTEGER_ARRAY]) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[Union[list[float], Tuple[float, ...], array.array[float]]],
+                 name: str,
+                 type_: Literal[Parameter.Type.DOUBLE_ARRAY]) -> None: ...
+
+    @overload
+    def __init__(self: Parameter[Union[list[str], Tuple[str, ...], array.array[str]]],
+                 name: str,
+                 type_: Literal[Parameter.Type.STRING_ARRAY]) -> None: ...
 
     @overload
     def __init__(self, name: str, *, value: AllowableParameterValueT) -> None: ...
 
-    def __init__(self, name: str, type_: Optional['Parameter.Type'] = None, value=None) -> None:
+    @overload
+    def __init__(self, name: str, type_: Optional[Parameter.Type] = None,
+                 value: None = None) -> None: ...
+
+    @overload
+    def __init__(self, name: str, type_: Parameter.Type,
+                 value: AllowableParameterValueT) -> None: ...
+
+    def __init__(self, name: str, type_: Optional[Parameter.Type] = None, value=None) -> None:
         if type_ is None:
             # This will raise a TypeError if it is not possible to get a type from the value.
             type_ = Parameter.Type.from_parameter_value(value)

--- a/rclpy/test/test_events_executor.py
+++ b/rclpy/test/test_events_executor.py
@@ -24,6 +24,7 @@ import rclpy.event_handler
 import rclpy.executors
 import rclpy.experimental
 import rclpy.node
+import rclpy.parameter
 import rclpy.qos
 import rclpy.time
 import rclpy.timer
@@ -183,7 +184,7 @@ class TimerTestNode(rclpy.node.Node):
     def __init__(
         self,
         index: int = 0,
-        parameter_overrides: typing.Optional[list[rclpy.Parameter]] = None,
+        parameter_overrides: typing.Optional[list[rclpy.parameter.Parameter[bool]]] = None,
     ) -> None:
         super().__init__(f'test_timer{index}', parameter_overrides=parameter_overrides)
         self._timer_events = 0
@@ -233,7 +234,7 @@ class ActionServerTestNode(rclpy.node.Node):
     def __init__(self) -> None:
         super().__init__(
             'test_action_server_node',
-            parameter_overrides=[rclpy.Parameter('use_sim_time', value=True)],
+            parameter_overrides=[rclpy.parameter.Parameter('use_sim_time', value=True)],
         )
         self._got_goal_future: typing.Optional[rclpy.Future[test_msgs.action.Fibonacci.Goal]] = (
             None
@@ -565,7 +566,7 @@ class TestEventsExecutor(unittest.TestCase):
     def test_timers(self) -> None:
         realtime_node = TimerTestNode(index=0)
         rostime_node = TimerTestNode(
-            index=1, parameter_overrides=[rclpy.Parameter('use_sim_time', value=True)]
+            index=1, parameter_overrides=[rclpy.parameter.Parameter('use_sim_time', value=True)]
         )
         clock_node = ClockPublisherNode()
         for node in [realtime_node, rostime_node, clock_node]:

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -15,7 +15,11 @@
 import pathlib
 import platform
 import time
+from typing import Any
 from typing import List
+from typing import Tuple
+from typing import TYPE_CHECKING
+from typing import Union
 import unittest
 from unittest.mock import Mock
 import warnings
@@ -32,6 +36,7 @@ from rcl_interfaces.msg import SetParametersResult
 from rcl_interfaces.srv import GetParameters
 import rclpy
 from rclpy.clock_type import ClockType
+import rclpy.context
 from rclpy.duration import Duration
 from rclpy.exceptions import InvalidParameterException
 from rclpy.exceptions import InvalidParameterTypeException
@@ -63,13 +68,16 @@ TEST_RESOURCES_DIR = pathlib.Path(__file__).resolve().parent / 'resources' / 'te
 
 class TestNodeAllowUndeclaredParameters(unittest.TestCase):
 
+    if TYPE_CHECKING:
+        context: rclpy.context.Context
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.context = rclpy.context.Context()
         rclpy.init(context=cls.context)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         rclpy.shutdown(context=cls.context)
 
     def setUp(self) -> None:
@@ -83,7 +91,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
     def test_accessors(self) -> None:
         self.assertIsNotNone(self.node.handle)
         with self.assertRaises(AttributeError):
-            self.node.handle = 'garbage'
+            self.node.handle = 'garbage'  # type: ignore[assignment]
         self.assertEqual(self.node.get_name(), TEST_NODE)
         self.assertEqual(self.node.get_namespace(), TEST_NAMESPACE)
         self.assertEqual(self.node.get_clock().clock_type, ClockType.ROS_TIME)
@@ -100,7 +108,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'must be greater than or equal to zero'):
             self.node.create_publisher(BasicTypes, 'chatter', -1)
         with self.assertRaisesRegex(TypeError, 'Expected QoSProfile or int'):
-            self.node.create_publisher(BasicTypes, 'chatter', 'foo')
+            self.node.create_publisher(BasicTypes, 'chatter', 'foo')  # type: ignore[arg-type]
 
     def test_create_subscription(self) -> None:
         self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 1)
@@ -115,7 +123,10 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'must be greater than or equal to zero'):
             self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), -1)
         with self.assertRaisesRegex(TypeError, 'Expected QoSProfile or int'):
-            self.node.create_subscription(BasicTypes, 'chatter', lambda msg: print(msg), 'foo')
+            self.node.create_subscription(BasicTypes,
+                                          'chatter',
+                                          lambda msg: print(msg),
+                                          'foo')  # type: ignore[arg-type]
 
     def raw_subscription_callback(self, msg):
         print('Raw subscription callback: %s length %d' % (msg, len(msg)))
@@ -389,7 +400,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
         node_logger.set_level(rclpy.logging.LoggingSeverity.INFO)
         node_logger.debug('test')
 
-    def modify_parameter_callback(self, parameters_list: List[Parameter]):
+    def modify_parameter_callback(self, parameters_list: List[Parameter[Any]]):
         modified_list = parameters_list.copy()
         for param in parameters_list:
             if param.name == 'foo':
@@ -437,7 +448,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
 
     def test_node_cannot_set_invalid_parameters(self) -> None:
         with self.assertRaises(TypeError):
-            self.node.set_parameters([42])
+            self.node.set_parameters([42])  # type: ignore[list-item]
 
     def test_node_set_parameters_atomically(self) -> None:
         result = self.node.set_parameters_atomically([
@@ -552,6 +563,9 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
 
 class TestExecutor(unittest.TestCase):
 
+    if TYPE_CHECKING:
+        context: rclpy.context.Context
+
     @classmethod
     def setUpClass(cls):
         cls.context = rclpy.context.Context()
@@ -599,6 +613,9 @@ class TestExecutor(unittest.TestCase):
 
 
 class TestNode(unittest.TestCase):
+
+    if TYPE_CHECKING:
+        context: rclpy.context.Context
 
     @classmethod
     def setUpClass(cls):
@@ -722,7 +739,7 @@ class TestNode(unittest.TestCase):
             self.node.declare_parameter(
                 1,
                 'wrong_name_type',
-                ParameterDescriptor())
+                ParameterDescriptor())  # type: ignore[call-overload]
 
         with self.assertRaises(ValueError):
             self.node.declare_parameter(
@@ -999,7 +1016,7 @@ class TestNode(unittest.TestCase):
         self.assertEqual(result.value, 153)
 
     def test_node_get_parameters_by_prefix(self) -> None:
-        parameters = [
+        parameter_tuples: List[Tuple[str, Union[int, str, float]]] = [
             ('foo_prefix.foo', 43),
             ('foo_prefix.bar', 'hello'),
             ('foo_prefix.baz', 2.41),
@@ -1007,7 +1024,7 @@ class TestNode(unittest.TestCase):
             ('bar_prefix.bar', 12.3),
             ('bar_prefix.baz', 'world'),
         ]
-        self.node.declare_parameters('', parameters)
+        self.node.declare_parameters('', parameter_tuples)
 
         parameters = self.node.get_parameters_by_prefix('foo_prefix')
         self.assertIsInstance(parameters, dict)
@@ -1078,7 +1095,7 @@ class TestNode(unittest.TestCase):
         ]
 
         # Create rclpy.Parameter list from tuples.
-        parameters = [
+        parameters: List[Parameter[Any]] = [
             Parameter(
                 name=parameter_tuples[0][0],
                 value=integer_value
@@ -1240,7 +1257,7 @@ class TestNode(unittest.TestCase):
         self.assertTrue(result[2].successful)
 
     def test_node_list_parameters(self) -> None:
-        parameters = [
+        parameters: List[Tuple[str, Union[int, str, float]]] = [
             ('foo_prefix.foo', 43),
             ('foo_prefix.bar', 'hello'),
             ('foo_prefix.baz', 2.41),
@@ -1379,15 +1396,16 @@ class TestNode(unittest.TestCase):
         )
 
         with self.assertRaises(TypeError):
-            self.node.list_parameters(prefixes='foo', depth=0)
+            self.node.list_parameters(prefixes='foo', depth=0)  # type: ignore[arg-type]
 
         with self.assertRaises(ValueError):
             self.node.list_parameters(prefixes=[], depth=-1)
 
         with self.assertRaises(TypeError):
-            self.node.list_parameters(prefixes=[], depth=1.5)
+            self.node.list_parameters(prefixes=[], depth=1.5)  # type: ignore[arg-type]
 
-    def modify_parameter_callback(self, parameter_list: List[Parameter]):
+    def modify_parameter_callback(self, parameter_list: List[Parameter[Any]]
+                                  ) -> List[Parameter[Any]]:
         modified_list = parameter_list.copy()
         for param in parameter_list:
             if param.name == 'foo':
@@ -1395,7 +1413,7 @@ class TestNode(unittest.TestCase):
 
         return modified_list
 
-    def empty_parameter_callback(self, parameter_list: List[Parameter]):
+    def empty_parameter_callback(self, parameter_list: List[Parameter[Any]]):
         return []
 
     def test_add_remove_pre_set_parameter_callback(self) -> None:
@@ -1532,7 +1550,7 @@ class TestNode(unittest.TestCase):
         self.assertTrue(result[0].successful)
 
     def test_add_remove_post_set_parameter_callback(self) -> None:
-        def successful_parameter_set_callback(parameter_list: List[Parameter]):
+        def successful_parameter_set_callback(parameter_list: List[Parameter[Any]]) -> None:
             for param in parameter_list:
                 if param.name == 'param1':
                     self.track_value1 = param.value
@@ -1567,8 +1585,8 @@ class TestNode(unittest.TestCase):
         self.assertTrue(self.node.has_parameter('param2'))
         self.assertEqual(self.node.get_parameter('param1').value, 1.0)
         self.assertEqual(self.node.get_parameter('param2').value, 2.0)
-        self.assertTrue(self.track_value1 == 1.0)
-        self.assertTrue(self.track_value2 == 2.0)
+        self.assertTrue(self.track_value1 == 1.0)  # type: ignore[comparison-overlap]
+        self.assertTrue(self.track_value2 == 2.0)  # type: ignore[comparison-overlap]
 
     def test_node_set_parameters_read_only(self) -> None:
         integer_value = 42
@@ -1593,7 +1611,7 @@ class TestNode(unittest.TestCase):
         ]
 
         # Create rclpy.Parameter list from tuples.
-        parameters = [
+        parameters: List[Parameter[Any]] = [
             Parameter(
                 name=parameter_tuples[0][0],
                 value=integer_value
@@ -1728,7 +1746,7 @@ class TestNode(unittest.TestCase):
         ]
 
         # Create rclpy.Parameter list from tuples.
-        parameters = [
+        parameters: List[Parameter[Any]] = [
             Parameter(
                 name=parameter_tuples[0][0],
                 value=integer_value
@@ -1871,7 +1889,7 @@ class TestNode(unittest.TestCase):
         ]
 
         # Create rclpy.Parameter list from tuples.
-        parameters = [
+        parameters: List[Parameter[Any]] = [
             Parameter(
                 name=parameter_tuples[0][0],
                 value=integer_value
@@ -2147,19 +2165,19 @@ class TestNode(unittest.TestCase):
             ('int_value', 123, ParameterDescriptor(floating_point_range=[fp_range]))
         ]
 
-        result = self.node.declare_parameters('', parameters)
+        declared_parameters_result = self.node.declare_parameters('', parameters)
 
-        self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], Parameter)
-        self.assertIsInstance(result[1], Parameter)
-        self.assertIsInstance(result[2], Parameter)
-        self.assertIsInstance(result[3], Parameter)
-        self.assertIsInstance(result[4], Parameter)
-        self.assertAlmostEqual(result[0].value, 0.0)
-        self.assertAlmostEqual(result[1].value, 10.0)
-        self.assertAlmostEqual(result[2].value, 4.5)
-        self.assertEqual(result[3].value, 'I am no float')
-        self.assertEqual(result[4].value, 123)
+        self.assertIsInstance(declared_parameters_result, list)
+        self.assertIsInstance(declared_parameters_result[0], Parameter)
+        self.assertIsInstance(declared_parameters_result[1], Parameter)
+        self.assertIsInstance(declared_parameters_result[2], Parameter)
+        self.assertIsInstance(declared_parameters_result[3], Parameter)
+        self.assertIsInstance(declared_parameters_result[4], Parameter)
+        self.assertAlmostEqual(declared_parameters_result[0].value, 0.0)
+        self.assertAlmostEqual(declared_parameters_result[1].value, 10.0)
+        self.assertAlmostEqual(declared_parameters_result[2].value, 4.5)
+        self.assertEqual(declared_parameters_result[3].value, 'I am no float')
+        self.assertEqual(declared_parameters_result[4].value, 123)
         self.assertEqual(self.node.get_parameter('from_value').value, 0.0)
         self.assertEqual(self.node.get_parameter('to_value').value, 10.0)
         self.assertEqual(self.node.get_parameter('in_range').value, 4.5)
@@ -2229,19 +2247,19 @@ class TestNode(unittest.TestCase):
             ('float_value', 123.0, ParameterDescriptor(integer_range=[integer_range]))
         ]
 
-        result = self.node.declare_parameters('', parameters)
+        declared_parameters = self.node.declare_parameters('', parameters)
 
-        self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], Parameter)
-        self.assertIsInstance(result[1], Parameter)
-        self.assertIsInstance(result[2], Parameter)
-        self.assertIsInstance(result[3], Parameter)
-        self.assertIsInstance(result[4], Parameter)
-        self.assertEqual(result[0].value, 0)
-        self.assertEqual(result[1].value, 10)
-        self.assertEqual(result[2].value, 4)
-        self.assertEqual(result[3].value, 'I am no integer')
-        self.assertAlmostEqual(result[4].value, 123.0)
+        self.assertIsInstance(declared_parameters, list)
+        self.assertIsInstance(declared_parameters[0], Parameter)
+        self.assertIsInstance(declared_parameters[1], Parameter)
+        self.assertIsInstance(declared_parameters[2], Parameter)
+        self.assertIsInstance(declared_parameters[3], Parameter)
+        self.assertIsInstance(declared_parameters[4], Parameter)
+        self.assertEqual(declared_parameters[0].value, 0)
+        self.assertEqual(declared_parameters[1].value, 10)
+        self.assertEqual(declared_parameters[2].value, 4)
+        self.assertEqual(declared_parameters[3].value, 'I am no integer')
+        self.assertAlmostEqual(declared_parameters[4].value, 123.0)
         self.assertEqual(self.node.get_parameter('from_value').value, 0)
         self.assertEqual(self.node.get_parameter('to_value').value, 10)
         self.assertEqual(self.node.get_parameter('in_range').value, 4)
@@ -2306,7 +2324,7 @@ class TestNode(unittest.TestCase):
             ('int_param_no_default', Parameter.Type.INTEGER),
             ('dynamic_param', None, ParameterDescriptor(dynamic_typing=True)),
         ]
-        result = self.node.declare_parameters('', parameters)
+        self.node.declare_parameters('', parameters)
 
         # Try getting parameters before setting values
         int_param = self.node.get_parameter('int_param')

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -114,13 +114,13 @@ class TestParameter(unittest.TestCase):
         p = Parameter('myparam', Parameter.Type.NOT_SET)
         self.assertIsNone(p.value)
 
-        p = Parameter('myparam')
-        self.assertIsNone(p.value)
-        self.assertEqual(p.type_, Parameter.Type.NOT_SET)
+        p1 = Parameter('myparam')
+        self.assertIsNone(p1.value)
+        self.assertEqual(p1.type_, Parameter.Type.NOT_SET)
 
-        p = Parameter('myparam', value=None)
-        self.assertIsNone(p.value)
-        self.assertEqual(p.type_, Parameter.Type.NOT_SET)
+        p2 = Parameter('myparam', value=None)
+        self.assertIsNone(p2.value)
+        self.assertEqual(p2.type_, Parameter.Type.NOT_SET)
 
     def test_value_and_type_must_agree(self) -> None:
         with self.assertRaises(ValueError):
@@ -130,10 +130,10 @@ class TestParameter(unittest.TestCase):
 
     def test_error_on_illegal_value_type(self) -> None:
         with self.assertRaises(TypeError):
-            Parameter('illegaltype', 'mytype', 'myvalue')
+            Parameter('illegaltype', 'mytype', 'myvalue')  # type: ignore[call-overload]
 
         with self.assertRaises(TypeError):
-            Parameter('illegaltype', value={'invalid': 'type'})
+            Parameter('illegaltype', value={'invalid': 'type'})  # type: ignore[call-overload]
 
     def test_integer_tuple_array(self) -> None:
         # list
@@ -246,7 +246,7 @@ class TestParameter(unittest.TestCase):
 
         for input_value, expected_value in test_cases:
             result_value = parameter_value_to_python(input_value)
-            if isinstance(expected_value, list):
+            if isinstance(result_value, list) and isinstance(expected_value, list):
                 assert len(result_value) == len(expected_value)
                 # element-wise comparison for lists
                 assert all(x == y for x, y in zip(result_value, expected_value))

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -114,13 +114,13 @@ class TestParameter(unittest.TestCase):
         p = Parameter('myparam', Parameter.Type.NOT_SET)
         self.assertIsNone(p.value)
 
-        p1 = Parameter('myparam')
-        self.assertIsNone(p1.value)
-        self.assertEqual(p1.type_, Parameter.Type.NOT_SET)
+        p = Parameter('myparam')
+        self.assertIsNone(p.value)
+        self.assertEqual(p.type_, Parameter.Type.NOT_SET)
 
-        p2 = Parameter('myparam', value=None)
-        self.assertIsNone(p2.value)
-        self.assertEqual(p2.type_, Parameter.Type.NOT_SET)
+        p = Parameter('myparam', value=None)
+        self.assertIsNone(p.value)
+        self.assertEqual(p.type_, Parameter.Type.NOT_SET)
 
     def test_value_and_type_must_agree(self) -> None:
         with self.assertRaises(ValueError):

--- a/rclpy/test/test_parameter_event_handler.py
+++ b/rclpy/test/test_parameter_event_handler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
 from typing import Union
 import unittest
 
@@ -32,7 +33,7 @@ from rclpy.qos import qos_profile_parameter_events
 
 class ParameterEventHandlerTester(ParameterEventHandler):
 
-    def test_event(self, parameter_event: ParameterEvent):
+    def test_event(self, parameter_event: ParameterEvent) -> None:
         self._callbacks.event_callback(parameter_event)
 
 
@@ -41,7 +42,7 @@ class CallbackChecker:
     def __init__(self) -> None:
         self.received = False
 
-    def callback(self, _: Union[Parameter, ParameterEvent]):
+    def callback(self, _: Union[Parameter[Any], ParameterEvent]) -> None:
         self.received = True
 
 
@@ -52,11 +53,11 @@ class CallCounter:
         self.first_callback_call_order = 0
         self.second_callback_call_order = 0
 
-    def first_callback(self, _: Union[Parameter, ParameterEvent]):
+    def first_callback(self, _: Union[Parameter[Any], ParameterEvent]) -> None:
         self.counter += 1
         self.first_callback_call_order = self.counter
 
-    def second_callback(self, _: Union[Parameter, ParameterEvent]):
+    def second_callback(self, _: Union[Parameter[Any], ParameterEvent]) -> None:
         self.counter += 1
         self.second_callback_call_order = self.counter
 
@@ -102,7 +103,7 @@ class TestParameterEventHandler(unittest.TestCase):
 
         # Callback is not called in this test anyway
         handle = self.parameter_event_handler.add_parameter_callback(
-            parameter_name, node_name, lambda: None
+            parameter_name, node_name, lambda _: None
         )
 
         assert isinstance(handle, ParameterCallbackHandle)

--- a/rclpy/test/test_parameter_service.py
+++ b/rclpy/test/test_parameter_service.py
@@ -18,6 +18,7 @@ from rcl_interfaces.msg import ParameterType
 from rcl_interfaces.srv import DescribeParameters
 from rcl_interfaces.srv import GetParameters
 import rclpy
+from rclpy.client import Client
 import rclpy.context
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.parameter import Parameter
@@ -34,15 +35,18 @@ class TestParameterService(unittest.TestCase):
             namespace='/rclpy',
             context=self.context)
 
-        self.get_parameter_client = self.test_node.create_client(
+        self.get_parameter_client: Client[GetParameters.Request,
+                                          GetParameters.Response] = self.test_node.create_client(
             GetParameters, '/rclpy/test_parameter_service/get_parameters',
             qos_profile=qos_profile_services_default
         )
 
-        self.describe_parameters_client = self.test_node.create_client(
-            DescribeParameters, '/rclpy/test_parameter_service/describe_parameters',
-            qos_profile=qos_profile_services_default
-        )
+        self.describe_parameters_client: Client[DescribeParameters.Response,
+                                                DescribeParameters.Response] = \
+            self.test_node.create_client(
+                DescribeParameters,
+                '/rclpy/test_parameter_service/describe_parameters',
+                qos_profile=qos_profile_services_default)
 
         self.executor = SingleThreadedExecutor(context=self.context)
         self.executor.add_node(self.test_node)


### PR DESCRIPTION
Updates `Parameter` Constructor to use `Parameter.Type` Enum to infer type of `Parameter`. Updated `declare_parameters` to use `Sequence` since it's TypeVar is [covariant](https://mypy.readthedocs.io/en/stable/generics.html#variance-of-generic-types) which is needed.