### PR TITLE
Fix windows regression: Increase clock accuracy

### DIFF
--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -365,19 +365,19 @@ class TestExecutor(unittest.TestCase):
                     await thread_future
 
                 def future_thread():
-                    threading.Event().wait(0.1)  # Simulate some work
+                    time.sleep(0.1)  # Simulate some work
                     thread_future.set_result(None)
 
                 t = threading.Thread(target=future_thread)
 
                 coroutine_future = executor.create_task(coroutine)
 
-                start_time = time.monotonic()
+                start_time = time.perf_counter()
 
                 t.start()
                 executor.spin_until_future_complete(coroutine_future, timeout_sec=1.0)
 
-                end_time = time.monotonic()
+                end_time = time.perf_counter()
 
                 self.assertTrue(coroutine_future.done())
 


### PR DESCRIPTION
## Description

The changes in https://github.com/ros2/rclpy/pull/1469 added a test, which uses `time.monotonic()` and `threading.Event().wait(0.1)`. Both use the default windows timer which only has a resolution of ~15ms, leading to a failed assertion. For a more detailed discussion see: https://github.com/ros2/rclpy/pull/1563 

Fixes #1562 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

