### PR TITLE
Avoid taking back GIL when the Python runtime is finalizing

### DIFF
--- a/rclpy/src/rclpy/clock_event.cpp
+++ b/rclpy/src/rclpy/clock_event.cpp
@@ -23,6 +23,7 @@
 #include <mutex>
 
 #include "clock_event.hpp"
+#include "gil_utils.hpp"
 
 namespace py = pybind11;
 
@@ -48,7 +49,7 @@ void ClockEvent::wait_until(std::shared_ptr<Clock> clock, rcl_time_point_t until
     std::chrono::nanoseconds(delta_t.nanoseconds));
 
   // Could be a long wait, release the gil
-  py::gil_scoped_release release;
+  gil_scoped_release release;
   std::unique_lock<std::mutex> lock(mutex_);
   cv_.wait_until(lock, chrono_until, [this]() {return state_;});
 }
@@ -58,7 +59,7 @@ void ClockEvent::wait_until_ros(std::shared_ptr<Clock> clock, rcl_time_point_t u
   // Check if ROS time is enabled in C++ to avoid TOCTTOU with TimeSource by holding GIL
   if (clock->get_ros_time_override_is_enabled()) {
     // Could be a long wait, release the gil
-    py::gil_scoped_release release;
+    gil_scoped_release release;
     std::unique_lock<std::mutex> lock(mutex_);
     // Caller must have setup a time jump callback to wake this event
     cv_.wait(lock, [this]() {return state_;});

--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -36,6 +36,7 @@
 
 #include "client.hpp"
 #include "context.hpp"
+#include "gil_utils.hpp"
 #include "service.hpp"
 #include "subscription.hpp"
 
@@ -100,7 +101,7 @@ bool EventsExecutor::shutdown(std::optional<double> timeout)
 
   // Block until spinning is done, or timeout.  Release the GIL while we block though.
   {
-    py::gil_scoped_release gil_release;
+    gil_scoped_release gil_release;
     std::unique_lock<std::timed_mutex> spin_lock(spinning_mutex_, std::defer_lock);
     if (timeout) {
       if (!spin_lock.try_lock_for(std::chrono::duration<double>(*timeout))) {
@@ -171,7 +172,7 @@ void EventsExecutor::spin(std::optional<double> timeout_sec, bool stop_after_use
     stop_after_user_callback_ = stop_after_user_callback;
     // Release the GIL while we block.  Any callbacks on the events queue that want to touch Python
     // will need to reacquire it though.
-    py::gil_scoped_release gil_release;
+    gil_scoped_release gil_release;
     if (timeout_sec) {
       const auto timeout_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::duration<double>(*timeout_sec));

--- a/rclpy/src/rclpy/gil_utils.hpp
+++ b/rclpy/src/rclpy/gil_utils.hpp
@@ -1,0 +1,57 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLPY__GIL_UTILS_HPP_
+#define RCLPY__GIL_UTILS_HPP_
+
+#include <pybind11/pybind11.h>
+
+#ifndef Py_PACK_FULL_VERSION
+#define Py_PACK_FULL_VERSION(X, Y, Z, LEVEL, SERIAL) ( \
+   (((X) & 0xff) << 24) |                              \
+   (((Y) & 0xff) << 16) |                              \
+   (((Z) & 0xff) << 8) |                               \
+   (((LEVEL) & 0xf) << 4) |                            \
+   (((SERIAL) & 0xf) << 0))
+#endif
+
+#if PY_VERSION_HEX < Py_PACK_FULL_VERSION(3, 13, 0, 0, 0)
+#define rclpy_IsPythonFinalizing _Py_IsFinalizing
+#else
+#define rclpy_IsPythonFinalizing Py_IsFinalizing
+#endif
+
+namespace rclpy
+{
+
+class gil_scoped_release
+{
+public:
+  gil_scoped_release() = default;
+
+  ~gil_scoped_release() {
+    // Avoid taking the GIL if runtime is finalizing
+    if (rclpy_IsPythonFinalizing()) {
+      gil_release_.disarm();
+    }
+  }
+
+private:
+
+  pybind11::gil_scoped_release gil_release_;
+};
+
+}  // namespace rclpy
+
+#endif  // RCLPY__GIL_UTILS_HPP_

--- a/rclpy/src/rclpy/wait_set.cpp
+++ b/rclpy/src/rclpy/wait_set.cpp
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "exceptions.hpp"
+#include "gil_utils.hpp"
 #include "wait_set.hpp"
 
 namespace rclpy
@@ -243,7 +244,7 @@ WaitSet::wait(int64_t timeout)
 
   // Could be a long wait, release the GIL
   {
-    py::gil_scoped_release gil_release;
+    gil_scoped_release gil_release;
     ret = rcl_wait(rcl_wait_set_.get(), timeout);
   }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

When using `gil_scoped_release`, care must be taken not to take the GIL when the Python runtime is finalizing.

According to [this](https://github.com/pybind/pybind11/blob/55e4bb9135f9ab19cf9af5ae2178eebb9d9ef23e/include/pybind11/gil.h#L175-L180) one can call `_Py_IsFinalizing()` to check the failure condition and then `disarm()` the `gil_scoped_release` object so it does not take the GIL back.

This would fix (in theroy) #1484 but locally it doesn't seem so. Opening in draft nonetheless, in case someone wants to take this as a base for a proper fix.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!-- Fixes # (issue) -->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
