### PR TITLE
Fix issue with MultiThreadedExecutor by adding lock to protect _futures

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -990,6 +990,7 @@ class MultiThreadedExecutor(Executor):
                 'Use the SingleThreadedExecutor instead.')
         self._futures: List[Future[Any]] = []
         self._executor = ThreadPoolExecutor(num_threads)
+        self._futures_lock = Lock()
 
     def _spin_once_impl(
         self,
@@ -1010,12 +1011,11 @@ class MultiThreadedExecutor(Executor):
         else:
             self._executor.submit(handler)
             self._futures.append(handler)
-            # make a copy of the list that we iterate over while modifying it
-            # (https://stackoverflow.com/q/1207406/3753684)
-            for future in self._futures[:]:
-                if future.done():
-                    self._futures.remove(future)
-                    future.result()  # raise any exceptions
+            with self._futures_lock:
+                for future in self._futures:
+                    if future.done():
+                        self._futures.remove(future)
+                        future.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         self._spin_once_impl(timeout_sec)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

The MultiThreadedExecutor contains a possible race condition. If _spin_once_impl is called more than once, it is possible that multiple threads may end up passing the condition on line 1008 and try to remove the same future on line 1009.

This solution proposes locking self._futures. This also has the benefit of removing the need to make a shallow copy of self._futures (#1129). 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Replaces #1129
Fixes #1393

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
An alternative solution might involve placing a lock to prevent multiple threads from entering _spin_once_impl.