### PR TITLE
Update release version to 10.0.4 in docs

### DIFF
--- a/rclpy/docs/source/conf.py
+++ b/rclpy/docs/source/conf.py
@@ -42,7 +42,7 @@ author = 'Open Source Robotics Foundation, Inc.'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '3.2.1'
+release = '10.0.4'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description

Kind of wacky we are 7 major versions behind on the docs.

### Is this user-facing behavior change?

Yes all ROS users will stop accidentally installing `3.2.1` on accident.
