### PR TITLE
Correct typos

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(rosidl_runtime_c REQUIRED)
 # /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
 # /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
 # The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
+# user specifically tells us otherwise through the Python3_EXECUTABLE hint.
 # Setting CMP0094 to NEW means that the search will stop after the first
 # python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
 # the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that

--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -302,7 +302,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT],
         if seq in self._result_sequence_number_to_goal_id:
             goal_uuid = bytes(self._result_sequence_number_to_goal_id[seq].uuid)
             del self._result_sequence_number_to_goal_id[seq]
-            # remove feeback_callback if user is aware of result and it's been received
+            # remove feedback_callback if user is aware of result and it's been received
             if goal_uuid in self._feedback_callbacks:
                 del self._feedback_callbacks[goal_uuid]
 

--- a/rclpy/rclpy/event_handler.py
+++ b/rclpy/rclpy/event_handler.py
@@ -161,7 +161,7 @@ class EventHandler(Waitable[EventHandlerData]):
         return NumberOfEntities(num_events=1)
 
     def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
-        """Add entites to wait set."""
+        """Add entities to wait set."""
         with self.__event:
             self._event_index = wait_set.add_event(self.__event)
 

--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -373,7 +373,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT, ImplT], Destroyable):
         """Take an action goal response."""
 
     def send_result_request(self, pyrequest: GetResultServiceRequest) -> int:
-        """Send an action result requst."""
+        """Send an action result request."""
 
     def take_cancel_response(self, pymsg_type: type[CancelGoal.Response]
                              ) -> tuple[int, CancelGoal.Response] | tuple[None, None]:
@@ -516,7 +516,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT], Destroyable):
     def process_cancel_request(
         self,
         pycancel_request: CancelGoal.Request,
-        pycancel_response_tpye: type[CancelGoal.Response]
+        pycancel_response_type: type[CancelGoal.Response]
     ) -> CancelGoal.Response:
         """Process a cancel request."""
 
@@ -704,7 +704,7 @@ class WaitSet(Destroyable):
         """Add a service to the wait set structure."""
 
     def add_subscription(self, subscription: Subscription[Any]) -> int:
-        """Add a subcription to the wait set structure."""
+        """Add a subscription to the wait set structure."""
 
     def add_client(self, client: Client[Any, Any]) -> int:
         """Add a client to the wait set structure."""
@@ -928,14 +928,14 @@ class EventHandle(Destroyable, Generic[T]):
     @overload
     def __init__(
         self,
-        subcription: Subscription[Any],
+        subscription: Subscription[Any],
         event_type: rcl_subscription_event_type_t
     ) -> None: ...
 
     @overload
     def __init__(
         self,
-        subcription: Publisher[Any],
+        subscription: Publisher[Any],
         event_type: rcl_publisher_event_type_t
     ) -> None: ...
 

--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -935,7 +935,7 @@ class EventHandle(Destroyable, Generic[T]):
     @overload
     def __init__(
         self,
-        subscription: Publisher[Any],
+        publisher: Publisher[Any],
         event_type: rcl_publisher_event_type_t
     ) -> None: ...
 

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -202,7 +202,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 lifecycle_msgs.msg.Transition.TRANSITION_INACTIVE_SHUTDOWN)
         if current_state == 'active':
             return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_ACTIVE_SHUTDOWN)
-        raise _rclpy.RCLError('Shutdown transtion not possible')
+        raise _rclpy.RCLError('Shutdown transition not possible')
 
     def trigger_activate(self) -> TransitionCallbackReturn:
         return self.__change_state(lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE)

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -395,7 +395,7 @@ QoSLivelinessPolicy: TypeAlias = LivelinessPolicy
 # See `RMW_QOS_DEADLINE_BEST_AVAILABLE` in rmw/types.h for more info.
 DeadlineBestAvailable = Duration(nanoseconds=_rclpy.RMW_QOS_DEADLINE_BEST_AVAILABLE)
 
