### PR TITLE
Feature: expose event callback setter in subscription, service, client and timer

### DIFF
--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -195,6 +195,12 @@ class Client(Destroyable, Generic[SrvRequestT, SrvResponseT]):
     def get_logger_name(self) -> str:
         """Get the name of the logger associated with the node of the client."""
 
+    def set_on_new_response_callback(self, callback: Callable[[int], None]) -> None:
+        ...
+
+    def clear_on_new_response_callback(self) -> None:
+        ...
+
 
 class Context(Destroyable):
 
@@ -285,6 +291,12 @@ class Service(Destroyable, Generic[SrvRequestT, SrvResponseT]):
 
     def get_logger_name(self) -> str:
         """Get the name of the logger associated with the node of the service."""
+
+    def set_on_new_request_callback(self, callback: Callable[[int], None]) -> None:
+        ...
+
+    def clear_on_new_request_callback(self) -> None:
+        ...
 
 
 class TypeDescriptionService(Destroyable):
@@ -578,6 +590,12 @@ class Timer(Destroyable):
     def is_timer_canceled(self) -> bool:
         """Check if a timer is canceled."""
 
+    def set_on_reset_callback(self, callback: Callable[[int], None]) -> None:
+        ...
+
+    def clear_on_reset_callback(self) -> None:
+        ...
+
 
 class Subscription(Destroyable, Generic[MsgT]):
 
@@ -599,6 +617,12 @@ class Subscription(Destroyable, Generic[MsgT]):
 
     def get_publisher_count(self) -> int:
         """Count the publishers from a subscription."""
+
+    def set_on_new_message_callback(self, callback: Callable[[int], None]) -> None:
+        ...
+
+    def clear_on_new_message_callback(self) -> None:
+        ...
 
 
 class rcl_time_point_t:

--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -196,10 +196,10 @@ class Client(Destroyable, Generic[SrvRequestT, SrvResponseT]):
         """Get the name of the logger associated with the node of the client."""
 
     def set_on_new_response_callback(self, callback: Callable[[int], None]) -> None:
-        ...
+        """Set the on new response callback function for the client."""
 
     def clear_on_new_response_callback(self) -> None:
-        ...
+        """Clear the on new response callback function for the client."""
 
 
 class Context(Destroyable):
@@ -293,10 +293,10 @@ class Service(Destroyable, Generic[SrvRequestT, SrvResponseT]):
         """Get the name of the logger associated with the node of the service."""
 
     def set_on_new_request_callback(self, callback: Callable[[int], None]) -> None:
-        ...
+        """Set the on new request callback function for the service."""
 
     def clear_on_new_request_callback(self) -> None:
-        ...
+        """Clear the on new request callback function for the service."""
 
 
 class TypeDescriptionService(Destroyable):
@@ -591,10 +591,10 @@ class Timer(Destroyable):
         """Check if a timer is canceled."""
 
     def set_on_reset_callback(self, callback: Callable[[int], None]) -> None:
-        ...
+        """Set the on reset callback function for the timer."""
 
     def clear_on_reset_callback(self) -> None:
-        ...
+        """Clear the on reset callback function for the timer."""
 
 
 class Subscription(Destroyable, Generic[MsgT]):
@@ -619,10 +619,10 @@ class Subscription(Destroyable, Generic[MsgT]):
         """Count the publishers from a subscription."""
 
     def set_on_new_message_callback(self, callback: Callable[[int], None]) -> None:
-        ...
+        """Set the on new message callback function for the subscription."""
 
     def clear_on_new_message_callback(self) -> None:
-        ...
+        """Clear the on new message callback function for the subscription."""
 
 
 class rcl_time_point_t:

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "client.hpp"
 #include "clock.hpp"
@@ -30,9 +31,11 @@
 #include "node.hpp"
 #include "python_allocator.hpp"
 #include "utils.hpp"
+#include "events_executor/rcl_support.hpp"
 
 namespace rclpy
 {
+using events_executor::RclEventCallbackTrampoline;
 
 void
 Client::destroy()
@@ -182,6 +185,40 @@ Client::get_logger_name() const
 }
 
 void
