### PR TITLE
ParameterEventHandler support ContentFiltering

### DIFF
--- a/rclpy/rclpy/parameter_event_handler.py
+++ b/rclpy/rclpy/parameter_event_handler.py
@@ -297,6 +297,10 @@ class ParameterEventHandler:
 
         Callbacks are called in FILO manner.
 
+        The configure_nodes_filter() function will affect the behavior of this function.
+        If the node specified in this function isn't included in the nodes specified in
+        configure_nodes_filter(), the callback will never be called.
+
         :param parameter_name: Name of a parameter to tie callback to
         :param node_name: Name of a node, that the parameter should be related to
         :param callback: A callable to be called when the parameter is modified
@@ -359,7 +363,7 @@ class ParameterEventHandler:
         """
         Configure which node parameter events will be received.
 
-        This function depends on middleware support for content filtering.
+        This function depends on rmw implementation support for content filtering.
         If middleware doesn't support contentfilter, return false.
 
         If node_names is empty, the configured node filter will be cleared.
@@ -379,10 +383,13 @@ class ParameterEventHandler:
         :param node_names: Node names to filter parameter events from
 
         :return: True if the filter was successfully applied, False otherwise.
+        :raises: RCLError if internal error occurred when calling the rcl function.
         """
         if node_names is None or len(node_names) == 0:
             # Clear content filter
             self.parameter_event_subscription.set_content_filter('', [])
+            if (self.parameter_event_subscription.is_cft_enabled is True):
+                return False
             return True
 
         filter_expression = ' OR '.join([f'node = %{i}' for i in range(len(node_names))])

--- a/rclpy/rclpy/parameter_event_handler.py
+++ b/rclpy/rclpy/parameter_event_handler.py
@@ -352,6 +352,48 @@ class ParameterEventHandler:
         """
         self._callbacks.remove_parameter_event_callback(handle)
 
+    def configure_nodes_filter(
+        self,
+        node_names: Optional[List[str]] = None,
+    ) -> bool:
+        """
+        Configure which node parameter events will be received.
+
+        This function depends on middleware support for content filtering.
+        If middleware doesn't support contentfilter, return false.
+
+        If node_names is empty, the configured node filter will be cleared.
+
+        If this function return true, only parameter events from the specified node will be
+        received.
+        It affects the behavior of the following two functions.
+        - add_parameter_event_callback()
+          The callback will only be called for parameter events from the specified nodes which are
+          configured in this function.
+        - add_parameter_callback()
+          The callback will only be called for parameter events from the specified nodes which are
+          configured in this function and add_parameter_callback().
+          If the nodes specified in this function is different from the nodes specified in
+          add_parameter_callback(), the callback will never be called.
+
+        :param node_names: Node names to filter parameter events from
+
+        :return: True if the filter was successfully applied, False otherwise.
+        """
+        if node_names is None or len(node_names) == 0:
+            # Clear content filter
+            self.parameter_event_subscription.set_content_filter('', [])
+            return True
+
+        filter_expression = ' OR '.join([f'node = %{i}' for i in range(len(node_names))])
+
+        # Enclose each node name in "'"
+        quoted_node_names = [f"'{node_name}'" for node_name in node_names]
+
+        self.parameter_event_subscription.set_content_filter(filter_expression, quoted_node_names)
+
+        return self.parameter_event_subscription.is_cft_enabled
+
     def _resolve_path(
         self,
         node_path: Optional[str] = None,


### PR DESCRIPTION
## Description

Implement this feature ros2/rclcpp#2957 for rclpy

### Is this user-facing behavior change?

In `ParameterEventHandler`,  
New API `configure_nodes_filter` affects the behavior of the following two functions.

- add_parameter_event_callback()

    The callback will only be called for parameter events from the specified nodes which are configured in this function.

- add_parameter_callback()

    The callback will only be called for parameter events from the specified nodes which are configured in this function and add_parameter_callback().
    If the nodes specified in this function are different from the nodes specified in add_parameter_callback(), the callback will never be called.

### Did you use Generative AI?

No

### Additional Information

No
