### PR TITLE
Fixes Action.*_async futures never complete (#1308)

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -243,7 +243,9 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
         self._node.add_waitable(self)
         self._logger = self._node.get_logger().get_child('action_client')
 
-    def _generate_random_uuid(self) -> UUID:
+        self._lock = threading.Lock()
+
+    def _generate_random_uuid(self):
         return UUID(uuid=list(uuid.uuid4().bytes))
 
     def _remove_pending_request(self, future: Future[T], pending_requests: Dict[int, Future[T]]
@@ -306,39 +308,44 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         data: 'ClientGoalHandleDict[ResultT, FeedbackT]' = {}
         if self._is_goal_response_ready:
-            taken_goal_data = self._client_handle.take_goal_response(
-                self._action_type.Impl.SendGoalService.Response)
-            # If take fails, then we get (None, None)
-            if taken_goal_data[0]:
-                data['goal'] = taken_goal_data
+            with self._lock:
+                taken_goal_data = self._client_handle.take_goal_response(
+                    self._action_type.Impl.SendGoalService.Response)
+                # If take fails, then we get (None, None)
+                if taken_goal_data[0]:
+                    data['goal'] = taken_goal_data
 
         if self._is_cancel_response_ready:
-            taken_cancel_data = self._client_handle.take_cancel_response(
-                self._action_type.Impl.CancelGoalService.Response)
-            # If take fails, then we get (None, None)
-            if taken_cancel_data[0]:
-                data['cancel'] = taken_cancel_data
+            with self._lock:
+                taken_cancel_data = self._client_handle.take_cancel_response(
+                    self._action_type.Impl.CancelGoalService.Response)
+                # If take fails, then we get (None, None)
+                if taken_cancel_data[0]:
+                    data['cancel'] = taken_cancel_data
 
         if self._is_result_response_ready:
-            taken_result_data = self._client_handle.take_result_response(
-                self._action_type.Impl.GetResultService.Response)
-            # If take fails, then we get (None, None)
-            if taken_result_data[0]:
-                data['result'] = taken_result_data
+            with self._lock:
+                taken_result_data = self._client_handle.take_result_response(
+                    self._action_type.Impl.GetResultService.Response)
+                # If take fails, then we get (None, None)
+                if taken_result_data[0]:
+                    data['result'] = taken_result_data
 
         if self._is_feedback_ready:
-            taken_feedback_data = self._client_handle.take_feedback(
-                self._action_type.Impl.FeedbackMessage)
-            # If take fails, then we get None
-            if taken_feedback_data is not None:
-                data['feedback'] = taken_feedback_data
+            with self._lock:
+                taken_feedback_data = self._client_handle.take_feedback(
+                    self._action_type.Impl.FeedbackMessage)
+                # If take fails, then we get None
+                if taken_feedback_data is not None:
+                    data['feedback'] = taken_feedback_data
 
         if self._is_status_ready:
-            taken_status_data = self._client_handle.take_status(
-                self._action_type.Impl.GoalStatusMessage)
-            # If take fails, then we get None
-            if taken_status_data is not None:
-                data['status'] = taken_status_data
+            with self._lock:
+                taken_status_data = self._client_handle.take_status(
+                    self._action_type.Impl.GoalStatusMessage)
+                # If take fails, then we get None
+                if taken_status_data is not None:
+                    data['status'] = taken_status_data
 
         return data
 
@@ -419,12 +426,14 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
 
     def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used in the wait set."""
-        num_entities = self._client_handle.get_num_entities()
+        with self._lock:
+            num_entities = self._client_handle.get_num_entities()
         return NumberOfEntities(*num_entities)
 
     def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         """Add entities to wait set."""
-        self._client_handle.add_to_waitset(wait_set)
+        with self._lock:
+            self._client_handle.add_to_waitset(wait_set)
 
     def __enter__(self) -> None:
         self._client_handle.__enter__()
@@ -515,10 +524,17 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
         request = self._action_type.Impl.SendGoalService.Request()
         request.goal_id = self._generate_random_uuid() if goal_uuid is None else goal_uuid
         request.goal = goal
-        sequence_number = self._client_handle.send_goal_request(request)
-        if sequence_number in self._pending_goal_requests:
-            raise RuntimeError(
-                'Sequence ({}) conflicts with pending goal request'.format(sequence_number))
+        future = Future()
+        with self._lock:
+            sequence_number = self._client_handle.send_goal_request(request)
+            if sequence_number in self._pending_goal_requests:
+                raise RuntimeError(
+                    'Sequence ({}) conflicts with pending goal request'.format(sequence_number))
+            self._pending_goal_requests[sequence_number] = future
+            self._goal_sequence_number_to_goal_id[sequence_number] = request.goal_id
+            future.add_done_callback(self._remove_pending_goal_request)
+            # Add future so executor is aware
+            self.add_future(future)
 
         if feedback_callback is not None:
             # TODO(jacobperron): Move conversion function to a general-use package
@@ -578,16 +594,17 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
 
         cancel_request = CancelGoal.Request()
         cancel_request.goal_info.goal_id = goal_handle.goal_id
-        sequence_number = self._client_handle.send_cancel_request(cancel_request)
-        if sequence_number in self._pending_cancel_requests:
-            raise RuntimeError(
-                'Sequence ({}) conflicts with pending cancel request'.format(sequence_number))
-
         future: Future[CancelGoal.Response] = Future()
-        self._pending_cancel_requests[sequence_number] = future
-        future.add_done_callback(self._remove_pending_cancel_request)
-        # Add future so executor is aware
-        self.add_future(future)
+        with self._lock:
+            sequence_number = self._client_handle.send_cancel_request(cancel_request)
+            if sequence_number in self._pending_cancel_requests:
+                raise RuntimeError(
+                    'Sequence ({}) conflicts with pending cancel request'.format(sequence_number))
+
+            self._pending_cancel_requests[sequence_number] = future
+            future.add_done_callback(self._remove_pending_cancel_request)
+            # Add future so executor is aware
+            self.add_future(future)
 
         return future
 
@@ -633,17 +650,18 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
 
         result_request = self._action_type.Impl.GetResultService.Request()
         result_request.goal_id = goal_handle.goal_id
-        sequence_number = self._client_handle.send_result_request(result_request)
-        if sequence_number in self._pending_result_requests:
-            raise RuntimeError(
-                'Sequence ({}) conflicts with pending result request'.format(sequence_number))
-
         future: Future[GetResultServiceResponse[ResultT]] = Future()
-        self._pending_result_requests[sequence_number] = future
-        self._result_sequence_number_to_goal_id[sequence_number] = result_request.goal_id
-        future.add_done_callback(self._remove_pending_result_request)
-        # Add future so executor is aware
-        self.add_future(future)
+        with self._lock:
+            sequence_number = self._client_handle.send_result_request(result_request)
+            if sequence_number in self._pending_result_requests:
+                raise RuntimeError(
+                    'Sequence ({}) conflicts with pending result request'.format(sequence_number))
+
+            self._pending_result_requests[sequence_number] = future
+            self._result_sequence_number_to_goal_id[sequence_number] = result_request.goal_id
+            future.add_done_callback(self._remove_pending_result_request)
+            # Add future so executor is aware
+            self.add_future(future)
 
         return future
 

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -365,7 +365,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT], Waitable['ServerGoalHandl
         try:
             # If the client goes away anytime before this, sending the goal response may fail.
             # Catch the exception here and go on so we don't crash.
-            self._handle.send_goal_response(request_header, response_msg)
+            with self._lock:
+                self._handle.send_goal_response(request_header, response_msg)
         except RCLError:
             self._logger.warn('Failed to send goal response (the client may have gone away)')
             return
@@ -455,7 +456,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT], Waitable['ServerGoalHandl
         try:
             # If the client goes away anytime before this, sending the goal response may fail.
             # Catch the exception here and go on so we don't crash.
-            self._handle.send_cancel_response(request_header, cancel_response)
+            with self._lock:
+                self._handle.send_cancel_response(request_header, cancel_response)
         except RCLError:
             self._logger.warn('Failed to send cancel response (the client may have gone away)')
 
@@ -476,7 +478,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT], Waitable['ServerGoalHandl
                 'Sending result response for unknown or expired goal ID: {0}'.format(goal_uuid))
             result_response = self._action_type.Impl.GetResultService.Response()
             result_response.status = GoalStatus.STATUS_UNKNOWN
-            self._handle.send_result_response(request_header, result_response)
+            with self._lock:
+                self._handle.send_result_response(request_header, result_response)
             return
 
         # There is an accepted goal matching the goal ID, register a callback to send the
@@ -502,7 +505,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT], Waitable['ServerGoalHandl
             # Catch the exception here and go on so we don't crash.
             result = future.result()
             if result:
-                self._handle.send_result_response(request_header, result)
+                with self._lock:
+                    self._handle.send_result_response(request_header, result)
         except RCLError:
             self._logger.warning('Failed to send result response (the client may have gone away)')
 
@@ -578,7 +582,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT], Waitable['ServerGoalHandl
 
     def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used in the wait set."""
-        num_entities = self._handle.get_num_entities()
+        with self._lock:
+            num_entities = self._handle.get_num_entities()
         return NumberOfEntities(
             num_entities[0],
             num_entities[1],


### PR DESCRIPTION
This is a manual backport which supersedes  https://github.com/ros2/rclpy/pull/1516.
If two separate client server actions are running in separate executors the future given to the ActionClient will never complete due to a race condition on the rcl handles

Tested using [this](https://github.com/ros2/rclpy/issues/1123#issuecomment-1664959346) from @apockill which was adapted to match rolling then test with and without locks

To reproduce initial issue remove the lock/sleep in the RaceyAction client
<details>
<summary>Adapted example Code here</summary>
<br>

**client.py**

```python
import rclpy
from rclpy import Future
from rclpy.action import ActionClient
from rclpy.action.client import ClientGoalHandle
from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
from rclpy.executors import MultiThreadedExecutor
from rclpy.node import Node

from test_msgs.action import Fibonacci as SomeMsg
from time import sleep

class RaceyActionClient(ActionClient):
    def _get_result_async(self, goal_handle):
        """
        Request the result for an active goal asynchronously.

        :param goal_handle: Handle to the goal to cancel.
        :type goal_handle: :class:`ClientGoalHandle`
        :return: a Future instance that completes when the get result request has been processed.
        :rtype: :class:`rclpy.task.Future` instance
        """
        if not isinstance(goal_handle, ClientGoalHandle):
            raise TypeError(
                'Expected type ClientGoalHandle but received {}'.format(type(goal_handle)))

        result_request = self._action_type.Impl.GetResultService.Request()
        result_request.goal_id = goal_handle.goal_id
        future = Future()
        with self._lock:
            sleep(1)
            sequence_number = self._client_handle.send_result_request(result_request)
            if sequence_number in self._pending_result_requests:
                raise RuntimeError(
                    'Sequence ({}) conflicts with pending result request'.format(sequence_number))
            sleep(1)
            self._pending_result_requests[sequence_number] = future
            sleep(1)
            self._result_sequence_number_to_goal_id[sequence_number] = result_request.goal_id
            sleep(1)
            future.add_done_callback(self._remove_pending_result_request)
            sleep(1)
            # Add future so executor is aware
            self.add_future(future)

        return future

class SomeActionClient(Node):
    def __init__(self):
        super().__init__("action_client")
        self._action_client = RaceyActionClient(
            self,
            SomeMsg,
            "some_action",
            callback_group=MutuallyExclusiveCallbackGroup(),
        )
        self.call_action_timer = self.create_timer(
            timer_period_sec=10,
            callback=self.send_goal,
            callback_group=MutuallyExclusiveCallbackGroup(),
        )

    def send_goal(self):
        goal_msg = SomeMsg.Goal()
        # self._action_client.wait_for_server()
        result = self._action_client.send_goal(goal_msg)
        print(result)


def main(args=None):
    rclpy.init(args=args)

    action_client = SomeActionClient()

    executor = MultiThreadedExecutor()
    rclpy.spin(action_client, executor)

if __name__ == "__main__":
    main()
```

**server.py**
```python
import rclpy
from rclpy.action import ActionServer
from rclpy.node import Node

from test_msgs.action import Fibonacci as SomeMsg


class SomeActionServer(Node):
    def __init__(self):
        super().__init__("fibonacci_action_server")
        self._action_server = ActionServer(
            self, SomeMsg, "some_action", self.execute_callback
        )

    def execute_callback(self, goal_handle):
        self.get_logger().info("Executing goal...")
        result = SomeMsg.Result()
        goal_handle.succeed()
        return result


def main(args=None):
    rclpy.init(args=args)

    action_server = SomeActionServer()
    rclpy.spin(action_server)


if __name__ == "__main__":
    main()
```

</details>

<details>
<summary>Before and after log results</summary>
<br>

**Before**
client output
```
[WARN] [1720739707.125040450] [action_client.action_client]: Ignoring unexpected result response. There may be more than one action server for the action 'some_action'
^C
```
server output
```
[INFO] [1720739706.054013974] [fibonacci_action_server]: Executing goal...
^C
```

**After**
client output
```
[INFO] [1720739524.873096289] [fibonacci_action_server]: Executing goal...
[INFO] [1720739534.791491183] [fibonacci_action_server]: Executing goal...
[INFO] [1720739544.789914632] [fibonacci_action_server]: Executing goal...
[INFO] [1720739554.791130534] [fibonacci_action_server]: Executing goal...
[INFO] [1720739564.791638162] [fibonacci_action_server]: Executing goal...
[INFO] [1720739574.793290290] [fibonacci_action_server]: Executing goal...
[INFO] [1720739584.790164903] [fibonacci_action_server]: Executing goal...
[INFO] [1720739594.794427458] [fibonacci_action_server]: Executing goal...
^C
```

```
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
test_msgs.action.Fibonacci_GetResult_Response(status=4, result=test_msgs.action.Fibonacci_Result(sequence=[]))
^C
```

</details>

I also initially tried to add locks to just the action client, but I was getting test failures in test_action_graph on the get_names_and_types function, so I added for action server as well.
