### PR TITLE
Prevents the Future result from being set twice.

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -215,15 +215,18 @@ class ServerGoalHandle(Generic[GoalT, ResultT, FeedbackT, ImplT]):
 
     def succeed(self, response: Optional[ResultT] = None) -> None:
         self._update_state(_rclpy.GoalEvent.SUCCEED)
-        self._set_result(response)
+        if response is not None:
+            self._set_result(response)
 
     def abort(self, response: Optional[ResultT] = None) -> None:
         self._update_state(_rclpy.GoalEvent.ABORT)
-        self._set_result(response)
+        if response is not None:
+            self._set_result(response)
 
     def canceled(self, response: Optional[ResultT] = None) -> None:
         self._update_state(_rclpy.GoalEvent.CANCELED)
-        self._set_result(response)
+        if response is not None:
+            self._set_result(response)
 
     def destroy(self) -> None:
         with self._lock:


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1598 

### Is this user-facing behavior change?

Yes, but this fixes the behavior that has been changed by https://github.com/ros2/rclpy/pull/1469

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Copilot Claude Sonnet 4.5

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
