### PR TITLE
[Jazzy] Improve the compatibility of processing YAML parameter files

### DIFF
--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -461,7 +461,7 @@ def parameter_dict_from_yaml_file(
                                         param_dict.update(param_value['ros__parameters'])
                                     else:
                                         raise RuntimeError(
-                                            f'YAML file is not a valid ROS parameter file for node'
+                                            f'YAML file is not a valid ROS parameter file for node '
                                             f'{n}/{node_name}')
                                 continue
             raise RuntimeError(f'YAML file is not a valid ROS parameter file for node {n}')

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -367,7 +367,6 @@ def parameter_dict_from_yaml_file(
                 # /namespace/node_name:
                 #   ros__parameters:
                 #     ...
-                is_found = False
                 ns, node_name = n.rsplit('/', 1)
 
                 # If ns is single level namespace and wildcard is true
@@ -382,7 +381,6 @@ def parameter_dict_from_yaml_file(
                             'YAML file is not a valid ROS parameter file for namespace "/*"')
                     if node_name in param_file['/*']:
                         param_keys.append('/*#' + node_name)
-                        is_found = True
 
                 # If 'ns' in target node is single level or multi level namespace and
                 # wildcard is true,
@@ -392,7 +390,6 @@ def parameter_dict_from_yaml_file(
                 #     ...
                 if use_wildcard and '/**/' + node_name in param_file:
                     param_keys.append('/**/' + node_name)
-                    is_found = True
 
                 # If 'ns' in target node is single level or multi level namespace,
                 # Match definition in param file.
@@ -403,7 +400,6 @@ def parameter_dict_from_yaml_file(
                 if ns in param_file and isinstance(param_file[ns], dict):
                     if node_name in param_file[ns]:
                         param_keys.append(ns + '#' + node_name)
-                        is_found = True
 
                 # if 'ns' in target node is single level or multi level namespace,
                 # Match definition in param file.
@@ -412,13 +408,6 @@ def parameter_dict_from_yaml_file(
                 #     ...
                 if n in param_file:
                     param_keys.append(n)
-                    is_found = True
-
-                if is_found:
-                    continue
-
-                raise RuntimeError(f'Param file does not contain parameters for {n},'
-                                   f'only for nodes: {list(param_file.keys())} ')
         else:
             # wildcard key must go to the front of param_keys so that
             # node-namespaced parameters will override the wildcard parameters

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -298,30 +298,175 @@ def parameter_dict_from_yaml_file(
         param_keys = []
         param_dict = {}
 
-        if use_wildcard and '/**' in param_file:
-            param_keys.append('/**')
+        if use_wildcard:
+            if '/**' in param_file:
+                param_keys.append('/**')
+
+            if not target_nodes:
+                # /*
+                #   node_name:
+                #     ros__parameters:
+                #       ...
+                if '/*' in param_file:
+                    param_keys.append('/*')
+
+                # /**/node_name
+                #   ros__parameters:
+                #     ...
+                for k, v in param_file.items():
+                    if k.startswith('/**/'):
+                        param_keys.append(k)
 
         if target_nodes:
             for n in target_nodes:
-                if n not in param_file.keys():
-                    raise RuntimeError(f'Param file does not contain parameters for {n},'
-                                       f'only for nodes: {list(param_file.keys())} ')
-                param_keys.append(n)
+
+                # target node is 'node_name' without namespace
+                # Match definition in param file
+                # node_name:
+                #   ros__parameters:
+                #     ...
+                # or
+                # /node_name:
+                #   ros__parameters:
+                #     ...
+                if '/' not in n:
+                    is_found = False
+                    if n in param_file:
+                        param_keys.append(n)
+                        is_found = True
+                    if '/'+n in param_file:
+                        param_keys.append('/'+n)
+                        is_found = True
+                    if is_found:
+                        continue
+
+                # target node is '/node_name' without namespace
+                # Match definition in param file
+                # /node_name:
+                #   ros__parameters:
+                #     ...
+                # or
+                # node_name:
+                #   ros__parameters:
+                #     ...
+                if '/' not in n[1:]:
+                    is_found = False
+                    if n in param_file:
+                        param_keys.append(n)
+                        is_found = True
+                    if n[1:] in param_file:
+                        param_keys.append(n[1:])
+                        is_found = True
+                    if is_found:
+                        continue
+
+                # target node include namespaces, e.g. /node_ns/node_name
+                # Matched definition in param file
+                # /node_ns
+                #   node_name:
+                #     ros__parameters:
+                #       ...
+                # or
+                # /node_ns/node_name:
+                #   ros__parameters:
+                #     ...
+                is_found = False
+                ns, node_name = n.rsplit('/', 1)
+                if '/' in n[1:]:  # single level namespace e.g. /ns1/node_name
+
+                    # If ns is single level namespace and wildcard is true
+                    # Match definition in param file
+                    # /*
+                    #   node_name:
+                    #     ros__parameters:
+                    #       ...
+                    # or
+                    # /**/node_name:
+                    #   ros__parameters:
+                    #     ...
+                    if use_wildcard and '/' not in ns[1:]:
+                        if '/*' in param_file:
+                            if node_name in param_file['/*']:
+                                param_keys.append('/*#' + node_name)
+                                is_found = True
+                        if '/**/' + node_name in param_file:
+                            param_keys.append('/**/' + node_name)
+                            is_found = True
+
+                # Match definition in param file. 'namespace' is single level or multi level.
+                # /namespace
+                #   node_name:
+                #     ros__parameters:
+                #       ...
+                if ns in param_file and isinstance(param_file[ns], dict):
+                    if node_name in param_file[ns]:
+                        param_keys.append(ns + '#' + node_name)
+                        is_found = True
+
+                # Match definition in param file. 'namespace' is single level or multi level.
+                # /namespace/node_name:
+                #   ros__parameters:
+                #     ...
+                if n in param_file:
+                    param_keys.append(n)
+                    is_found = True
+
+                if is_found:
+                    continue
+
+                raise RuntimeError(f'Param file does not contain parameters for {n},'
+                                   f'only for nodes: {list(param_file.keys())} ')
+
         else:
             # wildcard key must go to the front of param_keys so that
             # node-namespaced parameters will override the wildcard parameters
             keys = set(param_file.keys())
             keys.discard('/**')
+            keys.discard('/*')
+            keys_to_remove = [item for item in keys if item.startswith('/**/')]
+            for key in keys_to_remove:
+                keys.discard(key)
             param_keys.extend(keys)
 
         if len(param_keys) == 0:
             raise RuntimeError('Param file does not contain selected parameters')
 
         for n in param_keys:
-            value = param_file[n]
-            if not isinstance(value, dict) or 'ros__parameters' not in value:
-                raise RuntimeError(f'YAML file is not a valid ROS parameter file for node {n}')
-            param_dict.update(value['ros__parameters'])
+            # "namespace#node_name" means the following parameters need to be collected in
+            # the parameter file.
+            # namespace
+            #   node_name:
+            #     ros__parameters:
+            #       ...
+            if '#' in n:
+                ns, node_name = n.split('#', 1)
+                if (isinstance(param_file[ns][node_name], dict) and
+                        'ros__parameters' in param_file[ns][node_name]):
+                    param_dict.update(param_file[ns][node_name]['ros__parameters'])
+                    continue
+            else:
+                value = param_file[n]
+                if isinstance(value, dict):
+                    if 'ros__parameters' in value:
+                        param_dict.update(value['ros__parameters'])
+                        continue
+                    else:
+                        if n in param_file:
+                            # n is space name (e.g. '/*'). Add all node parameters under
+                            # this namespace
+                            if isinstance(param_file[n], dict):
+                                for node_name, param_value in param_file[n].items():
+                                    if (isinstance(param_value, dict) and
+                                            'ros__parameters' in param_value):
+                                        param_dict.update(param_value['ros__parameters'])
+                                        continue
+                                    else:
+                                        raise RuntimeError(
+                                            f'YAML file is not a valid ROS parameter file for node\
+                                             {n}/{node_name}')
+                                continue
+            raise RuntimeError(f'YAML file is not a valid ROS parameter file for node {n}')
+
         return _unpack_parameter_dict(namespace, param_dict)
 
 

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -319,28 +319,14 @@ def parameter_dict_from_yaml_file(
 
         if target_nodes:
             for n in target_nodes:
+                if n is None or n == '':
+                    continue
 
-                # target node is 'node_name' without namespace
-                # Match definition in param file
-                # node_name:
-                #   ros__parameters:
-                #     ...
-                # or
-                # /node_name:
-                #   ros__parameters:
-                #     ...
-                if '/' not in n:
-                    is_found = False
-                    if n in param_file:
-                        param_keys.append(n)
-                        is_found = True
-                    if '/'+n in param_file:
-                        param_keys.append('/'+n)
-                        is_found = True
-                    if is_found:
-                        continue
+                # Get absolute node name
+                if n[0] != '/':
+                    n = '/' + n
 
-                # target node is '/node_name' without namespace
+                # target node doesn't include namespace
                 # Match definition in param file
                 # /node_name:
                 #   ros__parameters:
@@ -351,6 +337,15 @@ def parameter_dict_from_yaml_file(
                 #     ...
                 if '/' not in n[1:]:
                     is_found = False
+                    # In the param file, there may be two ways to write a node_name.
+                    # So need to handle all of them.
+                    # /node_name:
+                    #   ros__parameters:
+                    #     ...
+                    # or
+                    # node_name:
+                    #   ros__parameters:
+                    #
                     if n in param_file:
                         param_keys.append(n)
                         is_found = True
@@ -359,15 +354,17 @@ def parameter_dict_from_yaml_file(
                         is_found = True
                     if is_found:
                         continue
+                    raise RuntimeError(f'Param file does not contain parameters for {n},'
+                                       f'only for nodes: {list(param_file.keys())} ')
 
-                # target node include namespaces, e.g. /node_ns/node_name
+                # target node include namespaces, e.g. /namespace/node_name
                 # Matched definition in param file
-                # /node_ns
+                # /namespace
                 #   node_name:
                 #     ros__parameters:
                 #       ...
                 # or
-                # /node_ns/node_name:
+                # /namespace/node_name:
                 #   ros__parameters:
                 #     ...
                 is_found = False
@@ -380,20 +377,23 @@ def parameter_dict_from_yaml_file(
                     #   node_name:
                     #     ros__parameters:
                     #       ...
-                    # or
-                    # /**/node_name:
-                    #   ros__parameters:
-                    #     ...
                     if use_wildcard and '/' not in ns[1:]:
-                        if '/*' in param_file:
-                            if node_name in param_file['/*']:
-                                param_keys.append('/*#' + node_name)
-                                is_found = True
-                        if '/**/' + node_name in param_file:
-                            param_keys.append('/**/' + node_name)
+                        if '/*' in param_file and node_name in param_file['/*']:
+                            param_keys.append('/*#' + node_name)
                             is_found = True
 
-                # Match definition in param file. 'namespace' is single level or multi level.
+                # If 'ns' in target node is single level or multi level namespace and
+                # wildcard is true,
+                # Match definition in param file
+                # /**/node_name:
+                #   ros__parameters:
+                #     ...
+                if use_wildcard and '/**/' + node_name in param_file:
+                    param_keys.append('/**/' + node_name)
+                    is_found = True
+
+                # If 'ns' in target node is single level or multi level namespace,
+                # Match definition in param file.
                 # /namespace
                 #   node_name:
                 #     ros__parameters:
@@ -403,7 +403,8 @@ def parameter_dict_from_yaml_file(
                         param_keys.append(ns + '#' + node_name)
                         is_found = True
 
-                # Match definition in param file. 'namespace' is single level or multi level.
+                # if 'ns' in target node is single level or multi level namespace,
+                # Match definition in param file.
                 # /namespace/node_name:
                 #   ros__parameters:
                 #     ...
@@ -416,7 +417,6 @@ def parameter_dict_from_yaml_file(
 
                 raise RuntimeError(f'Param file does not contain parameters for {n},'
                                    f'only for nodes: {list(param_file.keys())} ')
-
         else:
             # wildcard key must go to the front of param_keys so that
             # node-namespaced parameters will override the wildcard parameters
@@ -433,7 +433,7 @@ def parameter_dict_from_yaml_file(
 
         for n in param_keys:
             # "namespace#node_name" means the following parameters need to be collected in
-            # the parameter file.
+            # the param file.
             # namespace
             #   node_name:
             #     ros__parameters:
@@ -452,18 +452,17 @@ def parameter_dict_from_yaml_file(
                         continue
                     else:
                         if n in param_file:
-                            # n is space name (e.g. '/*'). Add all node parameters under
+                            # n is namespace (e.g. '/*'). Add all node parameters under
                             # this namespace
                             if isinstance(param_file[n], dict):
                                 for node_name, param_value in param_file[n].items():
                                     if (isinstance(param_value, dict) and
                                             'ros__parameters' in param_value):
                                         param_dict.update(param_value['ros__parameters'])
-                                        continue
                                     else:
                                         raise RuntimeError(
-                                            f'YAML file is not a valid ROS parameter file for node\
-                                             {n}/{node_name}')
+                                            f'YAML file is not a valid ROS parameter file for node'
+                                            f'{n}/{node_name}')
                                 continue
             raise RuntimeError(f'YAML file is not a valid ROS parameter file for node {n}')
 

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -369,18 +369,17 @@ def parameter_dict_from_yaml_file(
                 #     ...
                 is_found = False
                 ns, node_name = n.rsplit('/', 1)
-                if '/' in n[1:]:  # single level namespace e.g. /ns1/node_name
 
-                    # If ns is single level namespace and wildcard is true
-                    # Match definition in param file
-                    # /*
-                    #   node_name:
-                    #     ros__parameters:
-                    #       ...
-                    if use_wildcard and '/' not in ns[1:]:
-                        if '/*' in param_file and node_name in param_file['/*']:
-                            param_keys.append('/*#' + node_name)
-                            is_found = True
+                # If ns is single level namespace and wildcard is true
+                # Match definition in param file
+                # /*
+                #   node_name:
+                #     ros__parameters:
+                #       ...
+                if use_wildcard and '/' not in ns[1:]:
+                    if '/*' in param_file and node_name in param_file['/*']:
+                        param_keys.append('/*#' + node_name)
+                        is_found = True
 
                 # If 'ns' in target node is single level or multi level namespace and
                 # wildcard is true,
@@ -461,8 +460,8 @@ def parameter_dict_from_yaml_file(
                                         param_dict.update(param_value['ros__parameters'])
                                     else:
                                         raise RuntimeError(
-                                            f'YAML file is not a valid ROS parameter file for node '
-                                            f'{n}/{node_name}')
+                                            f'YAML file is not a valid ROS parameter file for node'
+                                            f' {n}/{node_name}')
                                 continue
             raise RuntimeError(f'YAML file is not a valid ROS parameter file for node {n}')
 

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -376,8 +376,11 @@ def parameter_dict_from_yaml_file(
                 #   node_name:
                 #     ros__parameters:
                 #       ...
-                if use_wildcard and '/' not in ns[1:]:
-                    if '/*' in param_file and node_name in param_file['/*']:
+                if use_wildcard and '/' not in ns[1:] and '/*' in param_file:
+                    if not isinstance(param_file['/*'], dict):
+                        raise RuntimeError(
+                            'YAML file is not a valid ROS parameter file for namespace "/*"')
+                    if node_name in param_file['/*']:
                         param_keys.append('/*#' + node_name)
                         is_found = True
 

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -313,6 +313,9 @@ class TestParameter(unittest.TestCase):
                 param_test_target3:
                     ros__parameters:
                         deep-ns-base-nodename: false
+            /**/param_test_target3:
+                ros__parameters:
+                    abs-wildcard-deep-ns-nodename: true
             """
         # Not set target nodes and wildcard is false
         expected_no_target_nodes_and_no_wildcard = {
@@ -337,6 +340,8 @@ class TestParameter(unittest.TestCase):
                 'abs-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
             'abs-ns-nodename': Parameter(
                 'abs-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-wildcard-deep-ns-nodename': Parameter(
+                'abs-wildcard-deep-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
             'abs-wildcard-ns-base-nodename': Parameter(
                 'abs-wildcard-ns-base-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
             'abs-wildcard-ns-nodename': Parameter(
@@ -396,6 +401,8 @@ class TestParameter(unittest.TestCase):
         }
         # Set one target node with multi level namespace and wildcard is true
         expected_one_target_node_with_multi_ns_and_wildcard = {
+            'abs-wildcard-deep-ns-nodename': Parameter(
+                'abs-wildcard-deep-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
             'deep-ns-base-nodename': Parameter(
                 'deep-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
             'deep-ns-nodename': Parameter(

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -281,6 +281,174 @@ class TestParameter(unittest.TestCase):
                 os.unlink(f.name)
         self.assertRaises(FileNotFoundError, parameter_dict_from_yaml_file, 'unknown_file')
 
+    def test_parameter_dict_from_yaml_file2(self):
+        yaml_string = """
+            /**:
+                ros__parameters:
+                    wildcard: true
+            /param_test_target1:
+                ros__parameters:
+                    abs-nodename: true
+            param_test_target1:
+                ros__parameters:
+                    base-nodename: false
+            /foo/param_test_target2:
+                ros__parameters:
+                    abs-ns-nodename: true
+            /foo:
+                param_test_target2:
+                    ros__parameters:
+                        abs-ns-base-nodename: false
+            /*:
+                param_test_target2:
+                    ros__parameters:
+                        abs-wildcard-ns-base-nodename: true
+            /**/param_test_target2:
+                ros__parameters:
+                    abs-wildcard-ns-nodename: false
+            /ns1/ns2/param_test_target3:
+                ros__parameters:
+                    deep-ns-nodename: true
+            /ns1/ns2:
+                param_test_target3:
+                    ros__parameters:
+                        deep-ns-base-nodename: false
+            """
+        # Not set target nodes and wildcard is false
+        expected_no_target_nodes_and_no_wildcard = {
+            'abs-nodename': Parameter(
+                'abs-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-ns-base-nodename': Parameter(
+                'abs-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'abs-ns-nodename': Parameter(
+                'abs-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'base-nodename': Parameter(
+                'base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'deep-ns-base-nodename': Parameter(
+                'deep-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'deep-ns-nodename': Parameter(
+                'deep-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # Not set target nodes and wildcard is true
+        expected_no_target_nodes_and_wildcard = {
+            'abs-nodename': Parameter(
+                'abs-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-ns-base-nodename': Parameter(
+                'abs-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'abs-ns-nodename': Parameter(
+                'abs-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-wildcard-ns-base-nodename': Parameter(
+                'abs-wildcard-ns-base-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-wildcard-ns-nodename': Parameter(
+                'abs-wildcard-ns-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'base-nodename': Parameter(
+                'base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'deep-ns-base-nodename': Parameter(
+                'deep-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'deep-ns-nodename': Parameter(
+                'deep-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'wildcard': Parameter(
+                'wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # Set one target node without ns and wildcard is false
+        expected_one_target_node_and_no_wildcard = {
+            'abs-nodename': Parameter(
+                'abs-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'base-nodename': Parameter(
+                'base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+        }
+        # Set one target node without ns and wildcard is true
+        expected_one_target_node_and_wildcard = {
+            'abs-nodename': Parameter(
+                'abs-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'base-nodename': Parameter(
+                'base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'wildcard': Parameter(
+                'wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # Set one target node with single level namespace and wildcard is false
+        expected_one_target_node_with_single_ns_and_no_wildcard = {
+            'abs-ns-base-nodename': Parameter(
+                'abs-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'abs-ns-nodename': Parameter(
+                'abs-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # Set one target node with single level namespace and wildcard is true
+        expected_one_target_node_with_single_ns_and_wildcard = {
+            'abs-ns-base-nodename': Parameter(
+                'abs-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'abs-ns-nodename': Parameter(
+                'abs-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-wildcard-ns-base-nodename': Parameter(
+                'abs-wildcard-ns-base-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'abs-wildcard-ns-nodename': Parameter(
+                'abs-wildcard-ns-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'wildcard': Parameter(
+                'wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+
+        # Set one target node with multi level namespace and wildcard is false
+        expected_one_target_node_with_multi_ns_and_no_wildcard = {
+            'deep-ns-base-nodename': Parameter(
+                'deep-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'deep-ns-nodename': Parameter(
+                'deep-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+        # Set one target node with multi level namespace and wildcard is true
+        expected_one_target_node_with_multi_ns_and_wildcard = {
+            'deep-ns-base-nodename': Parameter(
+                'deep-ns-base-nodename', Parameter.Type.BOOL, False).to_parameter_msg(),
+            'deep-ns-nodename': Parameter(
+                'deep-ns-nodename', Parameter.Type.BOOL, True).to_parameter_msg(),
+            'wildcard': Parameter(
+                'wildcard', Parameter.Type.BOOL, True).to_parameter_msg(),
+        }
+
+        try:
+            with NamedTemporaryFile(mode='w', delete=False) as f:
+                f.write(yaml_string)
+                f.flush()
+                f.close()
+                parameter_dict = parameter_dict_from_yaml_file(f.name, use_wildcard=False)
+                assert parameter_dict == expected_no_target_nodes_and_no_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(f.name, use_wildcard=True)
+                assert parameter_dict == expected_no_target_nodes_and_wildcard
+
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, use_wildcard=False, target_nodes=['param_test_target1'])
+                assert parameter_dict == expected_one_target_node_and_no_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, use_wildcard=True, target_nodes=['param_test_target1'])
+                assert parameter_dict == expected_one_target_node_and_wildcard
+
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, use_wildcard=False, target_nodes=['/foo/param_test_target2'])
+                assert parameter_dict == expected_one_target_node_with_single_ns_and_no_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, use_wildcard=True, target_nodes=['/foo/param_test_target2'])
+                assert parameter_dict == expected_one_target_node_with_single_ns_and_wildcard
+
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, use_wildcard=False, target_nodes=['/ns1/ns2/param_test_target3'])
+                assert parameter_dict == expected_one_target_node_with_multi_ns_and_no_wildcard
+                parameter_dict = parameter_dict_from_yaml_file(
+                    f.name, use_wildcard=True, target_nodes=['/ns1/ns2/param_test_target3'])
+                assert parameter_dict == expected_one_target_node_with_multi_ns_and_wildcard
+
+                with pytest.raises(RuntimeError,
+                                   match='Param file does not contain parameters for'):
+                    parameter_dict = parameter_dict_from_yaml_file(
+                        f.name, False, target_nodes=['/abc/cde/param_test_target3'])
+                with pytest.raises(RuntimeError,
+                                   match='Param file does not contain parameters for'):
+                    parameter_dict = parameter_dict_from_yaml_file(
+                        f.name, False, target_nodes=['/abc/param_test_target2'])
+
+        finally:
+            if os.path.exists(f.name):
+                os.unlink(f.name)
+        self.assertRaises(FileNotFoundError, parameter_dict_from_yaml_file, 'unknown_file')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -443,11 +443,11 @@ class TestParameter(unittest.TestCase):
                 assert parameter_dict == expected_one_target_node_with_multi_ns_and_wildcard
 
                 with pytest.raises(RuntimeError,
-                                   match='Param file does not contain parameters for'):
+                                   match='Param file does not contain selected parameters'):
                     parameter_dict = parameter_dict_from_yaml_file(
                         f.name, False, target_nodes=['/abc/cde/param_test_target3'])
                 with pytest.raises(RuntimeError,
-                                   match='Param file does not contain parameters for'):
+                                   match='Param file does not contain selected parameters'):
                     parameter_dict = parameter_dict_from_yaml_file(
                         f.name, False, target_nodes=['/abc/param_test_target2'])
 


### PR DESCRIPTION
## Description

The implementation of the parameter_dict_from_yaml_file() function differs significantly between the rolling version and the Jazzy version, so I made separate modifications for the Jazzy version.

Fixes https://github.com/ros2/rclpy/issues/1546

And also supports the following YAML parameter format
```yaml
/**/node_name:
   ros__parameters:
      ...
/*:
   node_name:
       ros__parameters:
```

### Is this user-facing behavior change?

Yes. parameter_dict_from_yaml_file() supports a more complete parameter file format (consistent with rcl_yaml_param_parser).


### Did you use Generative AI?

No

### Additional Information

No