+Client::set_callback(
+  rcl_event_callback_t callback,
+  const void * user_data)
+{
+  rcl_ret_t ret = rcl_client_set_on_new_response_callback(
+    rcl_client_.get(),
+    callback,
+    user_data);
+
+  if (RCL_RET_OK != ret) {
+    throw RCLError("failed to set the on new message callback for subscription");
+  }
+}
+
+void
+Client::set_on_new_response_callback(std::function<void(size_t)> callback)
+{
+  clear_on_new_response_callback();
+  on_new_response_callback_ = std::move(callback);
+  set_callback(
+    RclEventCallbackTrampoline,
+    static_cast<const void *>(&on_new_response_callback_));
+}
+
+void
+Client::clear_on_new_response_callback()
+{
+  if (on_new_response_callback_) {
+    set_callback(nullptr, nullptr);
+    on_new_response_callback_ = nullptr;
+  }
+}
+
+void
 define_client(py::object module)
 {
   py::class_<Client, Destroyable, std::shared_ptr<Client>>(module, "Client")
@@ -208,6 +245,10 @@ define_client(py::object module)
     "Configure whether introspection is enabled")
   .def(
     "get_logger_name", &Client::get_logger_name,
-    "Get the name of the logger associated with the node of the client.");
+    "Get the name of the logger associated with the node of the client.")
+  .def(
+    "set_on_new_response_callback", &Client::set_on_new_response_callback,
+    py::arg("callback"))
+  .def("clear_on_new_response_callback", &Client::clear_on_new_response_callback);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -40,6 +40,10 @@ using events_executor::RclEventCallbackTrampoline;
 void
 Client::destroy()
 {
+  try {
+    clear_on_new_response_callback();
+  } catch (RCLError) {
+  }
   rcl_client_.reset();
   node_.destroy();
 }
@@ -195,7 +199,8 @@ Client::set_callback(
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw RCLError("failed to set the on new message callback for subscription");
+    throw RCLError(std::string("Failed to set the on new response callback for client: ") +
+      rcl_get_error_string().str);
   }
 }
 

--- a/rclpy/src/rclpy/client.hpp
+++ b/rclpy/src/rclpy/client.hpp
@@ -16,6 +16,7 @@
 #define RCLPY__CLIENT_HPP_
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 
 #include <rcl/client.h>
 #include <rcl/service_introspection.h>
@@ -120,10 +121,20 @@ public:
   const char *
   get_logger_name() const;
 
+  void
+  set_on_new_response_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_new_response_callback();
+
 private:
   Node node_;
+  std::function<void(size_t)> on_new_response_callback_{nullptr};
   std::shared_ptr<rcl_client_t> rcl_client_;
   rosidl_service_type_support_t * srv_type_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 
 /// Define a pybind11 wrapper for an rclpy::Client

--- a/rclpy/src/rclpy/events_executor/rcl_support.cpp
+++ b/rclpy/src/rclpy/events_executor/rcl_support.cpp
@@ -26,7 +26,13 @@ namespace events_executor
 extern "C" void RclEventCallbackTrampoline(const void * user_data, size_t number_of_events)
 {
   const auto cb = reinterpret_cast<const std::function<void(size_t)> *>(user_data);
-  (*cb)(number_of_events);
+  try {
+    (*cb)(number_of_events);
+  } catch (const std::exception & e) {
+    // Catch and print any exception to avoid propagation to c code
+    std::fputs(e.what(), stderr);
+    std::exit(EXIT_FAILURE);
+  }
 }
 
 RclCallbackManager::RclCallbackManager(EventsQueue * events_queue)

--- a/rclpy/src/rclpy/events_executor/rcl_support.cpp
+++ b/rclpy/src/rclpy/events_executor/rcl_support.cpp
@@ -30,7 +30,7 @@ extern "C" void RclEventCallbackTrampoline(const void * user_data, size_t number
     (*cb)(number_of_events);
   } catch (const std::exception & e) {
     // Catch and print any exception to avoid propagation to c code
-    std::fputs(e.what(), stderr);
+    std::fprintf(stderr, "%s\n", e.what());
     std::exit(EXIT_FAILURE);
   }
 }

