### PR TITLE
add spinning state for the Executor classes.

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -225,6 +225,28 @@ class Executor(ContextManager['Executor']):
         self._sigint_gc: Optional[SignalHandlerGuardCondition] = \
             SignalHandlerGuardCondition(context)
         self._context.on_shutdown(self.wake)
+        # True when the executor is spinning
+        self._is_spinning = False
+        # Protects access to _is_spinning
+        self._is_spinning_lock = Lock()
+
+    def _enter_spin(self) -> None:
+        """Mark the executor as spinning and prevent concurrent spins."""
+        with self._is_spinning_lock:
+            if self._is_spinning:
+                raise RuntimeError('Executor is already spinning')
+            self._is_spinning = True
+
+    def _exit_spin(self) -> None:
+        """Clear the spinning flag."""
+        with self._is_spinning_lock:
+            self._is_spinning = False
+
+    @property
+    def is_spinning(self) -> bool:
+        """Return whether the executor is currently spinning."""
+        with self._is_spinning_lock:
+            return self._is_spinning
 
     @property
     def context(self) -> Context:
@@ -352,8 +374,11 @@ class Executor(ContextManager['Executor']):
 
     def spin(self) -> None:
         """Execute callbacks until shutdown."""
+        # Mark executor as spinning to prevent concurrent spins
+        self._enter_spin()
         while self._context.ok() and not self._is_shutdown:
-            self.spin_once()
+            self._spin_once_impl()
+        self._exit_spin()
 
     def spin_until_future_complete(
         self,
@@ -361,9 +386,10 @@ class Executor(ContextManager['Executor']):
         timeout_sec: Optional[float] = None
     ) -> None:
         """Execute callbacks until a given future is done or a timeout occurs."""
+        # Mark executor as spinning to prevent concurrent spins
+        self._enter_spin()
         # Make sure the future wakes this executor when it is done
         future.add_done_callback(lambda x: self.wake())
