### PR TITLE
Do not execute the timer if call_timer_with_info() fails

### DIFF
--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -46,7 +46,7 @@ Invalid {name_type}: {error_msg}:
 
 
 InvalidHandle = _rclpy.InvalidHandle
-RCLError = _rclpy.RCLError
+TimerCancelledError = _rclpy.TimerCancelledError
 
 
 class InvalidNamespaceException(NameValidationException):

--- a/rclpy/rclpy/exceptions.py
+++ b/rclpy/rclpy/exceptions.py
@@ -46,6 +46,7 @@ Invalid {name_type}: {error_msg}:
 
 
 InvalidHandle = _rclpy.InvalidHandle
+RCLError = _rclpy.RCLError
 
 
 class InvalidNamespaceException(NameValidationException):

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -44,7 +44,7 @@ from rclpy.client import Client
 from rclpy.clock import Clock
 from rclpy.clock_type import ClockType
 from rclpy.context import Context
-from rclpy.exceptions import InvalidHandle
+from rclpy.exceptions import InvalidHandle, RCLError
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.service import Service
@@ -461,8 +461,11 @@ class Executor(ContextManager['Executor']):
         except InvalidHandle:
             # Timer is a Destroyable, which means that on __enter__ it can throw an
             # InvalidHandle exception if the entity has already been destroyed.  Handle that here
-            # by just returning an empty argument, which means we will skip doing any real work
-            # in _execute_timer below
+            # by just returning an empty argument, which means we will skip doing any real work.
+            pass
+        except RCLError:
+            # If an exception occurs when calling call_timer_with_info(), we will skip doing any
+            # real work.
             pass
 
         return None

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -44,7 +44,7 @@ from rclpy.client import Client
 from rclpy.clock import Clock
 from rclpy.clock_type import ClockType
 from rclpy.context import Context
-from rclpy.exceptions import InvalidHandle, RCLError
+from rclpy.exceptions import InvalidHandle, TimerCancelledError
 from rclpy.guard_condition import GuardCondition
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.service import Service
@@ -463,9 +463,9 @@ class Executor(ContextManager['Executor']):
             # InvalidHandle exception if the entity has already been destroyed.  Handle that here
             # by just returning an empty argument, which means we will skip doing any real work.
             pass
-        except RCLError:
-            # If an exception occurs when calling call_timer_with_info(), we will skip doing any
-            # real work.
+        except TimerCancelledError:
+            # If TimerCancelledError exception occurs when calling call_timer_with_info(), we will
+            # skip doing any real work.
             pass
 
         return None

--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -145,6 +145,10 @@ class UnsupportedEventTypeError(RCLError):
     pass
 
 
+class TimerCancelledError(RCLError):
+    pass
+
+
 class NotImplementedError(builtins.NotImplementedError):  # noqa: A001
     pass
 

--- a/rclpy/src/rclpy/_rclpy_pybind11.cpp
+++ b/rclpy/src/rclpy/_rclpy_pybind11.cpp
@@ -118,6 +118,8 @@ PYBIND11_MODULE(_rclpy_pybind11, m) {
     m, "NodeNameNonExistentError", rclerror.ptr());
   py::register_exception<rclpy::UnsupportedEventTypeError>(
     m, "UnsupportedEventTypeError", rclerror.ptr());
+  py::register_exception<rclpy::TimerCancelledError>(
+    m, "TimerCancelledError", rclerror.ptr());
   py::register_exception<rclpy::NotImplementedError>(
     m, "NotImplementedError", PyExc_NotImplementedError);
   py::register_exception<rclpy::InvalidHandle>(

--- a/rclpy/src/rclpy/exceptions.hpp
+++ b/rclpy/src/rclpy/exceptions.hpp
@@ -75,6 +75,11 @@ class NotImplementedError : public RCLError
   using RCLError::RCLError;
 };
 
+class TimerCancelledError : public RCLError
+{
+  using RCLError::RCLError;
+};
+
 class InvalidHandle : public std::runtime_error
 {
   using std::runtime_error::runtime_error;

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -101,7 +101,11 @@ Timer::call_timer_with_info()
   rcl_timer_call_info_t call_info;
   rcl_ret_t ret = rcl_timer_call_with_info(rcl_timer_.get(), &call_info);
   if (ret != RCL_RET_OK) {
-    throw RCLError("failed to call timer");
+    if (ret == RCL_RET_TIMER_CANCELED) {
+      throw TimerCancelledError("Timer has been canceled");
+    } else {
+      throw RCLError("failed to call timer");
+    }
   }
 
   timer_info["expected_call_time"] = call_info.expected_call_time;


### PR DESCRIPTION
## Description

Fixes https://github.com/ros2/rclpy/issues/1485

I tried to add a test to reproduce the issue, but the test cannot reproduce it. So this commit does not include a related test.

Is this user-facing behavior change?
No

Did you use Generative AI?
No