--- a/rclpy/src/rclpy/events_executor/rcl_support.cpp
+++ b/rclpy/src/rclpy/events_executor/rcl_support.cpp
@@ -31,7 +31,7 @@ extern "C" void RclEventCallbackTrampoline(const void * user_data, size_t number
   } catch (const std::exception & e) {
     // Catch and print any exception to avoid propagation to c code
     std::fprintf(stderr, "%s\n", e.what());
-    std::exit(EXIT_FAILURE);
+    std::terminate();
   }
 }
 

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -22,15 +22,18 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "clock.hpp"
 #include "exceptions.hpp"
 #include "node.hpp"
 #include "service.hpp"
 #include "utils.hpp"
+#include "events_executor/rcl_support.hpp"
 
 namespace rclpy
 {
+using events_executor::RclEventCallbackTrampoline;
 
 void
 Service::destroy()
@@ -185,6 +188,40 @@ Service::configure_introspection(
 }
 
 void
+Service::set_callback(
+  rcl_event_callback_t callback,
+  const void * user_data)
+{
+  rcl_ret_t ret = rcl_service_set_on_new_request_callback(
+    rcl_service_.get(),
+    callback,
+    user_data);
+
+  if (RCL_RET_OK != ret) {
+    throw RCLError("failed to set the on new message callback for subscription");
+  }
+}
+
+void
+Service::set_on_new_request_callback(std::function<void(size_t)> callback)
+{
+  clear_on_new_request_callback();
+  on_new_request_callback_ = std::move(callback);
+  set_callback(
+    RclEventCallbackTrampoline,
+    static_cast<const void *>(&on_new_request_callback_));
+}
+
+void
+Service::clear_on_new_request_callback()
+{
+  if (on_new_request_callback_) {
+    set_callback(nullptr, nullptr);
+    on_new_request_callback_ = nullptr;
+  }
+}
+
+void
 define_service(py::object module)
 {
   py::class_<Service, Destroyable, std::shared_ptr<Service>>(module, "Service")
@@ -211,6 +248,10 @@ define_service(py::object module)
     "Configure whether introspection is enabled")
   .def(
     "get_logger_name", &Service::get_logger_name,
-    "Get the name of the logger associated with the node of the service.");
+    "Get the name of the logger associated with the node of the service.")
+  .def(
+    "set_on_new_request_callback", &Service::set_on_new_request_callback,
+    py::arg("callback"))
+  .def("clear_on_new_request_callback", &Service::clear_on_new_request_callback);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -38,6 +38,10 @@ using events_executor::RclEventCallbackTrampoline;
 void
 Service::destroy()
 {
+  try {
+    clear_on_new_request_callback();
+  } catch (RCLError) {
+  }
   rcl_service_.reset();
   node_.destroy();
 }
@@ -198,7 +202,8 @@ Service::set_callback(
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw RCLError("failed to set the on new message callback for subscription");
+    throw RCLError(std::string("Failed to set the on new request callback for service: ") +
+      rcl_get_error_string().str);
   }
 }
 

--- a/rclpy/src/rclpy/service.hpp
+++ b/rclpy/src/rclpy/service.hpp
@@ -16,6 +16,7 @@
 #define RCLPY__SERVICE_HPP_
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 
 #include <rcl/service.h>
 #include <rcl/service_introspection.h>
@@ -125,10 +126,20 @@ public:
   void
   destroy() override;
 
+  void
+  set_on_new_request_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_new_request_callback();
+
 private:
   Node node_;
+  std::function<void(size_t)> on_new_request_callback_{nullptr};
   std::shared_ptr<rcl_service_t> rcl_service_;
   rosidl_service_type_support_t * srv_type_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 
 /// Define a pybind11 wrapper for an rclpy::Service

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -91,6 +91,10 @@ Subscription::Subscription(
 
 void Subscription::destroy()
 {
+  try {
+    clear_on_new_message_callback();
+  } catch (RCLError) {
+  }
   rcl_subscription_.reset();
   node_.destroy();
 }
@@ -209,7 +213,8 @@ Subscription::set_callback(
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw RCLError("failed to set the on new message callback for subscription");
+    throw RCLError(std::string("Failed to set the on new message callback for subscription: ") +
+      rcl_get_error_string().str);
   }
 }
 

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -24,17 +24,21 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "exceptions.hpp"
 #include "node.hpp"
 #include "serialization.hpp"
 #include "subscription.hpp"
 #include "utils.hpp"
