### PR TITLE
Fix incorrect action client/server callback type hints

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -75,15 +75,16 @@ if TYPE_CHECKING:
         result: Tuple[int, GetResultServiceResponse[ClientGoalHandleDictResultT]]
         feedback: FeedbackMessage[ClientGoalHandleDictFeedbackT]
         status: GoalStatusArray
+
+    FeedbackCallbackUnion: TypeAlias = Union[
+        Callable[[FeedbackMessage[FeedbackT]], None],
+        Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
+    ]
 else:
     ClientGoalHandleDict: 'TypeAlias' = Dict[str, object]
 
 
 T = TypeVar('T')
-FeedbackCallbackUnion: TypeAlias = Union[
-    Callable[[FeedbackMessage[FeedbackT]], None],
-    Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
-]
 
 
 class SendGoalKWargs(TypedDict):

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -87,7 +87,7 @@ else:
 T = TypeVar('T')
 
 
-class SendGoalKWargs(TypedDict):
+class SendGoalKWargs(TypedDict, Generic[FeedbackT]):
     feedback_callback: Optional[FeedbackCallbackUnion[FeedbackT]]
     goal_uuid: Optional[UUID]
 
@@ -458,7 +458,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT],
 
     # End Waitable API
 
-    def send_goal(self, goal: GoalT, **kwargs: 'Unpack[SendGoalKWargs]'
+    def send_goal(self, goal: GoalT, **kwargs: 'Unpack[SendGoalKWargs[FeedbackT]]'
                   ) -> Optional[GetResultServiceResponse[ResultT]]:
         """
         Send a goal and wait for the result.

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -80,15 +80,14 @@ else:
 
 
 T = TypeVar('T')
+FeedbackCallbackUnion: TypeAlias = Union[
+    Callable[[FeedbackMessage[FeedbackT]], None],
+    Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
+]
 
 
 class SendGoalKWargs(TypedDict):
-    feedback_callback: Optional[
-        Union[
-            Callable[[FeedbackMessage[FeedbackT]], None],
-            Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
-        ]
-    ]
+    feedback_callback: Optional[FeedbackCallbackUnion[FeedbackT]]
     goal_uuid: Optional[UUID]
 
 
@@ -250,13 +249,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT],
         # key: result request sequence_number, value: UUID
         self._result_sequence_number_to_goal_id: Dict[int, UUID] = {}
         # key: UUID in bytes, value: callback function
-        self._feedback_callbacks: Dict[
-            bytes,
-            Union[
-                Callable[[FeedbackMessage[FeedbackT]], None],
-                Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
-            ],
-        ] = {}
+        self._feedback_callbacks: Dict[bytes, FeedbackCallbackUnion[FeedbackT]] = {}
 
         self._logger = self._node.get_logger().get_child('action_client')
         self._lock = threading.Lock()
@@ -514,12 +507,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT],
     def send_goal_async(
         self,
         goal: GoalT,
-        feedback_callback: Optional[
-            Union[
-                Callable[[FeedbackMessage[FeedbackT]], None],
-                Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
-            ]
-        ] = None,
+        feedback_callback: Optional[FeedbackCallbackUnion[FeedbackT]] = None,
         goal_uuid: Optional[UUID] = None
     ) -> Future[ClientGoalHandle[GoalT, ResultT, FeedbackT, ImplT]]:
         """

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -80,16 +80,15 @@ if TYPE_CHECKING:
         Callable[[FeedbackMessage[FeedbackT]], None],
         Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
     ]
+
+    class SendGoalKWargs(TypedDict, Generic[FeedbackT]):
+        feedback_callback: Optional[FeedbackCallbackUnion[FeedbackT]]
+        goal_uuid: Optional[UUID]
 else:
     ClientGoalHandleDict: 'TypeAlias' = Dict[str, object]
 
 
 T = TypeVar('T')
-
-
-class SendGoalKWargs(TypedDict, Generic[FeedbackT]):
-    feedback_callback: Optional[FeedbackCallbackUnion[FeedbackT]]
-    goal_uuid: Optional[UUID]
 
 
 class ClientGoalHandle(Generic[GoalT, ResultT, FeedbackT, ImplT]):

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -19,6 +19,7 @@ import time
 from types import TracebackType
 from typing import Any
 from typing import Callable
+from typing import Coroutine
 from typing import Dict
 from typing import Generic
 from typing import Optional
@@ -27,6 +28,7 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypedDict
 from typing import TypeVar
+from typing import Union
 
 import uuid
 import weakref
@@ -81,7 +83,12 @@ T = TypeVar('T')
 
 
 class SendGoalKWargs(TypedDict):
-    feedback_callback: Optional[Callable[[FeedbackT], None]]
+    feedback_callback: Optional[
+        Union[
+            Callable[[FeedbackMessage[FeedbackT]], None],
+            Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
+        ]
+    ]
     goal_uuid: Optional[UUID]
 
 
