### PR TITLE
Improve the compatibility of processing YAML parameter files

### DIFF
--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -369,7 +369,9 @@ def parameter_dict_from_yaml_file(
     """
     Build a dict of parameters from a YAML file.
 
-    Will load all parameters if ``target_nodes`` is None or empty.
+    if ``target_nodes`` is None or empty,
+    - ``use_wildcard`` is False, no parameters will be loaded from the file.
+    - ``use_wildcard`` is True, parameters under the wildcard (/**) will be loaded.
 
     :raises RuntimeError: if a target node is not in the file
     :raises RuntimeError: if the is not a valid ROS parameter file
@@ -422,6 +424,55 @@ def parameter_dict_from_yaml_file(
                         if not isinstance(value, dict) and 'ros__parameters' not in value:
                             raise RuntimeError('YAML file is not a valid ROS parameter '
                                                f'file for namespace {ns} node {node_basename}')
+                        param_dict.update(value['ros__parameters'])
+
+                    # '/*' as namespace wildcard in parameter file
+                    if '/*' in param_file.keys() and '/' not in ns[1:]:
+                        # ignore namespace (e.g. /abc)
+                        # Found node_basename defined in parameter file like
+                        # /*:
+                        #   node_name:
+                        #     ros__parameters:
+                        #       ...
+                        if node_basename in param_file['/*'].keys():
+                            value = param_file['/*'][node_basename]
+                            if not isinstance(value, dict) and 'ros__parameters' not in value:
+                                raise RuntimeError('YAML file is not a valid ROS parameter '
+                                                   f'file for namespace /* node {node_basename}')
+                            param_dict.update(value['ros__parameters'])
+
+                    # '/**' in target node name and match any namespace in parameter file
+                    if ns == '/**':
+                        for k1, v1 in param_file.items():
+                            if isinstance(v1, dict):
+                                if 'ros__parameters' in v1.keys():
+                                    if '/' in k1:
+                                        # key is node_name with namespace
+                                        node_name = k1.rsplit('/', 1)[1]
+                                    else:
+                                        # key is node_name without namespace
+                                        node_name = k1
+                                    if node_name == node_basename:
+                                        param_dict.update(v1['ros__parameters'])
+                                else:
+                                    # k1 is namespace
+                                    for k2, v2 in v1.items():
+                                        if 'ros__parameters' in v2.keys():
+                                            if k2 == node_basename:
+                                                param_dict.update(v2['ros__parameters'])
+
+            # Handle cases where any namespace definition is ignored
+            # parameter file like:
+            # /**/node_name:
+            #   ros__parameters:
+            #     ...
+            for key, value in param_file.items():
+                if key.startswith('/**/'):
+                    node_basename = key.rsplit('/', 1)[1]
+                    if node_basename in [n.rsplit('/', 1)[-1] for n in target_nodes]:
+                        if not isinstance(value, dict) and 'ros__parameters' not in value:
+                            raise RuntimeError('YAML file is not a valid ROS parameter '
+                                               f'file for node {key}')
                         param_dict.update(value['ros__parameters'])
 
         if not param_dict:

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -426,8 +426,9 @@ def parameter_dict_from_yaml_file(
                                                f'file for namespace {ns} node {node_basename}')
                         param_dict.update(value['ros__parameters'])
 
-                    # '/*' as namespace wildcard in parameter file
-                    if '/*' in param_file.keys() and '/' not in ns[1:]:
+                    # '/*' as namespace wildcard in parameter file and single-level namespace in
+                    # target node name (e.g. /abc/node_name)
+                    if use_wildcard and '/*' in param_file.keys() and '/' not in ns[1:]:
                         # Match single-level namespace in node name (e.g. /abc)
                         # Found node_basename defined in parameter file like
                         # /*:
@@ -441,40 +442,21 @@ def parameter_dict_from_yaml_file(
                                                    f'file for namespace /* node {node_basename}')
                             param_dict.update(value['ros__parameters'])
 
-                    # '/**' in target node name and match any namespace in parameter file
-                    if ns == '/**':
-                        for k1, v1 in param_file.items():
-                            if isinstance(v1, dict):
-                                if 'ros__parameters' in v1.keys():
-                                    if '/' in k1:
-                                        # key is node_name with namespace
-                                        node_name = k1.rsplit('/', 1)[1]
-                                    else:
-                                        # key is node_name without namespace
-                                        node_name = k1
-                                    if node_name == node_basename:
-                                        param_dict.update(v1['ros__parameters'])
-                                else:
-                                    # k1 is namespace
-                                    for k2, v2 in v1.items():
-                                        if isinstance(v2, dict) and 'ros__parameters' in v2.keys():
-                                            if k2 == node_basename:
-                                                param_dict.update(v2['ros__parameters'])
-
             # Handle cases where any namespace definition is ignored
             # parameter file like:
             # /**/node_name:
             #   ros__parameters:
             #     ...
-            target_node_basenames = [n.rsplit('/', 1)[-1] for n in target_nodes]
-            for key, value in param_file.items():
-                if key.startswith('/**/'):
-                    node_basename = key.rsplit('/', 1)[-1]
-                    if node_basename in target_node_basenames:
-                        if not isinstance(value, dict) or 'ros__parameters' not in value:
-                            raise RuntimeError('YAML file is not a valid ROS parameter '
-                                               f'file for node {key}')
-                        param_dict.update(value['ros__parameters'])
+            if use_wildcard:
+                target_node_basenames = [n.rsplit('/', 1)[-1] for n in target_nodes]
+                for key, value in param_file.items():
+                    if key.startswith('/**/'):
+                        node_basename = key.rsplit('/', 1)[-1]
+                        if node_basename in target_node_basenames:
+                            if not isinstance(value, dict) or 'ros__parameters' not in value:
+                                raise RuntimeError('YAML file is not a valid ROS parameter '
+                                                   f'file for node {key}')
+                            param_dict.update(value['ros__parameters'])
 
         if not param_dict:
             raise RuntimeError('Param file does not contain any valid parameters')

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -369,7 +369,7 @@ def parameter_dict_from_yaml_file(
     """
     Build a dict of parameters from a YAML file.
 
-    if ``target_nodes`` is None or empty,
+    If ``target_nodes`` is None or empty,
     - ``use_wildcard`` is False, no parameters will be loaded from the file.
     - ``use_wildcard`` is True, parameters under the wildcard (/**) will be loaded.
 
@@ -428,7 +428,7 @@ def parameter_dict_from_yaml_file(
 
                     # '/*' as namespace wildcard in parameter file
                     if '/*' in param_file.keys() and '/' not in ns[1:]:
-                        # ignore namespace (e.g. /abc)
+                        # Match single-level namespace in node name (e.g. /abc)
                         # Found node_basename defined in parameter file like
                         # /*:
                         #   node_name:
@@ -436,7 +436,7 @@ def parameter_dict_from_yaml_file(
                         #       ...
                         if node_basename in param_file['/*'].keys():
                             value = param_file['/*'][node_basename]
-                            if not isinstance(value, dict) and 'ros__parameters' not in value:
+                            if not isinstance(value, dict) or 'ros__parameters' not in value:
                                 raise RuntimeError('YAML file is not a valid ROS parameter '
                                                    f'file for namespace /* node {node_basename}')
                             param_dict.update(value['ros__parameters'])
@@ -457,7 +457,7 @@ def parameter_dict_from_yaml_file(
                                 else:
                                     # k1 is namespace
                                     for k2, v2 in v1.items():
-                                        if 'ros__parameters' in v2.keys():
+                                        if isinstance(v2, dict) and 'ros__parameters' in v2.keys():
                                             if k2 == node_basename:
                                                 param_dict.update(v2['ros__parameters'])
 
@@ -466,11 +466,12 @@ def parameter_dict_from_yaml_file(
             # /**/node_name:
             #   ros__parameters:
             #     ...
+            target_node_basenames = [n.rsplit('/', 1)[-1] for n in target_nodes]
             for key, value in param_file.items():
                 if key.startswith('/**/'):
-                    node_basename = key.rsplit('/', 1)[1]
-                    if node_basename in [n.rsplit('/', 1)[-1] for n in target_nodes]:
-                        if not isinstance(value, dict) and 'ros__parameters' not in value:
+                    node_basename = key.rsplit('/', 1)[-1]
+                    if node_basename in target_node_basenames:
+                        if not isinstance(value, dict) or 'ros__parameters' not in value:
                             raise RuntimeError('YAML file is not a valid ROS parameter '
                                                f'file for node {key}')
                         param_dict.update(value['ros__parameters'])

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -369,9 +369,7 @@ def parameter_dict_from_yaml_file(
     """
     Build a dict of parameters from a YAML file.
 
-    If ``target_nodes`` is None or empty,
-    - ``use_wildcard`` is False, no parameters will be loaded from the file.
-    - ``use_wildcard`` is True, parameters under the wildcard (/**) will be loaded.
+    Will load all parameters if ``target_nodes`` is None or empty.
 
     :raises RuntimeError: if a target node is not in the file
     :raises RuntimeError: if the is not a valid ROS parameter file

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -424,11 +424,11 @@ class TestParameter(unittest.TestCase):
                 assert parameter_dict == expected_target_node_single_ns
                 with pytest.raises(RuntimeError,
                                    match='Param file does not contain any valid parameters'):
-                    parameter_dict = parameter_dict_from_yaml_file(
+                    parameter_dict_from_yaml_file(
                         f.name, False, target_nodes=['/abc/cde/param_test_target2'])
                 with pytest.raises(RuntimeError,
                                    match='Param file does not contain any valid parameters'):
-                    parameter_dict = parameter_dict_from_yaml_file(
+                    parameter_dict_from_yaml_file(
                         f.name, False, target_nodes=['param_test_target2'])
 
                 parameter_dict = parameter_dict_from_yaml_file(
@@ -439,8 +439,6 @@ class TestParameter(unittest.TestCase):
                 assert parameter_dict == expected_target_node_specified_ns_wildcard
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, True, target_nodes=['param_test_target3'])
-                import logging
-                logging.info(f'parameter_dict: {parameter_dict}')
                 assert parameter_dict == expected_target_node_without_ns_wildcard
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, False, target_nodes=['/**/param_test_target3'])

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -283,6 +283,24 @@ class TestParameter(unittest.TestCase):
             /**:
                 ros__parameters:
                     wildcard: true
+            /*:
+                param_test_target2:
+                    ros__parameters:
+                        single-namespace1: false
+            /**/param_test_target3:
+                ros__parameters:
+                    any-namespace1: true
+            /a1:
+                param_test_target2:
+                    ros__parameters:
+                        single-namespace2: true
+            /a2/b2/c2/d2:
+                param_test_target3:
+                    ros__parameters:
+                        any-namespace2: false
+            param_test_target3:
+                ros__parameters:
+                    any-namespace3: true
             """
 
         # target nodes is specified, so it should only parse wildcard
@@ -313,6 +331,70 @@ class TestParameter(unittest.TestCase):
             'abs-ns-base-nodename': Parameter(
                 'abs-ns-base-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
         }
+        # target node is specified with wildcard and single namespace (e.g. /abc/)
+        expected_target_node_single_ns_wildcard = {
+            'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'single-namespace1': Parameter(
+                'single-namespace1', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'single-namespace2': Parameter(
+                'single-namespace2', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # target node is specified with single namespace (e.g. /abc/)
+        expected_target_node_single_ns = {
+            'single-namespace1': Parameter(
+                'single-namespace1', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'single-namespace2': Parameter(
+                'single-namespace2', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # target node is specified with wildcard and any namespace (e.g. /abc/cde/)
+        expected_target_node_any_ns_wildcard = {
+            'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace1': Parameter(
+                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace2': Parameter(
+                'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'any-namespace3': Parameter(
+                'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # target node is specified with any namespace (e.g. /abc/cde/)
+        expected_target_node_any_ns = {
+            'any-namespace1': Parameter(
+                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace2': Parameter(
+                'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'any-namespace3': Parameter(
+                'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # target node is specified with wildcard and namespace /a2/b2/c2/d2/
+        expected_target_node_specified_ns_wildcard = {
+            'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace1': Parameter(
+                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace2': Parameter(
+                'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
+        }
+        # target node is specified with namespace /a2/b2/c2/d2/
+        expected_target_node_specified_ns = {
+            'any-namespace1': Parameter(
+                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace2': Parameter(
+                'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
+        }
+        # target node is specified with wildcard and without namespace
+        expected_target_node_without_ns_wildcard = {
+            'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace3': Parameter(
+                'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace1': Parameter(
+                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # target node is specified without namespace
+        expected_target_node_without_ns = {
+            'any-namespace3': Parameter(
+                'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'any-namespace1': Parameter(
+                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
 
         try:
             with NamedTemporaryFile(mode='w', delete=False) as f:
@@ -333,6 +415,43 @@ class TestParameter(unittest.TestCase):
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, True, target_nodes=['/foo/param_test_target'])
                 assert parameter_dict == expected_target_node_ns
+
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, True, target_nodes=['/a1/param_test_target2'])
+                assert parameter_dict == expected_target_node_single_ns_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, False, target_nodes=['/a1/param_test_target2'])
+                assert parameter_dict == expected_target_node_single_ns
+                with pytest.raises(RuntimeError,
+                                   match='Param file does not contain any valid parameters'):
+                    parameter_dict = parameter_dict_from_yaml_file(
+                        f.name, False, target_nodes=['/abc/cde/param_test_target2'])
+                with pytest.raises(RuntimeError,
+                                   match='Param file does not contain any valid parameters'):
+                    parameter_dict = parameter_dict_from_yaml_file(
+                        f.name, False, target_nodes=['param_test_target2'])
+
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, True, target_nodes=['/**/param_test_target3'])
+                assert parameter_dict == expected_target_node_any_ns_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, True, target_nodes=['/a2/b2/c2/d2/param_test_target3'])
+                assert parameter_dict == expected_target_node_specified_ns_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, True, target_nodes=['param_test_target3'])
+                import logging
+                logging.info(f'parameter_dict: {parameter_dict}')
+                assert parameter_dict == expected_target_node_without_ns_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, False, target_nodes=['/**/param_test_target3'])
+                assert parameter_dict == expected_target_node_any_ns
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, False, target_nodes=['/a2/b2/c2/d2/param_test_target3'])
+                assert parameter_dict == expected_target_node_specified_ns
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, False, target_nodes=['param_test_target3'])
+                assert parameter_dict == expected_target_node_without_ns
+
         finally:
             if os.path.exists(f.name):
                 os.unlink(f.name)

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -286,14 +286,17 @@ class TestParameter(unittest.TestCase):
             /*:
                 param_test_target2:
                     ros__parameters:
-                        single-namespace1: false
+                        single-level-namespace1: false
             /**/param_test_target3:
                 ros__parameters:
                     any-namespace1: true
             /a1:
                 param_test_target2:
                     ros__parameters:
-                        single-namespace2: true
+                        single-level-namespace2: true
+            /**/param_test_target2:
+                ros__parameters:
+                    single-level-namespace3: false
             /a2/b2/c2/d2:
                 param_test_target3:
                     ros__parameters:
@@ -331,41 +334,22 @@ class TestParameter(unittest.TestCase):
             'abs-ns-base-nodename': Parameter(
                 'abs-ns-base-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
         }
-        # target node is specified with wildcard and single namespace (e.g. /abc/)
-        expected_target_node_single_ns_wildcard = {
+        # target node is specified with wildcard and single-level namespace (e.g. /abc/)
+        expected_target_node_single_level_ns_wildcard = {
             'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
-            'single-namespace1': Parameter(
-                'single-namespace1', Parameter.Type.BOOL, False).to_parameter_msg(),
-            'single-namespace2': Parameter(
-                'single-namespace2', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'single-level-namespace1': Parameter(
+                'single-level-namespace1', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'single-level-namespace2': Parameter(
+                'single-level-namespace2', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'single-level-namespace3': Parameter(
+                'single-level-namespace3', Parameter.Type.BOOL, False).to_parameter_msg(),
         }
-        # target node is specified with single namespace (e.g. /abc/)
-        expected_target_node_single_ns = {
-            'single-namespace1': Parameter(
-                'single-namespace1', Parameter.Type.BOOL, False).to_parameter_msg(),
-            'single-namespace2': Parameter(
-                'single-namespace2', Parameter.Type.BOOL, True).to_parameter_msg(),
+        # target node is specified with single-level namespace (e.g. /abc/)
+        expected_target_node_single_level_ns = {
+            'single-level-namespace2': Parameter(
+                'single-level-namespace2', Parameter.Type.BOOL, True).to_parameter_msg(),
         }
-        # target node is specified with wildcard and any namespace (e.g. /abc/cde/)
-        expected_target_node_any_ns_wildcard = {
-            'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
-            'any-namespace1': Parameter(
-                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
-            'any-namespace2': Parameter(
-                'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
-            'any-namespace3': Parameter(
-                'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
-        }
-        # target node is specified with any namespace (e.g. /abc/cde/)
-        expected_target_node_any_ns = {
-            'any-namespace1': Parameter(
-                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
-            'any-namespace2': Parameter(
-                'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
-            'any-namespace3': Parameter(
-                'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
-        }
-        # target node is specified with wildcard and namespace /a2/b2/c2/d2/
+        # target node is specified with wildcard and any namespace /a2/b2/c2/d2/
         expected_target_node_specified_ns_wildcard = {
             'wildcard': Parameter('wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
             'any-namespace1': Parameter(
@@ -373,10 +357,8 @@ class TestParameter(unittest.TestCase):
             'any-namespace2': Parameter(
                 'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
         }
-        # target node is specified with namespace /a2/b2/c2/d2/
+        # target node is specified with any namespace /a2/b2/c2/d2/
         expected_target_node_specified_ns = {
-            'any-namespace1': Parameter(
-                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
             'any-namespace2': Parameter(
                 'any-namespace2', Parameter.Type.BOOL, False).to_parameter_msg(),
         }
@@ -392,8 +374,6 @@ class TestParameter(unittest.TestCase):
         expected_target_node_without_ns = {
             'any-namespace3': Parameter(
                 'any-namespace3', Parameter.Type.BOOL, True).to_parameter_msg(),
-            'any-namespace1': Parameter(
-                'any-namespace1', Parameter.Type.BOOL, True).to_parameter_msg(),
         }
 
         try:
@@ -418,10 +398,10 @@ class TestParameter(unittest.TestCase):
 
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, True, target_nodes=['/a1/param_test_target2'])
-                assert parameter_dict == expected_target_node_single_ns_wildcard
+                assert parameter_dict == expected_target_node_single_level_ns_wildcard
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, False, target_nodes=['/a1/param_test_target2'])
-                assert parameter_dict == expected_target_node_single_ns
+                assert parameter_dict == expected_target_node_single_level_ns
                 with pytest.raises(RuntimeError,
                                    match='Param file does not contain any valid parameters'):
                     parameter_dict_from_yaml_file(
@@ -432,17 +412,11 @@ class TestParameter(unittest.TestCase):
                         f.name, False, target_nodes=['param_test_target2'])
 
                 parameter_dict = parameter_dict_from_yaml_file(
-                    f.name, True, target_nodes=['/**/param_test_target3'])
-                assert parameter_dict == expected_target_node_any_ns_wildcard
-                parameter_dict = parameter_dict_from_yaml_file(
                     f.name, True, target_nodes=['/a2/b2/c2/d2/param_test_target3'])
                 assert parameter_dict == expected_target_node_specified_ns_wildcard
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, True, target_nodes=['param_test_target3'])
                 assert parameter_dict == expected_target_node_without_ns_wildcard
-                parameter_dict = parameter_dict_from_yaml_file(
-                    f.name, False, target_nodes=['/**/param_test_target3'])
-                assert parameter_dict == expected_target_node_any_ns
                 parameter_dict = parameter_dict_from_yaml_file(
                     f.name, False, target_nodes=['/a2/b2/c2/d2/param_test_target3'])
                 assert parameter_dict == expected_target_node_specified_ns


### PR DESCRIPTION
## Description

Fixes #1546 
And also supports the following YAML parameter format

```yaml
/**/node_name:
   ros__parameters:
      ...
/*:
   node_name:
       ros__parameters:
          ...
```

### Is this user-facing behavior change?

Yes.  parameter_dict_from_yaml_file()  supports a more complete parameter file format (consistent with rcl_yaml_param_parser).


### Did you use Generative AI?

No

### Additional Information