+#include "events_executor/rcl_support.hpp"
 
 using pybind11::literals::operator""_a;
 
 namespace rclpy
 {
+using events_executor::RclEventCallbackTrampoline;
+
 Subscription::Subscription(
   Node & node, py::object pymsg_type, std::string topic,
   py::object pyqos_profile)
@@ -195,6 +199,40 @@ Subscription::get_publisher_count() const
 }
 
 void
+Subscription::set_callback(
+  rcl_event_callback_t callback,
+  const void * user_data)
+{
+  rcl_ret_t ret = rcl_subscription_set_on_new_message_callback(
+    rcl_subscription_.get(),
+    callback,
+    user_data);
+
+  if (RCL_RET_OK != ret) {
+    throw RCLError("failed to set the on new message callback for subscription");
+  }
+}
+
+void
+Subscription::set_on_new_message_callback(std::function<void(size_t)> callback)
+{
+  clear_on_new_message_callback();
+  on_new_message_callback_ = std::move(callback);
+  set_callback(
+    RclEventCallbackTrampoline,
+    static_cast<const void *>(&on_new_message_callback_));
+}
+
+void
+Subscription::clear_on_new_message_callback()
+{
+  if (on_new_message_callback_) {
+    set_callback(nullptr, nullptr);
+    on_new_message_callback_ = nullptr;
+  }
+}
+
+void
 define_subscription(py::object module)
 {
   py::class_<Subscription, Destroyable, std::shared_ptr<Subscription>>(module, "Subscription")
@@ -215,6 +253,10 @@ define_subscription(py::object module)
     "Return the resolved topic name of a subscription.")
   .def(
     "get_publisher_count", &Subscription::get_publisher_count,
-    "Count the publishers from a subscription.");
+    "Count the publishers from a subscription.")
+  .def(
+    "set_on_new_message_callback", &Subscription::set_on_new_message_callback,
+    py::arg("callback"))
+  .def("clear_on_new_message_callback", &Subscription::clear_on_new_message_callback);
 }
 }  // namespace rclpy

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -16,6 +16,7 @@
 #define RCLPY__SUBSCRIPTION_HPP_
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 
 #include <rcl/subscription.h>
 
@@ -105,9 +106,19 @@ public:
   void
   destroy() override;
 
+  void
+  set_on_new_message_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_new_message_callback();
+
 private:
   Node node_;
+  std::function<void(size_t)> on_new_message_callback_{nullptr};
   std::shared_ptr<rcl_subscription_t> rcl_subscription_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 /// Define a pybind11 wrapper for an rclpy::Subscription
 void define_subscription(py::object module);

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -19,6 +19,7 @@
 #include <rcl/types.h>
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "clock.hpp"
@@ -34,6 +35,10 @@ using events_executor::RclEventCallbackTrampoline;
 void
 Timer::destroy()
 {
+  try {
+    clear_on_reset_callback();
+  } catch (RCLError) {
+  }
   rcl_timer_.reset();
   clock_.destroy();
   context_.destroy();
@@ -190,7 +195,8 @@ Timer::set_callback(
     user_data);
 
   if (RCL_RET_OK != ret) {
-    throw RCLError("failed to set the on reset callback for timer");
+    throw RCLError(std::string("Failed to set the on reset callback for timer: ") +
+      rcl_get_error_string().str);
   }
 }
 

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -19,14 +19,18 @@
 #include <rcl/types.h>
 
 #include <memory>
+#include <utility>
 
 #include "clock.hpp"
 #include "context.hpp"
 #include "exceptions.hpp"
 #include "timer.hpp"
