### PR TITLE
Fix: deadlock when calling rclpy.shutdown() from callbacks (backport #947)

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -218,10 +218,14 @@ class Executor:
             if not self._is_shutdown:
                 self._is_shutdown = True
                 # Tell executor it's been shut down
-                self._guard.trigger()
+                try:
+                    self._guard.trigger()
+                except InvalidHandle:
+                    pass
 
-        if not self._work_tracker.wait(timeout_sec):
-            return False
+        if not self._is_shutdown:
+            if not self._work_tracker.wait(timeout_sec):
+                return False
 
         # Clean up stuff that won't be used anymore
         with self._nodes_lock:

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -438,14 +438,20 @@ class Executor:
             if is_shutdown or not entity.callback_group.beginning_execution(entity):
                 # Didn't get the callback, or the executor has been ordered to stop
                 entity._executor_event = False
-                gc.trigger()
+                try:
+                    gc.trigger()
+                except InvalidHandle:
+                    pass
                 return
             with work_tracker:
                 arg = take_from_wait_list(entity)
 
                 # Signal that this has been 'taken' and can be added back to the wait list
                 entity._executor_event = False
-                gc.trigger()
+                try:
+                    gc.trigger()
+                except InvalidHandle:
+                    pass
 
                 try:
                     await call_coroutine(entity, arg)

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -215,17 +215,17 @@ class Executor:
             timeot expires before all outstanding work is done.
         """
         with self._shutdown_lock:
-            if not self._is_shutdown:
-                self._is_shutdown = True
-                # Tell executor it's been shut down
-                try:
-                    self._guard.trigger()
-                except InvalidHandle:
-                    pass
+            if self._is_shutdown:
+                return True
+            self._is_shutdown = True
+            # Tell executor it's been shut down
+            try:
+                self._guard.trigger()
+            except InvalidHandle:
+                pass
 
-        if not self._is_shutdown:
-            if not self._work_tracker.wait(timeout_sec):
-                return False
+        if not self._work_tracker.wait(timeout_sec):
+            return False
 
         # Clean up stuff that won't be used anymore
         with self._nodes_lock:

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -459,7 +459,10 @@ class Executor:
                     entity.callback_group.ending_execution(entity)
                     # Signal that work has been done so the next callback in a mutually exclusive
                     # callback group can get executed
-                    gc.trigger()
+                    try:
+                        gc.trigger()
+                    except InvalidHandle:
+                        pass
         task = Task(
             handler, (entity, self._guard, self._is_shutdown, self._work_tracker),
             executor=self)
@@ -540,7 +543,10 @@ class Executor:
                 # retrigger a guard condition that was triggered but not handled
                 for gc in node_guards:
                     if gc._executor_triggered:
-                        gc.trigger()
+                        try:
+                            gc.trigger()
+                        except InvalidHandle:
+                            pass
                     guards.append(gc)
             if timeout_timer is not None:
                 timers.append(timeout_timer)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -532,7 +532,7 @@ class TestExecutor(unittest.TestCase):
             while not shutdown_called[0] and time.monotonic() - start_time < 5.0:
                 executor.spin_once(timeout_sec=0.1)
 
-            self.assertTrue(shutdown_called[0], "Timer callback was not executed")
+            self.assertTrue(shutdown_called[0], 'Timer callback was not executed')
 
             test_node.destroy_timer(timer)
             test_node.destroy_node()

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -511,6 +511,39 @@ class TestExecutor(unittest.TestCase):
         timer1.destroy()
         cli.destroy()
 
+    def test_shutdown_from_callback_no_deadlock(self):
+        test_context = rclpy.context.Context()
+        rclpy.init(context=test_context)
+
+        try:
+            test_node = rclpy.create_node('test_shutdown_node', context=test_context)
+            shutdown_called = [False]
+
+            def timer_callback():
+                shutdown_called[0] = True
+                rclpy.shutdown(context=test_context)
+
+            timer = test_node.create_timer(0.1, timer_callback)
+
+            executor = SingleThreadedExecutor(context=test_context)
+            executor.add_node(test_node)
+
+            start_time = time.monotonic()
+            while not shutdown_called[0] and time.monotonic() - start_time < 5.0:
+                executor.spin_once(timeout_sec=0.1)
+
+            self.assertTrue(shutdown_called[0], "Timer callback was not executed")
+
+            test_node.destroy_timer(timer)
+            test_node.destroy_node()
+            executor.shutdown()
+
+        finally:
+            try:
+                rclpy.shutdown(context=test_context)
+            except Exception:
+                pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This backports the fix from #947 to resolve #1489 where calling rclpy.shutdown() within a callback causes a deadlock in ROS 2 Humble.

## Problem
Calling rclpy.shutdown() from timer or subscription callbacks would hang indefinitely.

## Solution  
Modified Executor.shutdown() to return immediately if already in shutdown state.

Fixes #1489
Backports #947