### PR TITLE
Drop invalid waitables from wait set

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -825,12 +825,15 @@ class Executor(ContextManager['Executor']):
                     except InvalidHandle:
                         entity_count.num_guard_conditions -= 1
 
+                valid_waitables = []
                 for waitable in waitables:
                     try:
                         context_stack.enter_context(waitable)
                         entity_count += waitable.get_num_entities()
+                        valid_waitables.append(waitable)
                     except InvalidHandle:
                         pass
+                waitables = valid_waitables
 
                 if self._context.handle is None:
                     raise RuntimeError('Cannot enter context if context is None')


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Precisely what the title says. Invalid waitables are dropped from the list that eventually reaches the wait set.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1284.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No.

### Did you use Generative AI?

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
 There are no tests because I don't know of any way we can reproduce the conditions that trigger this issue consistently.