### PR TITLE
Cleanup the rclpy dependencies.

### DIFF
--- a/rclpy/package.xml
+++ b/rclpy/package.xml
@@ -17,33 +17,45 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>rcl</build_depend>
+  <build_depend>rcl_action</build_depend>
+  <build_depend>rcl_interfaces</build_depend>
+  <build_depend>rcl_lifecycle</build_depend>
+  <build_depend>rcl_logging_interface</build_depend>
+  <build_depend>rcl_yaml_param_parser</build_depend>
   <build_depend>pybind11_vendor</build_depend>
   <build_depend>python3-dev</build_depend>
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
+  <build_depend>rmw</build_depend>
+  <build_depend>rmw_implementation</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
-
-  <depend>lifecycle_msgs</depend>
-  <depend>rcl</depend>
-  <depend>rcl_interfaces</depend>
-  <depend>rcl_lifecycle</depend>
-  <depend>rcl_logging_interface</depend>
-  <depend>rcl_action</depend>
-  <depend>rcl_yaml_param_parser</depend>
-  <depend>rmw</depend>
-  <depend>rmw_implementation</depend>
-  <depend>rosidl_runtime_c</depend>
-  <depend>type_description_interfaces</depend>
-  <depend>unique_identifier_msgs</depend>
+  <build_depend>rosidl_runtime_c</build_depend>
+  <build_depend>type_description_interfaces</build_depend>
 
   <exec_depend>action_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>python3-typing-extensions</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>rcl</exec_depend>
+  <exec_depend>rcl_action</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rcl_lifecycle</exec_depend>
+  <exec_depend>rcl_logging_interface</exec_depend>
+  <exec_depend>rcl_yaml_param_parser</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
+  <exec_depend>rcutils</exec_depend>
+  <exec_depend>rmw</exec_depend>
+  <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rosgraph_msgs</exec_depend>
+  <exec_depend>rosidl_runtime_c</exec_depend>
   <exec_depend>rpyutils</exec_depend>
   <exec_depend>service_msgs</exec_depend>
+  <exec_depend>type_description_interfaces</exec_depend>
+  <exec_depend>unique_identifier_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/rclpy/src/rclpy/type_description_service.cpp
+++ b/rclpy/src/rclpy/type_description_service.cpp
@@ -14,6 +14,13 @@
 
 #include <pybind11/pybind11.h>
 
+#include <rcl/node.h>
+#include <rcl/service.h>
+
+#include <rmw/types.h>
+
+#include <type_description_interfaces/msg/type_description.h>
+
 #include "type_description_service.hpp"
 #include "utils.hpp"
 

--- a/rclpy/src/rclpy/type_description_service.hpp
+++ b/rclpy/src/rclpy/type_description_service.hpp
@@ -17,8 +17,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include <rmw/types.h>
-
 #include <memory>
 
 #include "destroyable.hpp"


### PR DESCRIPTION
## Description

Most importantly, we switch all dependencies to split out <build_depend>/<exec_depend>, rather than using <depend>. That's because <depend> implies <build_export_depend>, but we never want downstream libraries to link against nor try to #include the library that we build here.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No

### Additional Information

N/A