### PR TITLE
add `MessageInfo.publisher_gid`

### DIFF
--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -30,6 +30,7 @@ class MessageInfo(TypedDict):
     received_timestamp: int
     publication_sequence_number: Optional[int]
     reception_sequence_number: Optional[int]
+    publisher_gid: Optional[dict]
 
 
 # Left to support Legacy TypeVars.

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -139,12 +139,25 @@ Subscription::take_message(py::object pymsg_type, bool raw)
   if (message_info.reception_sequence_number != RMW_MESSAGE_INFO_SEQUENCE_NUMBER_UNSUPPORTED) {
     rec_seq_number = py::int_(message_info.reception_sequence_number);
   }
+
+  // Convert publisher_gid to Python dict with implementation_identifier and data
+  py::object publisher_gid = py::none();
+  if (message_info.publisher_gid.implementation_identifier != nullptr) {
+    publisher_gid = py::dict(
+      "implementation_identifier"_a = py::str(message_info.publisher_gid.implementation_identifier),
+      "data"_a = py::bytes(
+        reinterpret_cast<const char *>(message_info.publisher_gid.data),
+        RMW_GID_STORAGE_SIZE)
+    );
+  }
+
   return py::make_tuple(
     pytaken_msg, py::dict(
       "source_timestamp"_a = message_info.source_timestamp,
       "received_timestamp"_a = message_info.received_timestamp,
       "publication_sequence_number"_a = pub_seq_number,
-      "reception_sequence_number"_a = rec_seq_number));
+      "reception_sequence_number"_a = rec_seq_number,
+      "publisher_gid"_a = publisher_gid));
 }
 
 const char *

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -179,6 +179,12 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             if result is not None:
                 msg, info = result
                 self.assertNotEqual(0, info['source_timestamp'])
+                self.assertIn('data', info['publisher_gid'])
+                self.assertIsInstance(info['publisher_gid']['data'], (bytes, bytearray))
+                self.assertGreater(len(info['publisher_gid']['data']), 0)
+                self.assertEqual(
+                    get_rmw_implementation_identifier(),
+                    info['publisher_gid']['implementation_identifier'])
                 return
             else:
                 time.sleep(0.2)


### PR DESCRIPTION
## Description

Fixes https://github.com/ros2/rclpy/issues/1465

### Is this user-facing behavior change?

No, this PR just adds additional field to `MessageInfo` from rmw implementation.

### Did you use Generative AI?

No

### Additional Information

N.A