@@ -243,7 +250,13 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT],
         # key: result request sequence_number, value: UUID
         self._result_sequence_number_to_goal_id: Dict[int, UUID] = {}
         # key: UUID in bytes, value: callback function
-        self._feedback_callbacks: Dict[bytes, Callable[[FeedbackT], None]] = {}
+        self._feedback_callbacks: Dict[
+            bytes,
+            Union[
+                Callable[[FeedbackMessage[FeedbackT]], None],
+                Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
+            ],
+        ] = {}
 
         self._logger = self._node.get_logger().get_child('action_client')
         self._lock = threading.Lock()
@@ -501,7 +514,12 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT],
     def send_goal_async(
         self,
         goal: GoalT,
-        feedback_callback: Optional[Callable[[FeedbackT], None]] = None,
+        feedback_callback: Optional[
+            Union[
+                Callable[[FeedbackMessage[FeedbackT]], None],
+                Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
+            ]
+        ] = None,
         goal_uuid: Optional[UUID] = None
     ) -> Future[ClientGoalHandle[GoalT, ResultT, FeedbackT, ImplT]]:
         """

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -239,6 +239,19 @@ if TYPE_CHECKING:
         Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
                  Coroutine[Any, Any, ResultT]],
     ]
+    GoalCallbackUnion: TypeAlias = Union[
+        Callable[[GoalT], GoalResponse],
+        Callable[[GoalT], Coroutine[Any, Any, GoalResponse]],
+    ]
+    HandleAcceptedCallbackUnion: TypeAlias = Union[
+        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], None],
+        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], Coroutine[Any, Any, None]],
+    ]
+    CancelCallbackUnion: TypeAlias = Union[
+        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], CancelResponse],
+        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
+                 Coroutine[Any, Any, CancelResponse]],
+    ]
 
 def default_handle_accepted_callback(goal_handle: ServerGoalHandle[Any, Any, Any, Any]) -> None:
     """Execute the goal."""
@@ -269,12 +282,11 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
         execute_callback: Optional[ExecuteCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]] = None,
         *,
         callback_group: 'Optional[CallbackGroup]' = None,
-        goal_callback: Callable[[GoalT], GoalResponse] = default_goal_callback,
-        handle_accepted_callback: Callable[[ServerGoalHandle[GoalT,
-                                                             ResultT,
-                                                             FeedbackT, ImplT]],
-                                           None] = default_handle_accepted_callback,
-        cancel_callback: Callable[[CancelGoal.Request], CancelResponse] = default_cancel_callback,
+        goal_callback: GoalCallbackUnion[GoalT] = default_goal_callback,
+        handle_accepted_callback: HandleAcceptedCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]
+            = default_handle_accepted_callback,
+        cancel_callback: CancelCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]
+            = default_cancel_callback,
         goal_service_qos_profile: QoSProfile = qos_profile_services_default,
         result_service_qos_profile: QoSProfile = qos_profile_services_default,
         cancel_service_qos_profile: QoSProfile = qos_profile_services_default,
@@ -666,8 +678,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
 
     def register_handle_accepted_callback(
         self,
-        handle_accepted_callback: Optional[Callable[[
-            ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], None]]
+        handle_accepted_callback: Optional[
+            HandleAcceptedCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]] = None
     ) -> None:
         """
         Register a callback for handling newly accepted goals.
@@ -691,7 +703,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
 
     def register_goal_callback(
         self,
-        goal_callback: Optional[Callable[[GoalT], GoalResponse]]
+        goal_callback: Optional[GoalCallbackUnion[GoalT]] = None
     ) -> None:
         """
         Register a callback for handling new goal requests.
@@ -713,7 +725,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
 
     def register_cancel_callback(
         self,
-        cancel_callback: Optional[Callable[[CancelGoal.Request], CancelResponse]]
+        cancel_callback: Optional[CancelCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]] = None
     ) -> None:
         """
         Register a callback for handling cancel requests.

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -63,6 +63,26 @@ if TYPE_CHECKING:
         cancel: Tuple['_rclpy.rmw_request_id_t', CancelGoal.Request]
         result: Tuple['_rclpy.rmw_request_id_t', GetResultServiceRequest]
         expired: Tuple[GoalInfo, ...]
+
+    ExecuteCallbackUnion: TypeAlias = Union[
+        Callable[['ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]'], ResultT],
+        Callable[['ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]'],
+                 Coroutine[Any, Any, ResultT]],
+    ]
+    GoalCallbackUnion: TypeAlias = Union[
+        Callable[[GoalT], 'GoalResponse'],
+        Callable[[GoalT], Coroutine[Any, Any, 'GoalResponse']],
+    ]
+    HandleAcceptedCallbackUnion: TypeAlias = Union[
+        Callable[['ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]'], None],
+        Callable[['ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]'],
+                 Coroutine[Any, Any, None]],
+    ]
+    CancelCallbackUnion: TypeAlias = Union[
+        Callable[['ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]'], 'CancelResponse'],
+        Callable[['ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]'],
+                 Coroutine[Any, Any, 'CancelResponse']],
+    ]
 else:
     ServerGoalHandleDict: TypeAlias = Dict[str, object]
 
