### PR TITLE
Fix overflow caused by default spin timeout

### DIFF
--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -176,7 +176,7 @@ void EventsExecutor::spin(std::optional<double> timeout_sec, bool stop_after_use
       const auto timeout_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::duration<double>(*timeout_sec));
       const auto end = std::chrono::steady_clock::now() + timeout_ns;
-      events_queue_.RunUntil(end);
+      events_queue_.Run(end);
     } else {
       events_queue_.Run();
     }

--- a/rclpy/src/rclpy/events_executor/events_queue.hpp
+++ b/rclpy/src/rclpy/events_executor/events_queue.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <mutex>
 #include <queue>
+#include <optional>
 
 namespace rclpy
 {
@@ -37,12 +38,9 @@ public:
   /// Add an event handler to the queue to be dispatched.  Can be invoked by any thread.
   void Enqueue(std::function<void()>);
 
-  /// Run event handlers indefinitely, until stopped.
-  void Run();
-
   /// Run all ready event handlers, and any that become ready before the given deadline.  Calling
   /// Stop() will make this return immediately even if ready handlers are enqueued.
-  void RunUntil(std::chrono::steady_clock::time_point);
+  void Run(const std::optional<std::chrono::steady_clock::time_point> = {});
 
   /// Causes any Run*() methods outstanding to return immediately.  Can be invoked from any thread.
   /// The stopped condition persists (causing any *subsequent* Run*() calls to also return) until


### PR DESCRIPTION
## Description

Previously, the max() value of the steady time was used as the default deadline. In some environments this results in [overflows ](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58931) in the underlying `pthread_cond_timedwait` call, which waits for the conditional variable in the events queue implementation. Consequently, this lead to undefined behavior and freezes in the executor. Reducing the deadline significantly helped, but using `cv.wait` instead of `cv_.wait_until` seems to be the cleaner solution.

### Did you use Generative AI?

No

### Additional Information
