### PR TITLE
Fix msbuild warnings on `operator==` deprecation for pybind11 >=2.2

### DIFF
--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -327,7 +327,7 @@ void EventsExecutor::HandleSubscriptionReady(py::handle subscription, size_t num
     py::object msg_info = _rclpy_sub.take_message(msg_type, raw);
     if (!msg_info.is_none()) {
       try {
-        if (callback_type == message_only) {
+        if (callback_type.is(message_only)) {
           callback(py::cast<py::tuple>(msg_info)[0]);
         } else {
           callback(msg_info);

--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -327,7 +327,7 @@ void EventsExecutor::HandleSubscriptionReady(py::handle subscription, size_t num
     py::object msg_info = _rclpy_sub.take_message(msg_type, raw);
     if (!msg_info.is_none()) {
       try {
-        if (callback_type.is(message_only)) {
+        if (callback_type == message_only) {
           callback(py::cast<py::tuple>(msg_info)[0]);
         } else {
           callback(msg_info);

--- a/rclpy/src/rclpy/events_executor/events_executor.hpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.hpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "events_executor/events_queue.hpp"
+#include "events_executor/python_eq_handler.hpp"
 #include "events_executor/rcl_support.hpp"
 #include "events_executor/scoped_with.hpp"
 #include "events_executor/timers_manager.hpp"
@@ -192,7 +193,8 @@ private:
 
   /// Cache for rcl pointers underlying each waitables_ entry, because those are harder to retrieve
   /// than the other entity types.
-  std::unordered_map<pybind11::handle, WaitableSubEntities, PythonHasher, PythonEqHandler> waitable_entities_;
+  std::unordered_map<pybind11::handle, WaitableSubEntities, PythonHasher,
+    PythonEqHandler> waitable_entities_;
 
   RclCallbackManager rcl_callback_manager_;
   TimersManager timers_manager_;

--- a/rclpy/src/rclpy/events_executor/events_executor.hpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.hpp
@@ -192,7 +192,7 @@ private:
 
   /// Cache for rcl pointers underlying each waitables_ entry, because those are harder to retrieve
   /// than the other entity types.
-  std::unordered_map<pybind11::handle, WaitableSubEntities, PythonHasher> waitable_entities_;
+  std::unordered_map<pybind11::handle, WaitableSubEntities, PythonHasher, PythonEqHandler> waitable_entities_;
 
   RclCallbackManager rcl_callback_manager_;
   TimersManager timers_manager_;

--- a/rclpy/src/rclpy/events_executor/python_eq_handler.hpp
+++ b/rclpy/src/rclpy/events_executor/python_eq_handler.hpp
@@ -1,0 +1,35 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__EVENTS_EXECUTOR__PYTHON_EQ_HANDLER_HPP_
+#define RCLPY__EVENTS_EXECUTOR__PYTHON_EQ_HANDLER_HPP_
+
+#include <pybind11/pybind11.h>
+
+namespace rclpy
+{
+namespace events_executor
+{
+/// This is a workaround to the deprecation of `operator==` in Pybind11 >=2.2
+/// See https://pybind11.readthedocs.io/en/stable/upgrade.html#deprecation-of-some-py-object-apis
+/// It's intended to be replaced with the 
+struct PythonEqHandler
+{
+  inline auto operator()(const pybind11::handle &x, const pybind11::handle &y) const
+  {
+    return x.is(y);
+  }
+};
+}  // namespace events_executor
+}  // namespace rclpy
+
+#endif  // RCLPY__EVENTS_EXECUTOR__PYTHON_EQ_HANDLER_HPP_

--- a/rclpy/src/rclpy/events_executor/python_eq_handler.hpp
+++ b/rclpy/src/rclpy/events_executor/python_eq_handler.hpp
@@ -1,3 +1,5 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,10 +23,10 @@ namespace events_executor
 {
 /// This is a workaround to the deprecation of `operator==` in Pybind11 >=2.2
 /// See https://pybind11.readthedocs.io/en/stable/upgrade.html#deprecation-of-some-py-object-apis
-/// It's intended to be replaced with the 
+/// It's intended to be replaced with the
 struct PythonEqHandler
 {
-  inline auto operator()(const pybind11::handle &x, const pybind11::handle &y) const
+  inline auto operator()(const pybind11::handle & x, const pybind11::handle & y) const
   {
     return x.is(y);
   }

--- a/rclpy/src/rclpy/events_executor/timers_manager.hpp
+++ b/rclpy/src/rclpy/events_executor/timers_manager.hpp
@@ -86,7 +86,7 @@ private:
   RclTimersManager rcl_manager_;
   const std::function<void(pybind11::handle, const rcl_timer_call_info_t &)> ready_callback_;
 
-  std::unordered_map<pybind11::handle, PyRclMapping, PythonHasher> timer_mappings_;
+  std::unordered_map<pybind11::handle, PyRclMapping, PythonHasher, PythonEqHandler> timer_mappings_;
 };
 
 }  // namespace events_executor

--- a/rclpy/src/rclpy/events_executor/timers_manager.hpp
+++ b/rclpy/src/rclpy/events_executor/timers_manager.hpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 #include "events_executor/events_queue.hpp"
+#include "events_executor/python_eq_handler.hpp"
 #include "events_executor/python_hasher.hpp"
 #include "events_executor/scoped_with.hpp"
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

From pybind11 >= 2.2 the `operator== ` is [marked as deprecated](https://pybind11.readthedocs.io/en/stable/upgrade.html#deprecation-of-some-py-object-apis) for comparing objects. This started showing as a warning on Windows since it uses a newer pybind11 package than Ubuntu (2.11 on Noble).
See reference job: https://ci.ros2.org/view/nightly/job/nightly_win_rel/3504/

This PR changes the operator to the new way of comparing objects to remove the compiler warning. 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Nope.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