-
         if timeout_sec is None or timeout_sec < 0:
             while (
                 self._context.ok()
@@ -387,9 +413,11 @@ class Executor(ContextManager['Executor']):
                 now = time.monotonic()
 
                 if now >= end:
+                    self._exit_spin()
                     return
 
                 timeout_left.timeout = end - now
+        self._exit_spin()
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         """
@@ -402,6 +430,13 @@ class Executor(ContextManager['Executor']):
         :param timeout_sec: Seconds to wait. Block forever if ``None`` or negative.
             Don't wait if 0.
         """
+        raise NotImplementedError()
+
+    def _spin_once_impl(
+        self,
+        timeout_sec: Optional[Union[float, TimeoutObject]] = None,
+        wait_condition: Callable[[], bool] = lambda: False
+    ) -> None:
         raise NotImplementedError()
 
     def spin_once_until_future_complete(
@@ -939,7 +974,10 @@ class SingleThreadedExecutor(Executor):
             handler.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
+        # Mark executor as spinning to prevent concurrent spins
+        self._enter_spin()
         self._spin_once_impl(timeout_sec)
+        self._exit_spin()
 
     def _spin_once_until_future_complete(
         self,
@@ -953,8 +991,11 @@ class SingleThreadedExecutor(Executor):
         future: Future[Any],
         timeout_sec: Optional[Union[float, TimeoutObject]] = None
     ) -> None:
+        # Mark executor as spinning to prevent concurrent spins
+        self._enter_spin()
         future.add_done_callback(lambda x: self.wake())
         self._spin_once_until_future_complete(future, timeout_sec)
+        self._exit_spin()
 
 
 class MultiThreadedExecutor(Executor):
@@ -1018,7 +1059,10 @@ class MultiThreadedExecutor(Executor):
                         future.result()  # raise any exceptions
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
+        # Mark executor as spinning to prevent concurrent spins
+        self._enter_spin()
         self._spin_once_impl(timeout_sec)
+        self._exit_spin()
 
     def _spin_once_until_future_complete(
         self,
@@ -1032,8 +1076,11 @@ class MultiThreadedExecutor(Executor):
         future: Future[Any],
         timeout_sec: Optional[Union[float, TimeoutObject]] = None
     ) -> None:
+        # Mark executor as spinning to prevent concurrent spins
+        self._enter_spin()
         future.add_done_callback(lambda x: self.wake())
         self._spin_once_until_future_complete(future, timeout_sec)
+        self._exit_spin()
 
     def shutdown(
         self,

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -376,9 +376,11 @@ class Executor(ContextManager['Executor']):
         """Execute callbacks until shutdown."""
         # Mark executor as spinning to prevent concurrent spins
         self._enter_spin()
-        while self._context.ok() and not self._is_shutdown:
-            self._spin_once_impl()
-        self._exit_spin()
+        try:
+            while self._context.ok() and not self._is_shutdown:
+                self._spin_once_impl()
+        finally:
+            self._exit_spin()
 
     def spin_until_future_complete(
         self,
@@ -390,34 +392,36 @@ class Executor(ContextManager['Executor']):
         self._enter_spin()
         # Make sure the future wakes this executor when it is done
         future.add_done_callback(lambda x: self.wake())
-        if timeout_sec is None or timeout_sec < 0:
-            while (
-                self._context.ok()
-                and not future.done()
-                and not future.cancelled()
-                and not self._is_shutdown
-            ):
-                self._spin_once_until_future_complete(future, timeout_sec)
-        else:
-            start = time.monotonic()
-            end = start + timeout_sec
-            timeout_left = TimeoutObject(timeout_sec)
+        try:
+            if timeout_sec is None or timeout_sec < 0:
+                while (
+                    self._context.ok()
+                    and not future.done()
+                    and not future.cancelled()
+                    and not self._is_shutdown
+                ):
+                    self._spin_once_until_future_complete(future, timeout_sec)
+            else:
+                start = time.monotonic()
+                end = start + timeout_sec
+                timeout_left = TimeoutObject(timeout_sec)
 
-            while (
-                self._context.ok()
-                and not future.done()
-                and not future.cancelled()
-                and not self._is_shutdown
-            ):
-                self._spin_once_until_future_complete(future, timeout_left)
-                now = time.monotonic()
+                while (
+                    self._context.ok()
+                    and not future.done()
+                    and not future.cancelled()
+                    and not self._is_shutdown
+                ):
+                    self._spin_once_until_future_complete(future, timeout_left)
+                    now = time.monotonic()
 
-                if now >= end:
-                    self._exit_spin()
-                    return
+                    if now >= end:
+                        self._exit_spin()
+                        return
 
-                timeout_left.timeout = end - now
-        self._exit_spin()
+                    timeout_left.timeout = end - now
+        finally:
+            self._exit_spin()
 
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         """
@@ -976,8 +980,10 @@ class SingleThreadedExecutor(Executor):
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         # Mark executor as spinning to prevent concurrent spins
         self._enter_spin()
-        self._spin_once_impl(timeout_sec)
-        self._exit_spin()
+        try:
+            self._spin_once_impl(timeout_sec)
+        finally:
+            self._exit_spin()
 
     def _spin_once_until_future_complete(
         self,
@@ -994,8 +1000,10 @@ class SingleThreadedExecutor(Executor):
         # Mark executor as spinning to prevent concurrent spins
         self._enter_spin()
         future.add_done_callback(lambda x: self.wake())
-        self._spin_once_until_future_complete(future, timeout_sec)
-        self._exit_spin()
+        try:
+            self._spin_once_until_future_complete(future, timeout_sec)
+        finally:
+            self._exit_spin()
 
 
 class MultiThreadedExecutor(Executor):
@@ -1061,8 +1069,10 @@ class MultiThreadedExecutor(Executor):
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         # Mark executor as spinning to prevent concurrent spins
         self._enter_spin()
-        self._spin_once_impl(timeout_sec)
-        self._exit_spin()
+        try:
+            self._spin_once_impl(timeout_sec)
+        finally:
+            self._exit_spin()
 
     def _spin_once_until_future_complete(
         self,
@@ -1079,8 +1089,10 @@ class MultiThreadedExecutor(Executor):
         # Mark executor as spinning to prevent concurrent spins
         self._enter_spin()
         future.add_done_callback(lambda x: self.wake())
-        self._spin_once_until_future_complete(future, timeout_sec)
-        self._exit_spin()
+        try:
+            self._spin_once_until_future_complete(future, timeout_sec)
+        finally:
+            self._exit_spin()
 
     def shutdown(
         self,

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -742,6 +742,122 @@ class TestExecutor(unittest.TestCase):
                 finally:
                     executor.shutdown()
 
+    def test_spinning_multiple_times_spin(self) -> None:
+        self.assertIsNotNone(self.node.handle)
+        # Test all executor types including base Executor class
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                try:
+                    executor.add_node(self.node)
+
+                    # Start spinning in a background thread
+                    def spin_thread():
+                        executor.spin()
+
+                    t = threading.Thread(target=spin_thread, daemon=True)
+                    t.start()
+                    # Give the executor time to start spinning
+                    time.sleep(1.0)
+                    # Check that executor is spinning
+                    self.assertTrue(executor.is_spinning)
+                    # Try to spin again, should raise an exception
+                    with self.assertRaises(RuntimeError):
+                        executor.spin()
+                    # Shutdown the executor to stop the background thread
+                    executor.shutdown()
+                    t.join(timeout=1.0)
+                finally:
+                    executor.shutdown()
+
+    def test_spinning_multiple_times_spin_once(self) -> None:
+        self.assertIsNotNone(self.node.handle)
+        # Test all executor types including base Executor class
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                try:
+                    executor.add_node(self.node)
+
+                    # Start spinning in a background thread
+                    def spin_thread():
+                        executor.spin_once(timeout_sec=10.0)
+
+                    t = threading.Thread(target=spin_thread, daemon=True)
+                    t.start()
+                    # Give the executor time to start spinning
+                    time.sleep(1.0)
+                    # Check that executor is spinning
+                    self.assertTrue(executor.is_spinning)
+                    # Try to spin again, should raise an exception
+                    with self.assertRaises(RuntimeError):
+                        executor.spin_once(timeout_sec=1.0)
+                    # Wait for the background thread to complete
+                    t.join(timeout=1.0)
+                    executor.shutdown()
+                finally:
+                    executor.shutdown()
+
+    def test_spinning_multiple_times_spin_until_future_complete(self) -> None:
+        self.assertIsNotNone(self.node.handle)
+        # Test all executor types including base Executor class
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                try:
+                    executor.add_node(self.node)
+                    future = executor.create_future()
+
+                    # Start spinning in a background thread
+                    def spin_thread():
+                        executor.spin_until_future_complete(future, timeout_sec=10.0)
+
+                    t = threading.Thread(target=spin_thread, daemon=True)
+                    t.start()
+                    # Give the executor time to start spinning
+                    time.sleep(1.0)
+                    # Check that executor is spinning
+                    self.assertTrue(executor.is_spinning)
+                    # Try to spin again, should raise an exception
+                    with self.assertRaises(RuntimeError):
+                        executor.spin_until_future_complete(future, timeout_sec=1.0)
+                    # Complete the future and shutdown
+                    future.set_result(True)
+                    t.join(timeout=1.0)
+                    executor.shutdown()
+                finally:
+                    executor.shutdown()
+
+    def test_spinning_multiple_times_spin_once_until_future_complete(self) -> None:
+        self.assertIsNotNone(self.node.handle)
+        # Test all executor types including base Executor class
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                try:
+                    executor.add_node(self.node)
+                    future = executor.create_future()
+
+                    # Start spinning in a background thread
+                    def spin_thread():
+                        executor.spin_once_until_future_complete(future, timeout_sec=10.0)
+
+                    t = threading.Thread(target=spin_thread, daemon=True)
+                    t.start()
+                    # Give the executor time to start spinning
+                    time.sleep(1.0)
+                    # Check that executor is spinning
+                    self.assertTrue(executor.is_spinning)
+                    # Try to spin again, should raise an exception
+                    with self.assertRaises(RuntimeError):
+                        executor.spin_once_until_future_complete(future, timeout_sec=1.0)
+                    # Complete the future and shutdown
+                    future.set_result(True)
+                    t.join(timeout=1.0)
+                    executor.shutdown()
+                finally:
+                    executor.shutdown()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Follow up of https://github.com/ros2/rclpy/pull/1477#pullrequestreview-2959571638

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Possibly yes, it explicitly throws the exception on the 2nd spin call if the executor is already spinning.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
