### PR TITLE
Fix warnings from gcc.

### DIFF
--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -42,7 +42,7 @@ Client::destroy()
 {
   try {
     clear_on_new_response_callback();
-  } catch (RCLError) {
+  } catch (const rclpy::RCLError &) {
   }
   rcl_client_.reset();
   node_.destroy();

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -40,7 +40,7 @@ Service::destroy()
 {
   try {
     clear_on_new_request_callback();
-  } catch (RCLError) {
+  } catch (const rclpy::RCLError &) {
   }
   rcl_service_.reset();
   node_.destroy();

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -85,7 +85,7 @@ Subscription::Subscription(
       error_text += "'";
       throw py::value_error(error_text);
     }
-    throw RCLError("Failed to create subscription");
+    throw rclpy::RCLError("Failed to create subscription");
   }
 }
 
@@ -93,7 +93,7 @@ void Subscription::destroy()
 {
   try {
     clear_on_new_message_callback();
-  } catch (RCLError) {
+  } catch (const rclpy::RCLError &) {
   }
   rcl_subscription_.reset();
   node_.destroy();

--- a/rclpy/src/rclpy/timer.cpp
+++ b/rclpy/src/rclpy/timer.cpp
@@ -37,7 +37,7 @@ Timer::destroy()
 {
   try {
     clear_on_reset_callback();
-  } catch (RCLError) {
+  } catch (const rclpy::RCLError &) {
   }
   rcl_timer_.reset();
   clock_.destroy();


### PR DESCRIPTION
## Description

When compiling with gcc, it was complaining that:

"catching polymorphic type 'class rclpy::RCLError' by value".

Fix this by making it catch by constref instead.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

This is a follow-up to #1496  .  @nadavelkabets @fujitatomoya FYI.