### PR TITLE
[rclpy] Fix spin_once() removing node from executor even if already attached

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -296,11 +296,14 @@ def spin_once(
     :param timeout_sec: Seconds to wait. Block forever if ``None`` or negative. Don't wait if 0.
     """
     executor = get_global_executor() if executor is None else executor
+    node_was_added = False
     try:
-        executor.add_node(node)
+
+        node_was_added = executor.add_node(node)
         executor.spin_once(timeout_sec=timeout_sec)
     finally:
-        executor.remove_node(node)
+        if node_was_added:
+            executor.remove_node(node)
 
 
 def spin(node: 'Node', executor: Optional['Executor'] = None) -> None:


### PR DESCRIPTION
## Summary

This pull request fixes a bug where `rclpy.spin_once()` would remove a node from its executor that it didn't add.

Previously, `spin_once()` unconditionally called `executor.remove_node(node)` at the end, disconnecting nodes managed by user-created executors (e.g., `MultiThreadedExecutor`).

This fix tracks whether `spin_once()` itself added the node, and only removes it if necessary — matching the behavior already used in `spin_until_future_complete()`.

---

## Motivation

Calling `rclpy.spin_once()` on a node that is part of an existing executor (e.g., for asynchronous callbacks) currently breaks the executor's management, causing nodes to silently stop working.

This fix ensures better safety and makes `rclpy` utilities more consistent.

---

## Related Issue

It handles a similar issue like #1316 

---

  