### PR TITLE
Make no-op deprecated decorator ignore arguments

### DIFF
--- a/rclpy/rclpy/event_handler.py
+++ b/rclpy/rclpy/event_handler.py
@@ -36,8 +36,10 @@ try:
     from typing_extensions import deprecated
 except ImportError:
     # Compatibility with Debian Bookworm
-    def deprecated(func):
-        return func
+    def deprecated(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
 
 from typing_extensions import TypeAlias
 

--- a/rclpy/rclpy/impl/rcutils_logger.py
+++ b/rclpy/rclpy/impl/rcutils_logger.py
@@ -38,8 +38,10 @@ try:
     from typing_extensions import deprecated
 except ImportError:
     # Compatibility with Debian Bookworm
-    def deprecated(func):
-        return func
+    def deprecated(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
 
 
 SupportedFiltersKeys = Literal['throttle', 'skip_first', 'once']

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -106,8 +106,10 @@ try:
     from typing_extensions import deprecated
 except ImportError:
     # Compatibility with Debian Bookworm
-    def deprecated(func):
-        return func
+    def deprecated(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
 
 from typing_extensions import TypeAlias
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Debian Bookworm has an old version of `python3-typing-extensions` that does not include the `deprecated` decorator. #1458 added a no-op decorator for this use case, but I got the syntax wrong. A decorator that accepts args it not itself a decorator. It must instead return a decorator. This PR fixes that.

https://github.com/ros2/rclpy/pull/1458#issuecomment-2912634594

### Is this user-facing behavior change?
Only on Debian bookworm
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
no
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

I tested this by inserting `raise ImportError` in the blocks and making sure the `rclpy` tests still passed on Ubuntu.