### PR TITLE
remove unused 'param_type'

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -498,7 +498,6 @@ class Node:
                 )
 
             value = None
-            param_type = None
 
             # Get the values from the tuple, checking its types.
             # Use defaults if the tuple doesn't contain value and / or descriptor.


### PR DESCRIPTION
## Description

`param_type` is set but never used

Fixes # (issue)

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
