### PR TITLE
Remove default from switch with enum, so that compiler warns.

### DIFF
--- a/rclpy/src/rclpy/event_handle.cpp
+++ b/rclpy/src/rclpy/event_handle.cpp
@@ -148,9 +148,6 @@ EventHandle::take_event()
         return py::cast(data.incompatible_type);
       case RCL_SUBSCRIPTION_MATCHED:
         return py::cast(data.subscription_matched);
-      default:
-        // suggests a misalignment between C and Python interfaces
-        throw py::value_error("event type for subscriptions not understood");
     }
   } else if (auto pub_type = std::get_if<rcl_publisher_event_type_t>(&event_type_)) {
     switch (*pub_type) {
@@ -164,9 +161,6 @@ EventHandle::take_event()
         return py::cast(data.incompatible_type);
       case RCL_PUBLISHER_MATCHED:
         return py::cast(data.publisher_matched);
-      default:
-        // suggests a misalignment between C and Python interfaces
-        throw py::value_error("event type for publishers not understood");
     }
   }
   throw std::runtime_error("cannot take event that is neither a publisher or a subscription event");


### PR DESCRIPTION
## Description

Now the compiler will warn us if new enum values are added to it but aren't handled in this function.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
