### PR TITLE
ROS Kilted - make deprecated decorator a no-op on Debian bookworm

### DIFF
--- a/rclpy/rclpy/event_handler.py
+++ b/rclpy/rclpy/event_handler.py
@@ -31,7 +31,14 @@ from rclpy.logging import get_logger
 from rclpy.qos import qos_policy_name_from_kind
 from rclpy.waitable import NumberOfEntities
 from rclpy.waitable import Waitable
-from typing_extensions import deprecated
+
+try:
+    from typing_extensions import deprecated
+except ImportError:
+    # Compatibility with Debian Bookworm
+    def deprecated(func):
+        return func
+
 from typing_extensions import TypeAlias
 
 

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -31,7 +31,15 @@ from typing import Union
 from rclpy.clock import Clock
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.impl.logging_severity import LoggingSeverity
-from typing_extensions import deprecated, Unpack
+from typing_extensions import Unpack
+
+
+try:
+    from typing_extensions import deprecated
+except ImportError:
+    # Compatibility with Debian Bookworm
+    def deprecated(func):
+        return func
 
 
 SupportedFiltersKeys = Literal['throttle', 'skip_first', 'once']

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -101,7 +101,14 @@ from rclpy.validate_node_name import validate_node_name
 from rclpy.validate_parameter_name import validate_parameter_name
 from rclpy.validate_topic_name import validate_topic_name
 from rclpy.waitable import Waitable
-from typing_extensions import deprecated
+
+try:
+    from typing_extensions import deprecated
+except ImportError:
+    # Compatibility with Debian Bookworm
+    def deprecated(func):
+        return func
+
 from typing_extensions import TypeAlias
 
 


### PR DESCRIPTION
This is a ROS Kilted specific patch to fix compatibility with Debian Bookworm - a [Tier 3 platform for kilted](https://www.ros.org/reps/rep-2000.html#kilted-kaiju-may-2025-november-2026) that has [`python3-typing-extensions` version 4.4.0](https://packages.debian.org/bookworm/python3-typing-extensions).

The patch works by trying to import the deprecated decorator, and if that fails it makes a no-op decorator called `deprecated`. That means Debian Bookworm users won't get the deprecation warning, but as a Tier 3 platform I think that's fine.