### PR TITLE
Do not execute the timer if call_timer() fails

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -46,7 +46,7 @@ Invalid {name_type}: {error_msg}:
 
 
 InvalidHandle = _rclpy.InvalidHandle
-RCLError = _rclpy.RCLError
+TimerCancelledError = _rclpy.TimerCancelledError
 
 
 class InvalidNamespaceException(NameValidationException):

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -46,6 +46,7 @@ Invalid {name_type}: {error_msg}:
 
 
 InvalidHandle = _rclpy.InvalidHandle
+RCLError = _rclpy.RCLError
 
 
 class InvalidNamespaceException(NameValidationException):

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -41,7 +41,7 @@ from rclpy.client import Client
 from rclpy.clock import Clock
 from rclpy.clock_type import ClockType
 from rclpy.context import Context
-from rclpy.exceptions import InvalidHandle
+from rclpy.exceptions import InvalidHandle, RCLError
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.service import Service
@@ -384,8 +384,10 @@ class Executor(ContextManager['Executor']):
         except InvalidHandle:
             # Timer is a Destroyable, which means that on __enter__ it can throw an
             # InvalidHandle exception if the entity has already been destroyed.  Handle that here
-            # by just returning an empty argument, which means we will skip doing any real work
-            # in _execute_timer below
+            # by just returning an empty argument, which means we will skip doing any real work.
+            pass
+        except RCLError:
+            # If an exception occurs when calling call_timer(), we will skip doing any real work.
             pass
 
         return None

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -41,7 +41,7 @@ from rclpy.client import Client
 from rclpy.clock import Clock
 from rclpy.clock_type import ClockType
 from rclpy.context import Context
-from rclpy.exceptions import InvalidHandle, RCLError
+from rclpy.exceptions import InvalidHandle, TimerCancelledError
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.service import Service
@@ -386,8 +386,8 @@ class Executor(ContextManager['Executor']):
             # InvalidHandle exception if the entity has already been destroyed.  Handle that here
             # by just returning an empty argument, which means we will skip doing any real work.
             pass
-        except RCLError:
-            # If an exception occurs when calling call_timer(), we will skip doing any real work.
+        except TimerCancelledError:
+            # If this exception occurs when calling call_timer(), we will skip doing any real work.
             pass
 
         return None

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -118,6 +118,8 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     m, "NodeNameNonExistentError", rclerror.ptr());
   py::register_exception<rclpy::UnsupportedEventTypeError>(
     m, "UnsupportedEventTypeError", rclerror.ptr());
+  py::register_exception<rclpy::TimerCancelledError>(
+    m, "TimerCancelledError", rclerror.ptr());
   py::register_exception<rclpy::NotImplementedError>(
     m, "NotImplementedError", PyExc_NotImplementedError);
   py::register_exception<rclpy::InvalidHandle>(

--- a/rclpy/src/rclpy/exceptions.hpp
+++ b/rclpy/src/rclpy/exceptions.hpp
@@ -70,6 +70,11 @@ class UnsupportedEventTypeError : public RCLError
   using RCLError::RCLError;
 };
 
+class TimerCancelledError : public RCLError
+{
+  using RCLError::RCLError;
+};
+
 class NotImplementedError : public RCLError
 {
   using RCLError::RCLError;

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -90,7 +90,11 @@ void Timer::call_timer()
 {
   rcl_ret_t ret = rcl_timer_call(rcl_timer_.get());
   if (ret != RCL_RET_OK) {
-    throw RCLError("failed to call timer");
+    if (ret == RCL_RET_TIMER_CANCELED) {
+      throw TimerCancelledError("Timer has been canceled");
+    } else {
+      throw RCLError("failed to call timer");
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/ros2/rclpy/issues/1485

I tried to add a test, but the issue could not be reproduced by this test. Therefore, I didn't add test code.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
