### PR TITLE
fix(test_events_executor): destroy all nodes before shutdown

### DIFF
--- a/rclpy/test/test_events_executor.py
+++ b/rclpy/test/test_events_executor.py
@@ -448,6 +448,11 @@ class TestEventsExecutor(unittest.TestCase):
         self.executor = rclpy.experimental.EventsExecutor()
 
     def tearDown(self) -> None:
+        # Clean up all nodes still in the executor before shutdown
+        for node in self.executor.get_nodes():
+            self.executor.remove_node(node)
+            node.destroy_node()
+        self.executor.shutdown()
         rclpy.shutdown()
 
     def _expect_future_done(self, future: rclpy.Future[typing.Any]) -> None:


### PR DESCRIPTION
## Description

This closes https://github.com/ros2/rmw_zenoh/issues/852. rmw_zenoh failed to pass the test since the publisher declared in `test_async_sub` was accidentally detected by the subsequent `test_pub_sub` (the tests run in alphabetical order). The root cause is that the publisher node is not explicitly destroyed during the rclpy shutdown. 

To clarify, this behavior stems from the different mechanism used in rmw_zenoh compared to other DDS implementations. Specifically, the shutdown of rmw_zenoh doesn't immediately close the Zenoh session as long as other nodes are still alive. This aligns with the RMW philosophy that nodes and their associated entities such as publishers, subscriptions, and so on, are not explicitly destroyed by rmw_shutdown.

Introduing a sleep after `rclpy.shutdown` does not solve the issue because the node data remain referenced until the object destruction phase. Meanwhile, the next test begins immediately and reads the stale liveliness token, causing the test to fail.

This fix adotps the approach used in other tests by explicitly cleaning up the nodes to avoid such stale references. 

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->



### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

- Tested on rmw_zenoh [15915cb28fd732e76b269eab90e87c8f0c13f0a5 ](https://github.com/ros2/rmw_zenoh/commit/15915cb28fd732e76b269eab90e87c8f0c13f0a5)