@@ -233,25 +253,6 @@ class ServerGoalHandle(Generic[GoalT, ResultT, FeedbackT, ImplT]):
             self._goal_handle.destroy_when_not_in_use()
             self._goal_handle = None
 
-if TYPE_CHECKING:
-    ExecuteCallbackUnion: TypeAlias = Union[
-        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], ResultT],
-        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
-                 Coroutine[Any, Any, ResultT]],
-    ]
-    GoalCallbackUnion: TypeAlias = Union[
-        Callable[[GoalT], GoalResponse],
-        Callable[[GoalT], Coroutine[Any, Any, GoalResponse]],
-    ]
-    HandleAcceptedCallbackUnion: TypeAlias = Union[
-        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], None],
-        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], Coroutine[Any, Any, None]],
-    ]
-    CancelCallbackUnion: TypeAlias = Union[
-        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], CancelResponse],
-        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
-                 Coroutine[Any, Any, CancelResponse]],
-    ]
 
 def default_handle_accepted_callback(goal_handle: ServerGoalHandle[Any, Any, Any, Any]) -> None:
     """Execute the goal."""
@@ -283,10 +284,10 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
         *,
         callback_group: 'Optional[CallbackGroup]' = None,
         goal_callback: GoalCallbackUnion[GoalT] = default_goal_callback,
-        handle_accepted_callback: HandleAcceptedCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]
-            = default_handle_accepted_callback,
-        cancel_callback: CancelCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]
-            = default_cancel_callback,
+        handle_accepted_callback: HandleAcceptedCallbackUnion[
+            GoalT, ResultT, FeedbackT, ImplT] = default_handle_accepted_callback,
+        cancel_callback: CancelCallbackUnion[
+            GoalT, ResultT, FeedbackT, ImplT] = default_cancel_callback,
         goal_service_qos_profile: QoSProfile = qos_profile_services_default,
         result_service_qos_profile: QoSProfile = qos_profile_services_default,
         cancel_service_qos_profile: QoSProfile = qos_profile_services_default,

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -20,8 +20,8 @@ import threading
 import traceback
 
 from types import TracebackType
-from typing import (Any, Callable, Dict, Generic, Literal, Optional, Tuple, Type,
-                    TYPE_CHECKING, TypedDict, TypeVar)
+from typing import (Any, Callable, Coroutine, Dict, Generic, Literal, Optional, Tuple, Type,
+                    TYPE_CHECKING, TypedDict, TypeVar, Union)
 
 
 from action_msgs.msg import GoalInfo, GoalStatus
@@ -181,8 +181,7 @@ class ServerGoalHandle(Generic[GoalT, ResultT, FeedbackT, ImplT]):
 
     def execute(
         self,
-        execute_callback: Optional[Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
-                                   ResultT]] = None
+        execute_callback: Optional[ExecuteCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]] = None
     ) -> None:
         # It's possible that there has been a request to cancel the goal prior to executing.
         # In this case we want to avoid the illegal state transition to EXECUTING
@@ -234,6 +233,12 @@ class ServerGoalHandle(Generic[GoalT, ResultT, FeedbackT, ImplT]):
             self._goal_handle.destroy_when_not_in_use()
             self._goal_handle = None
 
+if TYPE_CHECKING:
+    ExecuteCallbackUnion: TypeAlias = Union[
+        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], ResultT],
+        Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
+                 Coroutine[Any, Any, ResultT]],
+    ]
 
 def default_handle_accepted_callback(goal_handle: ServerGoalHandle[Any, Any, Any, Any]) -> None:
     """Execute the goal."""
@@ -261,8 +266,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
         node: 'Node',
         action_type: type[Action[GoalT, ResultT, FeedbackT, ImplT]],
         action_name: str,
-        execute_callback: Optional[Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
-                                            ResultT]] = None,
+        execute_callback: Optional[ExecuteCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]] = None,
         *,
         callback_group: 'Optional[CallbackGroup]' = None,
         goal_callback: Callable[[GoalT], GoalResponse] = default_goal_callback,
@@ -420,7 +424,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
 
     async def _execute_goal(
         self,
-        execute_callback: Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], ResultT],
+        execute_callback: ExecuteCallbackUnion[GoalT, ResultT, FeedbackT, ImplT],
         goal_handle: ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]
     ) -> None:
         goal_uuid = goal_handle.goal_id.uuid
