### PR TITLE
Compatiblity with 'Populate Transitions' ros2/rcl#1269

### DIFF
--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -126,9 +126,11 @@ class LifecycleNodeMixin(ManagedEntity):
             # this doesn't only checks, but also imports some stuff we need later
             check_is_valid_srv_type(srv_type)
 
+        clock = self.get_clock()
+
         with self.handle:
             self._state_machine: _rclpy.LifecycleStateMachine = _rclpy.LifecycleStateMachine(
-                self.handle, enable_communication_interface)
+                self.handle, clock.handle, enable_communication_interface)
         if enable_communication_interface:
             self._service_change_state = Service(
                 self._state_machine.service_change_state,


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Compatibility with ros2/rcl#1269

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, the timestamp and transition field of a lifecycle_msg/TransitionEvent will be filled.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Requires ros2/rcl#1269