+#include "events_executor/rcl_support.hpp"
 
 namespace rclpy
 {
+using events_executor::RclEventCallbackTrampoline;
+
 void
 Timer::destroy()
 {
@@ -176,6 +180,40 @@ bool Timer::is_timer_canceled()
 }
 
 void
+Timer::set_callback(
+  rcl_event_callback_t callback,
+  const void * user_data)
+{
+  rcl_ret_t ret = rcl_timer_set_on_reset_callback(
+    rcl_timer_.get(),
+    callback,
+    user_data);
+
+  if (RCL_RET_OK != ret) {
+    throw RCLError("failed to set the on reset callback for timer");
+  }
+}
+
+void
+Timer::set_on_reset_callback(std::function<void(size_t)> callback)
+{
+  clear_on_reset_callback();
+  on_reset_callback_ = std::move(callback);
+  set_callback(
+    RclEventCallbackTrampoline,
+    static_cast<const void *>(&on_reset_callback_));
+}
+
+void
+Timer::clear_on_reset_callback()
+{
+  if (on_reset_callback_) {
+    set_callback(nullptr, nullptr);
+    on_reset_callback_ = nullptr;
+  }
+}
+
+void
 define_timer(py::object module)
 {
   py::class_<Timer, Destroyable, std::shared_ptr<Timer>>(module, "Timer")
@@ -212,7 +250,11 @@ define_timer(py::object module)
     "Cancel a timer.")
   .def(
     "is_timer_canceled", &Timer::is_timer_canceled,
-    "Check if a timer is canceled.");
+    "Check if a timer is canceled.")
+  .def(
+    "set_on_reset_callback", &Timer::set_on_reset_callback,
+    py::arg("callback"))
+  .def("clear_on_reset_callback", &Timer::clear_on_reset_callback);
 }
 
 }  // namespace rclpy

--- a/rclpy/src/rclpy/timer.hpp
+++ b/rclpy/src/rclpy/timer.hpp
@@ -17,6 +17,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/functional.h>
 
 #include <rcl/timer.h>
 
@@ -145,10 +146,20 @@ public:
   /// Force an early destruction of this object
   void destroy() override;
 
+  void
+  set_on_reset_callback(std::function<void(size_t)> callback);
+
+  void
+  clear_on_reset_callback();
+
 private:
   Context context_;
   Clock clock_;
+  std::function<void(size_t)> on_reset_callback_{nullptr};
   std::shared_ptr<rcl_timer_t> rcl_timer_;
+
+  void
+  set_callback(rcl_event_callback_t callback, const void * user_data);
 };
 
 /// Define a pybind11 wrapper for an rcl_timer_t

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -18,6 +18,7 @@ import time
 import traceback
 from typing import TYPE_CHECKING
 import unittest
+from unittest.mock import Mock
 
 from rcl_interfaces.srv import GetParameters
 import rclpy
@@ -274,6 +275,27 @@ class TestClient(unittest.TestCase):
     def test_logger_name_is_equal_to_node_name(self) -> None:
         with self.node.create_client(GetParameters, 'get/parameters') as cli:
             self.assertEqual(cli.logger_name, 'TestClient')
+
+    def test_on_new_response_callback(self) -> None:
+        def _service(request, response):
+            return response
+        with self.node.create_client(Empty, '/service') as cli:
+            with self.node.create_service(Empty, '/service', _service):
+                executor = rclpy.executors.SingleThreadedExecutor(context=self.context)
+                try:
+                    self.assertTrue(cli.wait_for_service(timeout_sec=20))
+                    executor.add_node(self.node)
+                    cb = Mock()
+                    cli.handle.set_on_new_response_callback(cb)
+                    cli.call_async(Empty.Request())
+                    executor.spin_once(0)
+                    cb.assert_called_once_with(1)
+                    cli.handle.clear_on_new_response_callback()
+                    cli.call_async(Empty.Request())
+                    executor.spin_once(0)
+                    cb.assert_called_once()
+                finally:
+                    executor.shutdown()
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -287,6 +287,7 @@ class TestClient(unittest.TestCase):
                     executor.add_node(self.node)
                     cb = Mock()
                     cli.handle.set_on_new_response_callback(cb)
+                    cb.assert_not_called()
                     cli.call_async(Empty.Request())
                     executor.spin_once(0)
                     cb.assert_called_once_with(1)

--- a/rclpy/test/test_service.py
+++ b/rclpy/test/test_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from unittest.mock import Mock
 
 import rclpy
 from rclpy.node import Node
@@ -105,3 +106,16 @@ def test_service_context_manager() -> None:
         with node.create_service(
                 srv_type=Empty, srv_name='empty_service', callback=lambda _, _1: None) as srv:
             assert srv.service_name == '/empty_service'