@@ -643,8 +647,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
     def notify_execute(
         self,
         goal_handle: ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT],
-        execute_callback: Optional[Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]],
-                                            ResultT]]
+        execute_callback: Optional[ExecuteCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]] = None
     ) -> None:
         # Use provided callback, defaulting to a previously registered callback
         if execute_callback is None:
@@ -732,7 +735,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
 
     def register_execute_callback(
         self,
-        execute_callback: Callable[[ServerGoalHandle[GoalT, ResultT, FeedbackT, ImplT]], ResultT]
+        execute_callback: ExecuteCallbackUnion[GoalT, ResultT, FeedbackT, ImplT]
     ) -> None:
         """
         Register a callback for executing action goals.

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -266,7 +266,9 @@ def default_goal_callback(
     return GoalResponse.ACCEPT
 
 
-def default_cancel_callback(cancel_request: CancelGoal.Request) -> Literal[CancelResponse.REJECT]:
+def default_cancel_callback(
+    goal_handle: ServerGoalHandle[Any, Any, Any, Any]
+) -> Literal[CancelResponse.REJECT]:
     """No cancellations."""
     return CancelResponse.REJECT
 

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -32,6 +32,9 @@ from test_msgs.action import Fibonacci
 
 from unique_identifier_msgs.msg import UUID
 
+if TYPE_CHECKING:
+    from rclpy.type_support import FeedbackMessage
+
 # TODO(jacobperron) Reduce fudge once wait_for_service uses node graph events
 TIME_FUDGE = 0.3
 
@@ -85,6 +88,7 @@ class TestActionClient(unittest.TestCase):
         executor: SingleThreadedExecutor
         node: rclpy.node.Node
         mock_action_server: MockActionServer
+        feedback: FeedbackMessage[Fibonacci.Feedback] | None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -102,7 +106,7 @@ class TestActionClient(unittest.TestCase):
     def setUp(self) -> None:
         self.feedback = None
 
-    def feedback_callback(self, feedback: Fibonacci.Feedback) -> None:
+    def feedback_callback(self, feedback: FeedbackMessage[Fibonacci.Feedback]) -> None:
         self.feedback = feedback
 
     def timed_spin(self, duration: float) -> None:
@@ -391,9 +395,9 @@ class TestActionClient(unittest.TestCase):
         ac = ActionClient(self.node, Fibonacci, 'fibonacci')
         try:
             with self.assertRaises(TypeError):
-                ac.send_goal('different goal type')  # type: ignore[call-arg]
+                ac.send_goal('different goal type')  # type: ignore[call-arg,arg-type]
             with self.assertRaises(TypeError):
-                ac.send_goal_async('different goal type')
+                ac.send_goal_async('different goal type')  # type: ignore[arg-type]
         finally:
             ac.destroy()
 

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 from typing import List
 from typing import TYPE_CHECKING

--- a/rclpy/test/test_action_server.py
+++ b/rclpy/test/test_action_server.py
@@ -332,7 +332,7 @@ class TestActionServer(unittest.TestCase):
             goal_handle.canceled()
             return Fibonacci.Result()
 
-        def cancel_callback(request: CancelGoal.Request) -> CancelResponse:
+        def cancel_callback(goal_handle: ServerGoalHandle[Any, Any, Any, Any]) -> CancelResponse:
             return CancelResponse.ACCEPT
 
         executor = MultiThreadedExecutor(context=self.context)
@@ -383,7 +383,7 @@ class TestActionServer(unittest.TestCase):
             goal_handle.canceled()
             return Fibonacci.Result()
 
-        def cancel_callback(request: CancelGoal.Request) -> CancelResponse:
+        def cancel_callback(goal_handle: ServerGoalHandle[Any, Any, Any, Any]) -> CancelResponse:
             return CancelResponse.REJECT
 
         executor = MultiThreadedExecutor(context=self.context)
@@ -431,7 +431,7 @@ class TestActionServer(unittest.TestCase):
             nonlocal server_goal_handle
             server_goal_handle = gh
 
-        def cancel_callback(request: CancelGoal.Request) -> CancelResponse:
+        def cancel_callback(goal_handle: ServerGoalHandle[Any, Any, Any, Any]) -> CancelResponse:
             return CancelResponse.ACCEPT
 
         def execute_callback(gh: ServerGoalHandle[Fibonacci.Goal,


### PR DESCRIPTION
## Description
This fixes some incorrect type hints in Action Client and Server callbacks.
1. `feedback_callback` argument changed from `FeedbackT` to `FeedbackMessage[FeedbackT]`
2. `cancel_callback` argument changed from `GoalT` to `ServerGoalHandle`
3. All callback type hints now support passing a coroutine function instead of a normal function.

### Is this user-facing behavior change?

The user no longer has to add `# type: ignore` comments if using a static type checker

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
