### PR TITLE
EventsExecutor: Handle async callbacks for services and subscriptions

### DIFF
--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -300,9 +300,6 @@ void EventsExecutor::HandleRemovedSubscription(py::handle subscription)
 
 void EventsExecutor::HandleSubscriptionReady(py::handle subscription, size_t number_of_events)
 {
-  if (stop_after_user_callback_) {
-    events_queue_.Stop();
-  }
   py::gil_scoped_acquire gil_acquire;
 
   // Largely based on rclpy.Executor._take_subscription() and _execute_subcription().
@@ -326,15 +323,25 @@ void EventsExecutor::HandleSubscriptionReady(py::handle subscription, size_t num
   for (size_t i = 0; number_of_events ? i < number_of_events : !got_none; ++i) {
     py::object msg_info = _rclpy_sub.take_message(msg_type, raw);
     if (!msg_info.is_none()) {
+      py::object result;
       try {
         if (callback_type == message_only) {
-          callback(py::cast<py::tuple>(msg_info)[0]);
+          result = callback(py::cast<py::tuple>(msg_info)[0]);
         } else {
-          callback(msg_info);
+          result = callback(msg_info);
         }
       } catch (const py::error_already_set & e) {
         HandleCallbackExceptionInNodeEntity(e, subscription, "subscriptions");
         throw;
+      }
+
+      // The type markup claims the callback can't be a coroutine, but this seems to be a lie
+      // because the stock executor handles it just fine.
+      if (py::cast<bool>(inspect_iscoroutine_(result))) {
+        // Create a Task to manage iteration of this coroutine later.
+        create_task(result);
+      } else if (stop_after_user_callback_) {
+        events_queue_.Stop();
       }
     } else {
       got_none = true;
@@ -489,9 +496,6 @@ void EventsExecutor::HandleRemovedService(py::handle service)
 
 void EventsExecutor::HandleServiceReady(py::handle service, size_t number_of_events)
 {
-  if (stop_after_user_callback_) {
-    events_queue_.Stop();
-  }
   py::gil_scoped_acquire gil_acquire;
 
   // Largely based on rclpy.Executor._take_service() and _execute_service().
@@ -506,7 +510,7 @@ void EventsExecutor::HandleServiceReady(py::handle service, size_t number_of_eve
   for (size_t i = 0; i < number_of_events; ++i) {
     py::tuple request_and_header = _rclpy_service.service_take_request(req_type);
     py::handle request = request_and_header[0];
-    py::handle header = request_and_header[1];
+    py::object header = request_and_header[1];
     if (!request.is_none()) {
       py::object response;
       try {
@@ -515,7 +519,21 @@ void EventsExecutor::HandleServiceReady(py::handle service, size_t number_of_eve
         HandleCallbackExceptionInNodeEntity(e, service, "services");
         throw;
       }
-      send_response(response, header);
+
+      // The type markup claims the callback can't be a coroutine, but this seems to be a lie
+      // because the stock executor handles it just fine.
+      if (py::cast<bool>(inspect_iscoroutine_(response))) {
+        // Create a Task to manage iteration of this coroutine later.
+        create_task(response).attr("add_done_callback")(
+          py::cpp_function([send_response, header](py::object future) {
+            send_response(future.attr("result")(), header);
+          }));
+      } else {
+        send_response(response, header);
+        if (stop_after_user_callback_) {
+          events_queue_.Stop();
+        }
+      }
     }
   }
 

--- a/rclpy/test/test_events_executor.py
+++ b/rclpy/test/test_events_executor.py
@@ -48,7 +48,7 @@ def _get_pub_sub_qos(transient_local: bool) -> rclpy.qos.QoSProfile:
 class SubTestNode(rclpy.node.Node):
     """Node to test subscriptions and subscription-related events."""
 
-    def __init__(self, *, transient_local: bool = False) -> None:
+    def __init__(self, *, transient_local: bool = False, use_async_handler: bool = False) -> None:
         super().__init__('test_sub_node')
         self._new_pub_future: typing.Optional[
             rclpy.Future[rclpy.event_handler.QoSSubscriptionMatchedInfo]
@@ -59,7 +59,7 @@ class SubTestNode(rclpy.node.Node):
             # This node seems to get stale discovery data and then complain about QoS
             # changes if we reuse the same topic name.
             'test_topic' + ('_transient_local' if transient_local else ''),
-            self._handle_sub,
+            self._async_handle_sub if use_async_handler else self._handle_sub,
             _get_pub_sub_qos(transient_local),
             event_callbacks=rclpy.event_handler.SubscriptionEventCallbacks(
                 matched=self._handle_matched_sub
@@ -84,6 +84,10 @@ class SubTestNode(rclpy.node.Node):
             future = self._received_future
             self._received_future = None
             future.set_result(msg)
+
+    async def _async_handle_sub(self, msg: test_msgs.msg.BasicTypes) -> None:
+        # Don't bother to actually delay at all for this test
+        return self._handle_sub(msg)
 
     def _handle_matched_sub(self, info: rclpy.event_handler.QoSSubscriptionMatchedInfo) -> None:
         """Handle a new publisher being matched to our subscription."""
@@ -128,13 +132,22 @@ class PubTestNode(rclpy.node.Node):
 class ServiceServerTestNode(rclpy.node.Node):
     """Node to test service server-side operation."""
 
-    def __init__(self) -> None:
-        super().__init__('test_service_server_node')
+    def __init__(
+        self,
+        *,
+        use_async_handler: bool = False,
+        parameter_overrides: typing.Optional[list[rclpy.parameter.Parameter[bool]]] = None,
+    ) -> None:
+        super().__init__('test_service_server_node', parameter_overrides=parameter_overrides)
         self._got_request_future: typing.Optional[
             rclpy.Future[test_msgs.srv.BasicTypes.Request]
         ] = None
         self._pending_response: typing.Optional[test_msgs.srv.BasicTypes.Response] = None
-        self.create_service(test_msgs.srv.BasicTypes, 'test_service', self._handle_request)
+        self.create_service(
+            test_msgs.srv.BasicTypes,
+            'test_service',
+            self._async_handle_service if use_async_handler else self._handle_service,
+        )
 
     def expect_request(
         self, success: bool, error_msg: str
@@ -150,18 +163,46 @@ class ServiceServerTestNode(rclpy.node.Node):
         )
         return self._got_request_future
 
-    def _handle_request(
+    def _handle_service(
         self,
         req: test_msgs.srv.BasicTypes.Request,
         res: test_msgs.srv.BasicTypes.Response,
     ) -> test_msgs.srv.BasicTypes.Response:
+        self._handle_request(req)
+        return self._get_response(res)
+
+    def _handle_request(self, req: test_msgs.srv.BasicTypes.Request) -> None:
         if self._got_request_future is not None:
             self._got_request_future.set_result(req)
             self._got_request_future = None
+
+    def _get_response(
+        self, res: test_msgs.srv.BasicTypes.Response
+    ) -> test_msgs.srv.BasicTypes.Response:
         if self._pending_response is not None:
             res = self._pending_response
             self._pending_response = None
         return res
+
+    async def _async_handle_service(
+        self, req: test_msgs.srv.BasicTypes.Request, res: test_msgs.srv.BasicTypes.Response
+    ) -> test_msgs.srv.BasicTypes.Response:
+        self._handle_request(req)
+
+        # Create and await a timer before replying, to represent other work.
+        timer_future = rclpy.Future[None]()
+        timer = self.create_timer(
+            1.0,
+            lambda: timer_future.set_result(None),
+            # NOTE: As of this writing, the callback_group is entirely ignored by EventsExecutor;
+            # however, it would be needed for SingleThreadedExecutor to pass this same test, so
+            # we'll include it anyway.
+            callback_group=rclpy.callback_groups.ReentrantCallbackGroup(),
+        )
+        await timer_future
+        self.destroy_timer(timer)
+
+        return self._get_response(res)
 
 
 class ServiceClientTestNode(rclpy.node.Node):
@@ -506,6 +547,17 @@ class TestEventsExecutor(unittest.TestCase):
         self.assertFalse(new_pub_future.done())  # Already waited a bit
         self.assertFalse(received_future.done())  # Already waited a bit
 
+    def test_async_sub(self) -> None:
+        sub_node = SubTestNode(use_async_handler=True)
+        received_future = sub_node.expect_message()
+        self.executor.add_node(sub_node)
+        self._expect_future_not_done(received_future)
+
+        pub_node = PubTestNode()
+        self.executor.add_node(pub_node)
+        pub_node.publish(0.0)
+        self._check_message_future(received_future, 0.0)
+
     def test_pub_sub_multi_message(self) -> None:
         # Creates a transient local publisher and queues multiple messages on it.  Then
         # creates a subscriber and makes sure all sent messages get delivered when it
@@ -562,6 +614,24 @@ class TestEventsExecutor(unittest.TestCase):
         got_response_future = client_node.issue_request(5.0)
         self._expect_future_not_done(got_request_future)
         self.assertFalse(got_response_future.done())  # Already waited a bit
+
+    def test_async_service(self) -> None:
+        server_node = ServiceServerTestNode(
+            use_async_handler=True,
+            parameter_overrides=[rclpy.parameter.Parameter('use_sim_time', value=True)],
+        )
+        got_request_future = server_node.expect_request(True, 'test response')
+        client_node = ServiceClientTestNode()
+        clock_node = ClockPublisherNode()
+        for node in [server_node, client_node, clock_node]:
+            self.executor.add_node(node)
+
+        self._expect_future_not_done(got_request_future)
+        got_response_future = client_node.issue_request(7.1)
+        self._check_service_request_future(got_request_future, 7.1)
+        self._expect_future_not_done(got_response_future)
+        clock_node.advance_time(1000)
+        self._check_service_response_future(got_response_future, True, 'test response')
 
     def test_timers(self) -> None:
         realtime_node = TimerTestNode(index=0)


### PR DESCRIPTION
## Description

EventsExecutor was not properly handling async callbacks for services and subscriptions.

Fixes #1473

### Is this user-facing behavior change?

No workflow that previously worked with this executor should be impacted at all.

### Did you use Generative AI?

F no.

### Additional Information

Handling of async callbacks is arguably still not completely correct, as with SingleThreadedExecutor a ReentrantCallbackGroup must be used to enable the executor to do anything else while an async callback is awaiting something, and EventsExecutor ignores all callback groups.  However this is still preferable to the previous behavior of exploding with a TypeError, and it sounds like from discussion on the issue that we aren't sure the SingleThreadedExecutor behavior is desirable going forward either.