-# Liveliness lease duraiton policy to match the majority of endpoints while being as strict as
+# Liveliness lease duration policy to match the majority of endpoints while being as strict as
 # possible
 # See `RMW_QOS_LIVELINESS_LEASE_DURATION_BEST_AVAILABLE` in rmw/types.h for more info.
 LivelinessLeaseDurationeBestAvailable = Duration(

--- a/rclpy/rclpy/qos_overriding_options.py
+++ b/rclpy/rclpy/qos_overriding_options.py
@@ -68,7 +68,7 @@ class QoSOverridingOptions:
 
         :param policy_kinds: QoS kinds that will have a declared parameter.
         :param callback: Callback that will be used to validate the QoS profile
-            after the paramter overrides get applied.
+            after the parameter overrides get applied.
         :param entity_id: Optional identifier, to disambiguate in the case that different QoS
             policies for the same topic are desired.
         """

--- a/rclpy/rclpy/time_source.py
+++ b/rclpy/rclpy/time_source.py
@@ -38,7 +38,7 @@ class TimeSource:
         self._clock_sub: Optional['Subscription[rosgraph_msgs.msg.Clock]'] = None
         self._node_weak_ref: Optional[weakref.ReferenceType['Node']] = None
         self._associated_clocks: Set[ROSClock] = set()
-        # Zero time is a special value that means time is uninitialzied
+        # Zero time is a special value that means time is uninitialized
         self._last_time_set = Time(clock_type=ClockType.ROS_TIME)
         self._ros_time_is_active = False
         if node is not None:

--- a/rclpy/rclpy/utilities.py
+++ b/rclpy/rclpy/utilities.py
@@ -135,7 +135,7 @@ def get_available_rmw_implementations() -> Set[str]:
         missing_rmw_implementations = set(rmw_implementations_array) - \
             available_rmw_implementations
         if missing_rmw_implementations:
-            # TODO(sloretz) function name suggets to me it would return available ones even
+            # TODO(sloretz) function name suggests to me it would return available ones even
             # if some were missing.
             raise RuntimeError(
                 f'The RMW implementations {missing_rmw_implementations} '

--- a/rclpy/src/rclpy/_rclpy_logging.cpp
+++ b/rclpy/src/rclpy/_rclpy_logging.cpp
@@ -109,7 +109,7 @@ rclpy_logging_get_logger_effective_level(const char * name)
 
 /// Get the level of a logger
 /**
- * This considers the severity level of the specifed logger only.
+ * This considers the severity level of the specified logger only.
  *
  * \param[in] name Fully-qualified name of logger.
  * \return The level of the logger

--- a/rclpy/src/rclpy/action_server.cpp
+++ b/rclpy/src/rclpy/action_server.cpp
@@ -223,7 +223,7 @@ ActionServer::notify_goal_done()
 {
   rcl_ret_t ret = rcl_action_notify_goal_done(rcl_action_server_.get());
   if (RCL_RET_OK != ret) {
-    throw rclpy::RCLError("Failed to notfiy action server of goal done");
+    throw rclpy::RCLError("Failed to notify action server of goal done");
   }
 }
 

--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -312,7 +312,7 @@ void EventsExecutor::HandleSubscriptionReady(py::handle subscription, size_t num
 {
   py::gil_scoped_acquire gil_acquire;
 
-  // Largely based on rclpy.Executor._take_subscription() and _execute_subcription().
+  // Largely based on rclpy.Executor._take_subscription() and _execute_subscription().
   // https://github.com/ros2/rclpy/blob/06d78fb28a6d61ede793201ae75474f3e5432b47/rclpy/rclpy/executors.py#L355-L367
   //
   // NOTE: Simple object attributes we can count on to be owned by the parent object, but bound

--- a/rclpy/src/rclpy/qos.hpp
+++ b/rclpy/src/rclpy/qos.hpp
@@ -43,7 +43,7 @@ struct QoSCheckCompatibleResult
 
 /// Check if two QoS profiles are compatible.
 /**
- * Two QoS profiles are compatible if a publisher and subcription
+ * Two QoS profiles are compatible if a publisher and subscription
  * using the QoS policies can communicate with each other.
  *
  * If any policies have value "system default" or "unknown" then it is possible that

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -123,7 +123,7 @@ public:
    * \param[in] filter_expression A filter expression to set.
    *   An empty string ("") will clear the content filter setting of the subscription.
    * \param[in] expression_parameters Array of expression parameters to set.
-   * \throws RCLError if an unexpect error occurs
+   * \throws RCLError if an unexpected error occurs
    */
   void
   set_content_filter(
@@ -133,7 +133,7 @@ public:
   /// Get the filter expression and expression parameters for the subscription.
   /**
    * \return The content filter options to get.
-   * \throws RCLError if an unexpect error occurs
+   * \throws RCLError if an unexpected error occurs
    */
   py::object
   get_content_filter() const;

--- a/rclpy/src/rclpy/wait_set.cpp
+++ b/rclpy/src/rclpy/wait_set.cpp
@@ -269,7 +269,7 @@ void define_waitset(py::object module)
     "Add a service to the wait set structure")
   .def(
     "add_subscription", &WaitSet::add_subscription,
-    "Add a subcription to the wait set structure")
+    "Add a subscription to the wait set structure")
   .def(
     "add_client", &WaitSet::add_client,
     "Add a client to the wait set structure")

--- a/rclpy/src/rclpy/wait_set.hpp
+++ b/rclpy/src/rclpy/wait_set.hpp
@@ -79,7 +79,7 @@ public:
   size_t
   add_service(const Service & service);
 
-  /// Add a subcription to the wait set structure
+  /// Add a subscription to the wait set structure
   /**
    * Raises RCLError if any lower level error occurs
    *

--- a/rclpy/test/test_action_server.py
+++ b/rclpy/test/test_action_server.py
@@ -421,7 +421,7 @@ class TestActionServer(unittest.TestCase):
         action_server.destroy()
         executor.shutdown()
 
-    def test_cancel_defered_goal(self) -> None:
+    def test_cancel_deferred_goal(self) -> None:
         server_goal_handle = None
 
         def handle_accepted_callback(gh: ServerGoalHandle[Fibonacci.Goal,

--- a/rclpy/test/test_node.py
+++ b/rclpy/test/test_node.py
@@ -157,7 +157,7 @@ class TestNodeAllowUndeclaredParameters(unittest.TestCase):
             executor.spin_once(timeout_sec=1)
         self.assertIsNotNone(self.raw_subscription_msg, 'raw subscribe timed out')
         self.assertIs(type(self.raw_subscription_msg), bytes, 'raw subscribe did not return bytes')
-        # The length might be implementation dependant, but shouldn't be zero
+        # The length might be implementation dependent, but shouldn't be zero
         # There may be a canonical serialization in the future at which point this can be updated
         self.assertNotEqual(len(cast(bytes, self.raw_subscription_msg)), 0,
                             'raw subscribe invalid length')

--- a/rclpy/test/test_parameter_client.py
+++ b/rclpy/test/test_parameter_client.py
@@ -101,7 +101,7 @@ class TestParameterClient(unittest.TestCase):
         assert results.descriptors[0].type == ParameterType.PARAMETER_INTEGER_ARRAY
         assert results.descriptors[0].name == 'int_arr_param'
 
-    def test_get_paramter_types(self) -> None:
+    def test_get_parameter_types(self) -> None:
         future = self.client.get_parameter_types(['int_arr_param'])
         self.executor.spin_until_future_complete(future)
         results = future.result()

--- a/rclpy/test/test_parameter_event_handler.py
+++ b/rclpy/test/test_parameter_event_handler.py
@@ -122,7 +122,7 @@ class TestParameterEventHandler(unittest.TestCase):
             new_parameters=[int_param, str_param]
         )
 
-        # Correct parameter name, corrent node name
+        # Correct parameter name, correct node name
         assert int_param == ParameterEventHandler.get_parameter_from_event(
             new_params_event, 'int_param', self.target_node.get_fully_qualified_name()
         )

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -159,7 +159,7 @@ def test_cancel_reset(period: float) -> None:
                         executor.spin_once(timeout_sec=period / 10)
                     assert [] == callbacks
 
-                    # Reenable timer and make sure callbacks are received again
+                    # Re-enable timer and make sure callbacks are received again
                     timer.reset()
                     assert not timer.is_canceled()
                     begin_time = time.time()


### PR DESCRIPTION
## Description

I ran a typo check using [typos](https://github.com/crate-ci/typos) and [codespell](https://github.com/codespell-project/codespell)

I also found that one of the parameter names in `_rclpy_pybind11.pyi` was wrong so I corrected it