+
+
+def test_set_on_new_request_callback(test_node) -> None:
+    cli = test_node.create_client(Empty, '/service')
+    srv = test_node.create_service(Empty, '/service', lambda req, res: res)
+    cb = Mock()
+    srv.handle.set_on_new_request_callback(cb)
+    cb.assert_not_called()
+    cli.call_async(Empty.Request())
+    cb.assert_called_once_with(1)
+    srv.handle.clear_on_new_request_callback()
+    cli.call_async(Empty.Request())
+    cb.assert_called_once()

--- a/rclpy/test/test_service.py
+++ b/rclpy/test/test_service.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 import rclpy
 from rclpy.node import Node

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -14,7 +14,9 @@
 
 import time
 
+from numpy import cbrt
 import pytest
+from unittest.mock import Mock
 
 import rclpy
 from rclpy.node import Node
@@ -172,3 +174,19 @@ def test_subscription_publisher_count() -> None:
     sub.destroy()
 
     node.destroy_node()
+
+def test_on_new_message_callback(test_node) -> None:
+    topic_name = "/topic"
+    cb = Mock()
+    sub = test_node.create_subscription(
+        msg_type=Empty,
+        topic=topic_name,
+        qos_profile=10,
+        callback=cb)
+    pub = test_node.create_publisher(Empty, topic_name, 10)
+    sub.handle.set_on_new_message_callback(cb)
+    pub.publish(Empty())
+    cb.assert_called_once_with(1)
+    sub.handle.clear_on_new_message_callback()
+    pub.publish(Empty())
+    cb.assert_called_once()

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -185,6 +185,7 @@ def test_on_new_message_callback(test_node) -> None:
         callback=cb)
     pub = test_node.create_publisher(Empty, topic_name, 10)
     sub.handle.set_on_new_message_callback(cb)
+    cb.assert_not_called()
     pub.publish(Empty())
     cb.assert_called_once_with(1)
     sub.handle.clear_on_new_message_callback()

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import time
-
-from numpy import cbrt
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 import rclpy
 from rclpy.node import Node
@@ -175,8 +174,9 @@ def test_subscription_publisher_count() -> None:
 
     node.destroy_node()
 
+
 def test_on_new_message_callback(test_node) -> None:
-    topic_name = "/topic"
+    topic_name = '/topic'
     cb = Mock()
     sub = test_node.create_subscription(
         msg_type=Empty,

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -18,6 +18,7 @@ import platform
 import time
 from typing import List
 from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 import rclpy
@@ -25,6 +26,25 @@ from rclpy.clock_type import ClockType
 from rclpy.constants import S_TO_NS
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.timer import TimerInfo
+
+
+@pytest.fixture
+def context() -> None:
+    return rclpy.context.Context()
+
+
+@pytest.fixture
+def setup_ros(context) -> None:
+    rclpy.init(context=context)
+    yield
+    rclpy.shutdown(context=context)
+
+
+@pytest.fixture
+def test_node(context, setup_ros):
+    node = rclpy.create_node('test_node', context=context)
+    yield node
+    node.destroy_node()
 
 
 TEST_PERIODS = (
@@ -328,3 +348,14 @@ def test_timer_info_with_partial() -> None:
                 node.destroy_timer(timer)
             node.destroy_node()
         rclpy.shutdown(context=context)
+
+def test_on_reset_callback(test_node):
+    tmr = test_node.create_timer(1, lambda: None)
+    cb = Mock()
+    tmr.handle.set_on_reset_callback(cb)
+    cb.assert_not_called()
+    tmr.reset()
+    cb.assert_called_once_with(1)
+    tmr.handle.clear_on_reset_callback()
+    tmr.reset()
+    cb.assert_called_once()

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -349,6 +349,7 @@ def test_timer_info_with_partial() -> None:
             node.destroy_node()
         rclpy.shutdown(context=context)
 
+
 def test_on_reset_callback(test_node):
     tmr = test_node.create_timer(1, lambda: None)
     cb = Mock()


### PR DESCRIPTION
Part of #1399.
- Expose set_on_new_message_callback and clear_on_new_message_callback for subscription.
- Expose set_on_new_request_callback and clear_on_new_request_callback for service.
- Expose set_on_new_response_callback and clear_on_new_response_callback for client.
- Expose set_on_reset_callback and clear_on_reset_callback for timer.