### PR TITLE
Refactor: base entity classes

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -36,7 +36,84 @@ SrvTypeRequest = TypeVar('SrvTypeRequest')
 SrvTypeResponse = TypeVar('SrvTypeResponse')
 
 
-class Client(Generic[SrvRequestT, SrvResponseT]):
+class BaseClient(Generic[SrvRequestT, SrvResponseT]):
+    def __init__(
+        self,
+        context: Context,
+        client_impl: '_rclpy.Client[SrvRequestT, SrvResponseT]',
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        qos_profile: QoSProfile,
+    ) -> None:
+        self.context = context
+        self.__client = client_impl
+        self.srv_type = srv_type
+        self.srv_name = srv_name
+        self.qos_profile = qos_profile
+
+    def service_is_ready(self) -> bool:
+        """
+        Check if there is a service server ready.
+
+        :return: ``True`` if a server is ready, ``False`` otherwise.
+        """
+        with self.handle:
+            return self.__client.service_server_is_available()
+
+    def configure_introspection(
+        self, clock: Clock,
+        service_event_qos_profile: QoSProfile,
+        introspection_state: ServiceIntrospectionState
+    ) -> None:
+        """
+        Configure client introspection.
+
+        :param clock: Clock to use for generating timestamps.
+        :param service_event_qos_profile: QoSProfile to use when creating service event publisher.
+        :param introspection_state: ServiceIntrospectionState to set introspection.
+        """
+        with self.handle:
+            self.__client.configure_introspection(clock.handle,
+                                                  service_event_qos_profile.get_c_qos_profile(),
+                                                  introspection_state)
+
+    @property
+    def handle(self) -> '_rclpy.Client[SrvRequestT, SrvResponseT]':
+        return self.__client
+
+    @property
+    def service_name(self) -> str:
+        with self.handle:
+            return self.__client.service_name
+
+    @property
+    def logger_name(self) -> str:
+        """Get the name of the logger associated with the node of the client."""
+        with self.handle:
+            return self.__client.get_logger_name()
+
+    def destroy(self) -> None:
+        """
+        Destroy a container for a ROS service client.
+
+        .. warning:: Users should not destroy a service client with this destructor, instead they
+           should call :meth:`.Node.destroy_client`.
+        """
+        self.__client.destroy_when_not_in_use()
+
+    def __enter__(self) -> 'Client[SrvRequestT, SrvResponseT]':
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.destroy()
+
+
+class Client(BaseClient[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvResponseT]):
     def __init__(
         self,
         context: Context,
@@ -60,11 +137,13 @@ class Client(Generic[SrvRequestT, SrvResponseT]):
         :param callback_group: The callback group for the service client. If ``None``, then the
             nodes default callback group is used.
         """
-        self.context = context
-        self.__client = client_impl
-        self.srv_type = srv_type
-        self.srv_name = srv_name
-        self.qos_profile = qos_profile
+        super().__init__(
+            context=context,
+            client_impl=client_impl,
+            srv_type=srv_type,
+            srv_name=srv_name,
+            qos_profile=qos_profile
+        )
         # Key is a sequence number, value is an instance of a Future
         self._pending_requests: Dict[int, Future[SrvResponseT]] = {}
         self.callback_group = callback_group
@@ -132,7 +211,7 @@ class Client(Generic[SrvRequestT, SrvResponseT]):
 
         with self._lock:
             with self.handle:
-                sequence_number = self.__client.send_request(request)
+                sequence_number = self.handle.send_request(request)
             if sequence_number in self._pending_requests:
                 raise RuntimeError(f'Sequence ({sequence_number}) conflicts with pending request')
 
@@ -168,15 +247,6 @@ class Client(Generic[SrvRequestT, SrvResponseT]):
                     del self._pending_requests[seq]
                     break
 
-    def service_is_ready(self) -> bool:
-        """
-        Check if there is a service server ready.
-
-        :return: ``True`` if a server is ready, ``False`` otherwise.
-        """
-        with self.handle:
-            return self.__client.service_server_is_available()
-
     def wait_for_service(self, timeout_sec: Optional[float] = None) -> bool:
         """
         Wait for a service server to become ready.
@@ -197,55 +267,3 @@ class Client(Generic[SrvRequestT, SrvResponseT]):
             timeout_sec -= sleep_time
 
         return self.service_is_ready()
-
-    def configure_introspection(
-        self, clock: Clock,
-        service_event_qos_profile: QoSProfile,
-        introspection_state: ServiceIntrospectionState
-    ) -> None:
-        """
-        Configure client introspection.
-
-        :param clock: Clock to use for generating timestamps.
-        :param service_event_qos_profile: QoSProfile to use when creating service event publisher.
-        :param introspection_state: ServiceIntrospectionState to set introspection.
-        """
-        with self.handle:
-            self.__client.configure_introspection(clock.handle,
-                                                  service_event_qos_profile.get_c_qos_profile(),
-                                                  introspection_state)
-
-    @property
-    def handle(self) -> '_rclpy.Client[SrvRequestT, SrvResponseT]':
-        return self.__client
-
-    @property
-    def service_name(self) -> str:
-        with self.handle:
-            return self.__client.service_name
-
-    @property
-    def logger_name(self) -> str:
-        """Get the name of the logger associated with the node of the client."""
-        with self.handle:
-            return self.__client.get_logger_name()
-
-    def destroy(self) -> None:
-        """
-        Destroy a container for a ROS service client.
-
-        .. warning:: Users should not destroy a service client with this destructor, instead they
-           should call :meth:`.Node.destroy_client`.
-        """
-        self.__client.destroy_when_not_in_use()
-
-    def __enter__(self) -> 'Client[SrvRequestT, SrvResponseT]':
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        self.destroy()

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -121,6 +121,7 @@ class Client(BaseClient[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvResp
         srv_type: type[Srv[SrvRequestT, SrvResponseT]],
         srv_name: str,
         qos_profile: QoSProfile,
+        *,
         callback_group: CallbackGroup
     ) -> None:
         """

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -101,7 +101,7 @@ class BaseClient(Generic[SrvRequestT, SrvResponseT]):
         """
         self.__client.destroy_when_not_in_use()
 
-    def __enter__(self) -> 'Client[SrvRequestT, SrvResponseT]':
+    def __enter__(self) -> 'BaseClient[SrvRequestT, SrvResponseT]':
         return self
 
     def __exit__(

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -722,7 +722,7 @@ class Executor(ContextManager['Executor']):
         timeout_nsec = timeout_sec_to_nsec(
             timeout_sec.timeout if isinstance(timeout_sec, TimeoutObject) else timeout_sec)
         if timeout_nsec > 0:
-            timeout_timer = Timer(None, None, timeout_nsec, self._clock, context=self._context)
+            timeout_timer = Timer(None, timeout_nsec, self._clock, None, context=self._context)
 
         yielded_work = False
         while not yielded_work and not self._is_shutdown and not condition():

--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -722,7 +722,9 @@ class Executor(ContextManager['Executor']):
         timeout_nsec = timeout_sec_to_nsec(
             timeout_sec.timeout if isinstance(timeout_sec, TimeoutObject) else timeout_sec)
         if timeout_nsec > 0:
-            timeout_timer = Timer(None, timeout_nsec, self._clock, None, context=self._context)
+            timeout_timer = Timer(
+                None, timeout_nsec, self._clock, context=self._context
+            )
 
         yielded_work = False
         while not yielded_work and not self._is_shutdown and not condition():

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -144,35 +144,35 @@ class LifecycleNodeMixin(ManagedEntity):
                 self._state_machine.service_change_state.name,
                 self.__on_change_state,
                 QoSProfile(**self._state_machine.service_change_state.qos),
-                callback_group)
+                callback_group=callback_group)
             self._service_get_state = Service(
                 self._state_machine.service_get_state,
                 lifecycle_msgs.srv.GetState,
                 self._state_machine.service_get_state.name,
                 self.__on_get_state,
                 QoSProfile(**self._state_machine.service_get_state.qos),
-                callback_group)
+                callback_group=callback_group)
             self._service_get_available_states = Service(
                 self._state_machine.service_get_available_states,
                 lifecycle_msgs.srv.GetAvailableStates,
                 self._state_machine.service_get_available_states.name,
                 self.__on_get_available_states,
                 QoSProfile(**self._state_machine.service_get_available_states.qos),
-                callback_group)
+                callback_group=callback_group)
             self._service_get_available_transitions = Service(
                 self._state_machine.service_get_available_transitions,
                 lifecycle_msgs.srv.GetAvailableTransitions,
                 self._state_machine.service_get_available_transitions.name,
                 self.__on_get_available_transitions,
                 QoSProfile(**self._state_machine.service_get_available_transitions.qos),
-                callback_group)
+                callback_group=callback_group)
             self._service_get_transition_graph = Service(
                 self._state_machine.service_get_transition_graph,
                 lifecycle_msgs.srv.GetAvailableTransitions,
                 self._state_machine.service_get_transition_graph.name,
                 self.__on_get_transition_graph,
                 QoSProfile(**self._state_machine.service_get_transition_graph.qos),
-                callback_group)
+                callback_group=callback_group)
 
             lifecycle_services = [
                 self._service_change_state,

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -143,36 +143,36 @@ class LifecycleNodeMixin(ManagedEntity):
                 lifecycle_msgs.srv.ChangeState,
                 self._state_machine.service_change_state.name,
                 self.__on_change_state,
-                callback_group,
-                QoSProfile(**self._state_machine.service_change_state.qos))
+                QoSProfile(**self._state_machine.service_change_state.qos),
+                callback_group)
             self._service_get_state = Service(
                 self._state_machine.service_get_state,
                 lifecycle_msgs.srv.GetState,
                 self._state_machine.service_get_state.name,
                 self.__on_get_state,
-                callback_group,
-                QoSProfile(**self._state_machine.service_get_state.qos))
+                QoSProfile(**self._state_machine.service_get_state.qos),
+                callback_group)
             self._service_get_available_states = Service(
                 self._state_machine.service_get_available_states,
                 lifecycle_msgs.srv.GetAvailableStates,
                 self._state_machine.service_get_available_states.name,
                 self.__on_get_available_states,
-                callback_group,
-                QoSProfile(**self._state_machine.service_get_available_states.qos))
+                QoSProfile(**self._state_machine.service_get_available_states.qos),
+                callback_group)
             self._service_get_available_transitions = Service(
                 self._state_machine.service_get_available_transitions,
                 lifecycle_msgs.srv.GetAvailableTransitions,
                 self._state_machine.service_get_available_transitions.name,
                 self.__on_get_available_transitions,
-                callback_group,
-                QoSProfile(**self._state_machine.service_get_available_transitions.qos))
+                QoSProfile(**self._state_machine.service_get_available_transitions.qos),
+                callback_group)
             self._service_get_transition_graph = Service(
                 self._state_machine.service_get_transition_graph,
                 lifecycle_msgs.srv.GetAvailableTransitions,
                 self._state_machine.service_get_transition_graph.name,
                 self.__on_get_transition_graph,
-                callback_group,
-                QoSProfile(**self._state_machine.service_get_transition_graph.qos))
+                QoSProfile(**self._state_machine.service_get_transition_graph.qos),
+                callback_group)
 
             lifecycle_services = [
                 self._service_change_state,

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -29,8 +29,7 @@ from typing_extensions import Unpack
 from .managed_entity import SimpleManagedEntity
 
 if TYPE_CHECKING:
-    LifecyclePublisherArgs: TypeAlias = Tuple[_rclpy.Publisher[MsgT], Type[MsgT], str, QoSProfile,
-                                              PublisherEventCallbacks, CallbackGroup]
+    LifecyclePublisherArgs: TypeAlias = Tuple[_rclpy.Publisher[MsgT], Type[MsgT], str, QoSProfile]
 
     class LifecyclePublisherKWArgs(TypedDict, Generic[MsgT]):
         publisher_impl: _rclpy.Publisher[MsgT]

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1862,7 +1862,7 @@ class Node:
         if clock is None:
             clock = self._clock
         timer = Timer(
-            callback, callback_group, timer_period_nsec, clock, context=self.context,
+            callback, timer_period_nsec, clock, callback_group, context=self.context,
             autostart=autostart)
 
         callback_group.add_entity(timer)

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1825,7 +1825,8 @@ class Node:
 
         service = Service(
             service_impl,
-            srv_type, srv_name, callback, callback_group, qos_profile)
+            srv_type, srv_name, callback, qos_profile,
+            callback_group=callback_group)
         callback_group.add_entity(service)
         self._services.append(service)
         self._wake_executor()

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1730,7 +1730,8 @@ class Node:
         try:
             subscription = Subscription(
                 subscription_object, msg_type,
-                topic, callback, callback_group, qos_profile, raw,
+                topic, callback, qos_profile, raw,
+                callback_group=callback_group,
                 event_callbacks=event_callbacks or SubscriptionEventCallbacks())
         except Exception:
             subscription_object.destroy_when_not_in_use()

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1781,7 +1781,7 @@ class Node:
         client = Client(
             self.context,
             client_impl, srv_type, srv_name, qos_profile,
-            callback_group)
+            callback_group=callback_group)
         callback_group.add_entity(client)
         self._clients.append(client)
         self._wake_executor()
@@ -1862,8 +1862,11 @@ class Node:
         if clock is None:
             clock = self._clock
         timer = Timer(
-            callback, timer_period_nsec, clock, callback_group, context=self.context,
-            autostart=autostart)
+            callback, timer_period_nsec, clock,
+            callback_group=callback_group,
+            context=self.context,
+            autostart=autostart
+        )
 
         callback_group.add_entity(timer)
         self._timers.append(timer)

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -26,7 +26,7 @@ from rclpy.type_support import MsgT
 MsgType = TypeVar('MsgType')
 
 
-class Publisher(Generic[MsgT]):
+class BasePublisher(Generic[MsgT]):
 
     def __init__(
         self,
@@ -34,30 +34,11 @@ class Publisher(Generic[MsgT]):
         msg_type: Type[MsgT],
         topic: str,
         qos_profile: QoSProfile,
-        event_callbacks: PublisherEventCallbacks,
-        callback_group: CallbackGroup,
     ) -> None:
-        """
-        Create a container for a ROS publisher.
-
-        .. warning:: Users should not create a publisher with this constructor, instead they should
-           call :meth:`.Node.create_publisher`.
-
-        A publisher is used as a primary means of communication in a ROS system by publishing
-        messages on a ROS topic.
-
-        :param publisher_impl: Publisher wrapping the underlying ``rcl_publisher_t`` object.
-        :param msg_type: The type of ROS messages the publisher will publish.
-        :param topic: The name of the topic the publisher will publish to.
-        :param qos_profile: The quality of service profile to apply to the publisher.
-        """
         self.__publisher = publisher_impl
         self.msg_type = msg_type
         self.topic = topic
         self.qos_profile = qos_profile
-
-        self.event_handlers: List[EventHandler] = event_callbacks.create_event_handlers(
-            callback_group, publisher_impl, topic)
 
     def publish(self, msg: Union[MsgT, bytes]) -> None:
         """
@@ -96,14 +77,6 @@ class Publisher(Generic[MsgT]):
             return self.__publisher.get_logger_name()
 
     def destroy(self) -> None:
-        """
-        Destroy a container for a ROS publisher.
-
-        .. warning:: Users should not destroy a publisher with this method, instead they should
-           call :meth:`.Node.destroy_publisher`.
-        """
-        for handler in self.event_handlers:
-            handler.destroy()
         self.__publisher.destroy_when_not_in_use()
 
     def assert_liveliness(self) -> None:
@@ -115,6 +88,53 @@ class Publisher(Generic[MsgT]):
         """
         with self.handle:
             _rclpy.rclpy_assert_liveliness(self.handle)
+
+    def __enter__(self) -> 'Publisher[MsgT]':
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.destroy()
+
+
+class Publisher(BasePublisher[MsgT], Generic[MsgT]):
+
+    def __init__(
+        self,
+        publisher_impl: '_rclpy.Publisher[MsgT]',
+        msg_type: Type[MsgT],
+        topic: str,
+        qos_profile: QoSProfile,
+        event_callbacks: PublisherEventCallbacks,
+        callback_group: CallbackGroup,
+    ) -> None:
+        """
+        Create a container for a ROS publisher.
+
+        .. warning:: Users should not create a publisher with this constructor, instead they should
+           call :meth:`.Node.create_publisher`.
+
+        A publisher is used as a primary means of communication in a ROS system by publishing
+        messages on a ROS topic.
+
+        :param publisher_impl: Publisher wrapping the underlying ``rcl_publisher_t`` object.
+        :param msg_type: The type of ROS messages the publisher will publish.
+        :param topic: The name of the topic the publisher will publish to.
+        :param qos_profile: The quality of service profile to apply to the publisher.
+        """
+        super().__init__(
+            publisher_impl=publisher_impl,
+            msg_type=msg_type,
+            topic=topic,
+            qos_profile=qos_profile
+        )
+
+        self.event_handlers: List[EventHandler] = event_callbacks.create_event_handlers(
+            callback_group, publisher_impl, topic)
 
     def wait_for_all_acked(self, timeout: Duration = Duration(seconds=-1)) -> bool:
         """
@@ -134,15 +154,15 @@ class Publisher(Generic[MsgT]):
             false.
         """
         with self.handle:
-            return self.__publisher.wait_for_all_acked(timeout._duration_handle)
+            return self.handle.wait_for_all_acked(timeout._duration_handle)
 
-    def __enter__(self) -> 'Publisher[MsgT]':
-        return self
+    def destroy(self) -> None:
+        """
+        Destroy a container for a ROS publisher.
 
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        self.destroy()
+        .. warning:: Users should not destroy a publisher with this method, instead they should
+           call :meth:`.Node.destroy_publisher`.
+        """
+        for handler in self.event_handlers:
+            handler.destroy()
+        super().destroy()

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -89,7 +89,7 @@ class BasePublisher(Generic[MsgT]):
         with self.handle:
             _rclpy.rclpy_assert_liveliness(self.handle)
 
-    def __enter__(self) -> 'Publisher[MsgT]':
+    def __enter__(self) -> 'BasePublisher[MsgT]':
         return self
 
     def __exit__(

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -109,6 +109,7 @@ class Publisher(BasePublisher[MsgT], Generic[MsgT]):
         msg_type: Type[MsgT],
         topic: str,
         qos_profile: QoSProfile,
+        *,
         event_callbacks: PublisherEventCallbacks,
         callback_group: CallbackGroup,
     ) -> None:

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from types import TracebackType
-from typing import Awaitable, Callable, TypeAlias
+from typing import Awaitable, Callable
 from typing import Generic
 from typing import Optional
 from typing import Type
@@ -26,6 +26,7 @@ from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.qos import QoSProfile
 from rclpy.service_introspection import ServiceIntrospectionState
 from rclpy.type_support import Srv, SrvRequestT, SrvResponseT
+from typing_extensions import TypeAlias
 
 # Used for documentation purposes only
 SrvType = TypeVar('SrvType')
@@ -115,7 +116,7 @@ class BaseService(Generic[SrvRequestT, SrvResponseT]):
         """
         self.__service.destroy_when_not_in_use()
 
-    def __enter__(self) -> 'Service[SrvRequestT, SrvResponseT]':
+    def __enter__(self) -> 'BaseService[SrvRequestT, SrvResponseT]':
         return self
 
     def __exit__(

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -136,6 +136,7 @@ class Service(BaseService[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvRe
         srv_name: str,
         callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
         qos_profile: QoSProfile,
+        *,
         callback_group: CallbackGroup
     ) -> None:
         """

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -50,7 +50,7 @@ class BaseService(Generic[SrvRequestT, SrvResponseT]):
         service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]',
         srv_type: type[Srv[SrvRequestT, SrvResponseT]],
         srv_name: str,
-        callback: AsyncGenericServiceCallback[SrvRequestT, SrvResponseT],
+        callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
         qos_profile: QoSProfile
     ) -> None:
         self.__service = service_impl

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from types import TracebackType
-from typing import Callable
+from typing import Awaitable, Callable, TypeAlias
 from typing import Generic
 from typing import Optional
 from typing import Type
@@ -32,52 +32,38 @@ SrvType = TypeVar('SrvType')
 SrvTypeRequest = TypeVar('SrvTypeRequest')
 SrvTypeResponse = TypeVar('SrvTypeResponse')
 
+GenericServiceCallback: TypeAlias = Callable[[SrvRequestT, SrvResponseT], SrvResponseT]
+AsyncGenericServiceCallback: TypeAlias = Callable[
+    [SrvRequestT, SrvResponseT],
+    Awaitable[SrvResponseT]
+]
+ServiceCallbackUnion: TypeAlias = Union[
+    GenericServiceCallback[SrvRequestT, SrvResponseT],
+    AsyncGenericServiceCallback[SrvRequestT, SrvResponseT]
+]
 
-class Service(Generic[SrvRequestT, SrvResponseT]):
+
+class BaseService(Generic[SrvRequestT, SrvResponseT]):
+
     def __init__(
         self,
         service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]',
         srv_type: type[Srv[SrvRequestT, SrvResponseT]],
         srv_name: str,
-        callback: Callable[[SrvRequestT, SrvResponseT], SrvResponseT],
-        callback_group: CallbackGroup,
+        callback: AsyncGenericServiceCallback[SrvRequestT, SrvResponseT],
         qos_profile: QoSProfile
     ) -> None:
-        """
-        Create a container for a ROS service server.
-
-        .. warning:: Users should not create a service server with this constructor, instead they
-           should call :meth:`.Node.create_service`.
-
-        :param service_impl: :class:`_rclpy.Service` wrapping the underlying ``rcl_service_t``
-            object.
-        :param srv_type: The service type.
-        :param srv_name: The name of the service.
-        :param callback: The callback that should be called to handle the request.
-        :param callback_group: The callback group for the service server. If ``None``, then the
-            nodes default callback group is used.
-        :param qos_profile: The quality of service profile to apply the service server.
-        """
         self.__service = service_impl
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.callback = callback
-        self.callback_group = callback_group
-        # True when the callback is ready to fire but has not been "taken" by an executor
-        self._executor_event = False
         self.qos_profile = qos_profile
 
-    def send_response(self, response: SrvResponseT,
-                      header: Union[_rclpy.rmw_service_info_t, _rclpy.rmw_request_id_t]) -> None:
-        """
-        Send a service response.
-
-        :param response: The service response.
-        :param header: Service header from the original request.
-        :raises: TypeError if the type of the passed response isn't an instance
-          of the Response type of the provided service when the service was
-          constructed.
-        """
+    def _send_response(
+        self,
+        response: SrvResponseT,
+        header: Union[_rclpy.rmw_service_info_t, _rclpy.rmw_request_id_t]
+    ) -> None:
         if not isinstance(response, self.srv_type.Response):
             raise TypeError()
         with self.handle:
@@ -139,3 +125,56 @@ class Service(Generic[SrvRequestT, SrvResponseT]):
         exc_tb: Optional[TracebackType],
     ) -> None:
         self.destroy()
+
+
+class Service(BaseService[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvResponseT]):
+    def __init__(
+        self,
+        service_impl: '_rclpy.Service[SrvRequestT, SrvResponseT]',
+        srv_type: type[Srv[SrvRequestT, SrvResponseT]],
+        srv_name: str,
+        callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
+        qos_profile: QoSProfile,
+        callback_group: CallbackGroup
+    ) -> None:
+        """
+        Create a container for a ROS service server.
+
+        .. warning:: Users should not create a service server with this constructor, instead they
+           should call :meth:`.Node.create_service`.
+
+        :param service_impl: :class:`_rclpy.Service` wrapping the underlying ``rcl_service_t``
+            object.
+        :param srv_type: The service type.
+        :param srv_name: The name of the service.
+        :param callback: The callback that should be called to handle the request.
+        :param callback_group: The callback group for the service server. If ``None``, then the
+            nodes default callback group is used.
+        :param qos_profile: The quality of service profile to apply the service server.
+        """
+        super().__init__(
+            service_impl=service_impl,
+            srv_type=srv_type,
+            srv_name=srv_name,
+            callback=callback,
+            qos_profile=qos_profile
+        )
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
+
+    def send_response(
+        self,
+        response: SrvResponseT,
+        header: Union[_rclpy.rmw_service_info_t, _rclpy.rmw_request_id_t]
+    ) -> None:
+        """
+        Send a service response.
+
+        :param response: The service response.
+        :param header: Service header from the original request.
+        :raises: TypeError if the type of the passed response isn't an instance
+          of the Response type of the provided service when the service was
+          constructed.
+        """
+        self._send_response(response, header)

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -223,6 +223,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          callback: GenericSubscriptionCallbackUnion[bytes],
          qos_profile: QoSProfile,
          raw: Literal[True],
+         *,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -236,6 +237,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          callback: GenericSubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: Literal[False],
+         *,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -249,6 +251,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          callback: SubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
+         *,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -261,6 +264,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          callback: SubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
+         *,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None:

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -119,8 +119,7 @@ class BaseSubscription(Generic[MsgT]):
         self.__subscription = subscription_impl
         self.msg_type = msg_type
         self.topic = topic
-        self._callback = callback
-        self._set_callback_type(callback)
+        self.callback = callback
         self.qos_profile = qos_profile
         self.raw = raw
 
@@ -140,6 +139,15 @@ class BaseSubscription(Generic[MsgT]):
     def topic_name(self) -> str:
         with self.handle:
             return self.__subscription.get_topic_name()
+
+    @property
+    def callback(self) -> SubscriptionCallbackUnion[MsgT]:
+        return self._callback
+
+    @callback.setter
+    def callback(self, value: SubscriptionCallbackUnion[MsgT]) -> None:
+        self._set_callback_type(value)
+        self._callback = value
 
     def _set_callback_type(self, callback: SubscriptionCallbackUnion[MsgT]) -> None:
         try:
@@ -288,15 +296,6 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
 
         self.event_handlers = event_callbacks.create_event_handlers(
             callback_group, subscription_impl, topic)
-
-    @property
-    def callback(self) -> SubscriptionCallbackUnion[MsgT]:
-        return self._callback
-
-    @callback.setter
-    def callback(self, value: SubscriptionCallbackUnion[MsgT]) -> None:
-        self._set_callback_type(value)
-        self._callback = value
 
     def destroy(self) -> None:
         """

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -62,11 +62,10 @@ GenericSubscriptionCallback: TypeAlias = Union[Callable[[T], None],
                                                Callable[[T, MessageInfo], None]]
 AsyncGenericSubscriptionCallback: TypeAlias = Union[Callable[[T], Awaitable[None]],
                                                     Callable[[T, MessageInfo], Awaitable[None]]]
-AsyncSubscriptionCallbackUnion: TypeAlias = Union[AsyncGenericSubscriptionCallback[MsgT],
-                                                  AsyncGenericSubscriptionCallback[bytes]]
-SubscriptionCallbackUnion: TypeAlias = Union[GenericSubscriptionCallback[MsgT],
-                                             GenericSubscriptionCallback[bytes],
-                                             AsyncSubscriptionCallbackUnion[MsgT]]
+GenericSubscriptionCallbackUnion: TypeAlias = Union[GenericSubscriptionCallback[T],
+                                                    AsyncGenericSubscriptionCallback[T]]
+SubscriptionCallbackUnion: TypeAlias = Union[GenericSubscriptionCallbackUnion[MsgT],
+                                             GenericSubscriptionCallbackUnion[bytes]]
 
 
 class BaseSubscription(Generic[MsgT]):
@@ -81,7 +80,7 @@ class BaseSubscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: AsyncGenericSubscriptionCallback[bytes],
+         callback: GenericSubscriptionCallbackUnion[bytes],
          qos_profile: QoSProfile,
          raw: Literal[True],
     ) -> None: ...
@@ -92,7 +91,7 @@ class BaseSubscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: AsyncGenericSubscriptionCallback[MsgT],
+         callback: GenericSubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: Literal[False],
     ) -> None: ...
@@ -103,7 +102,7 @@ class BaseSubscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: AsyncSubscriptionCallbackUnion[MsgT],
+         callback: SubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
     ) -> None: ...
@@ -113,14 +112,15 @@ class BaseSubscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: AsyncSubscriptionCallbackUnion[MsgT],
+         callback: SubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
     ) -> None:
         self.__subscription = subscription_impl
         self.msg_type = msg_type
         self.topic = topic
-        self.callback = callback
+        self._callback = callback
+        self._set_callback_type(callback)
         self.qos_profile = qos_profile
         self.raw = raw
 
@@ -140,15 +140,6 @@ class BaseSubscription(Generic[MsgT]):
     def topic_name(self) -> str:
         with self.handle:
             return self.__subscription.get_topic_name()
-
-    @property
-    def callback(self) -> AsyncSubscriptionCallbackUnion[MsgT]:
-        return self._callback
-
-    @callback.setter
-    def callback(self, value: AsyncSubscriptionCallbackUnion[MsgT]) -> None:
-        self._callback = value
-        self._set_callback_type(value)
 
     def _set_callback_type(self, callback: SubscriptionCallbackUnion[MsgT]) -> None:
         try:
@@ -221,7 +212,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: GenericSubscriptionCallback[bytes],
+         callback: GenericSubscriptionCallbackUnion[bytes],
          qos_profile: QoSProfile,
          raw: Literal[True],
          callback_group: CallbackGroup,
@@ -234,7 +225,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: GenericSubscriptionCallback[MsgT],
+         callback: GenericSubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: Literal[False],
          callback_group: CallbackGroup,
@@ -300,7 +291,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
 
     @property
     def callback(self) -> SubscriptionCallbackUnion[MsgT]:
-        return super().callback
+        return self._callback
 
     @callback.setter
     def callback(self, value: SubscriptionCallbackUnion[MsgT]) -> None:

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -295,8 +295,8 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
 
     @callback.setter
     def callback(self, value: SubscriptionCallbackUnion[MsgT]) -> None:
-        self._callback = value
         self._set_callback_type(value)
+        self._callback = value
 
     def destroy(self) -> None:
         """

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -16,6 +16,7 @@
 from enum import Enum
 import inspect
 from types import TracebackType
+from typing import Awaitable
 from typing import Callable
 from typing import Generic
 from typing import Literal
@@ -59,11 +60,16 @@ MsgType = TypeVar('MsgType')
 T = TypeVar('T')
 GenericSubscriptionCallback: TypeAlias = Union[Callable[[T], None],
                                                Callable[[T, MessageInfo], None]]
+AsyncGenericSubscriptionCallback: TypeAlias = Union[Callable[[T], Awaitable[None]],
+                                                    Callable[[T, MessageInfo], Awaitable[None]]]
+AsyncSubscriptionCallbackUnion: TypeAlias = Union[AsyncGenericSubscriptionCallback[MsgT],
+                                                  AsyncGenericSubscriptionCallback[bytes]]
 SubscriptionCallbackUnion: TypeAlias = Union[GenericSubscriptionCallback[MsgT],
-                                             GenericSubscriptionCallback[bytes]]
+                                             GenericSubscriptionCallback[bytes],
+                                             AsyncSubscriptionCallbackUnion[MsgT]]
 
 
-class Subscription(Generic[MsgT]):
+class BaseSubscription(Generic[MsgT]):
 
     class CallbackType(Enum):
         MessageOnly = 0
@@ -75,11 +81,9 @@ class Subscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: GenericSubscriptionCallback[bytes],
-         callback_group: CallbackGroup,
+         callback: AsyncGenericSubscriptionCallback[bytes],
          qos_profile: QoSProfile,
          raw: Literal[True],
-         event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
 
     @overload
@@ -88,11 +92,9 @@ class Subscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: GenericSubscriptionCallback[MsgT],
-         callback_group: CallbackGroup,
+         callback: AsyncGenericSubscriptionCallback[MsgT],
          qos_profile: QoSProfile,
          raw: Literal[False],
-         event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
 
     @overload
@@ -101,11 +103,9 @@ class Subscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: SubscriptionCallbackUnion[MsgT],
-         callback_group: CallbackGroup,
+         callback: AsyncSubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
-         event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
 
     def __init__(
@@ -113,42 +113,16 @@ class Subscription(Generic[MsgT]):
          subscription_impl: '_rclpy.Subscription[MsgT]',
          msg_type: Type[MsgT],
          topic: str,
-         callback: SubscriptionCallbackUnion[MsgT],
-         callback_group: CallbackGroup,
+         callback: AsyncSubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
-         event_callbacks: SubscriptionEventCallbacks,
     ) -> None:
-        """
-        Create a container for a ROS subscription.
-
-        .. warning:: Users should not create a subscription with this constructor, instead they
-           should call :meth:`.Node.create_subscription`.
-
-        :param subscription_impl: :class:`Subscription` wrapping the underlying
-            ``rcl_subscription_t`` object.
-        :param msg_type: The type of ROS messages the subscription will subscribe to.
-        :param topic: The name of the topic the subscription will subscribe to.
-        :param callback: A user-defined callback function that is called when a message is
-            received by the subscription.
-        :param callback_group: The callback group for the subscription. If ``None``, then the
-            nodes default callback group is used.
-        :param qos_profile: The quality of service profile to apply to the subscription.
-        :param raw: If ``True``, then received messages will be stored in raw binary
-            representation.
-        """
         self.__subscription = subscription_impl
         self.msg_type = msg_type
         self.topic = topic
         self.callback = callback
-        self.callback_group = callback_group
-        # True when the callback is ready to fire but has not been "taken" by an executor
-        self._executor_event = False
         self.qos_profile = qos_profile
         self.raw = raw
-
-        self.event_handlers = event_callbacks.create_event_handlers(
-            callback_group, subscription_impl, topic)
 
     def get_publisher_count(self) -> int:
         """Get the number of publishers that this subscription has."""
@@ -160,14 +134,6 @@ class Subscription(Generic[MsgT]):
         return self.__subscription
 
     def destroy(self) -> None:
-        """
-        Destroy a container for a ROS subscription.
-
-        .. warning:: Users should not destroy a subscription with this method, instead they
-           should call :meth:`.Node.destroy_subscription`.
-        """
-        for handler in self.event_handlers:
-            handler.destroy()
         self.handle.destroy_when_not_in_use()
 
     @property
@@ -176,21 +142,24 @@ class Subscription(Generic[MsgT]):
             return self.__subscription.get_topic_name()
 
     @property
-    def callback(self) -> SubscriptionCallbackUnion[MsgT]:
+    def callback(self) -> AsyncSubscriptionCallbackUnion[MsgT]:
         return self._callback
 
     @callback.setter
-    def callback(self, value: SubscriptionCallbackUnion[MsgT]) -> None:
+    def callback(self, value: AsyncSubscriptionCallbackUnion[MsgT]) -> None:
         self._callback = value
-        self._callback_type = Subscription.CallbackType.MessageOnly
+        self._set_callback_type(value)
+
+    def _set_callback_type(self, callback: SubscriptionCallbackUnion[MsgT]) -> None:
         try:
-            inspect.signature(value).bind(object())
+            inspect.signature(callback).bind(object())
+            self._callback_type = BaseSubscription.CallbackType.MessageOnly
             return
         except TypeError:
             pass
         try:
-            inspect.signature(value).bind(object(), object())
-            self._callback_type = Subscription.CallbackType.WithMessageInfo
+            inspect.signature(callback).bind(object(), object())
+            self._callback_type = BaseSubscription.CallbackType.WithMessageInfo
             return
         except TypeError:
             pass
@@ -242,3 +211,109 @@ class Subscription(Generic[MsgT]):
         exc_tb: Optional[TracebackType],
     ) -> None:
         self.destroy()
+
+
+class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
+
+    @overload
+    def __init__(
+         self,
+         subscription_impl: '_rclpy.Subscription[MsgT]',
+         msg_type: Type[MsgT],
+         topic: str,
+         callback: GenericSubscriptionCallback[bytes],
+         qos_profile: QoSProfile,
+         raw: Literal[True],
+         callback_group: CallbackGroup,
+         event_callbacks: SubscriptionEventCallbacks,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+         self,
+         subscription_impl: '_rclpy.Subscription[MsgT]',
+         msg_type: Type[MsgT],
+         topic: str,
+         callback: GenericSubscriptionCallback[MsgT],
+         qos_profile: QoSProfile,
+         raw: Literal[False],
+         callback_group: CallbackGroup,
+         event_callbacks: SubscriptionEventCallbacks,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+         self,
+         subscription_impl: '_rclpy.Subscription[MsgT]',
+         msg_type: Type[MsgT],
+         topic: str,
+         callback: SubscriptionCallbackUnion[MsgT],
+         qos_profile: QoSProfile,
+         raw: bool,
+         callback_group: CallbackGroup,
+         event_callbacks: SubscriptionEventCallbacks,
+    ) -> None: ...
+
+    def __init__(
+         self,
+         subscription_impl: '_rclpy.Subscription[MsgT]',
+         msg_type: Type[MsgT],
+         topic: str,
+         callback: SubscriptionCallbackUnion[MsgT],
+         qos_profile: QoSProfile,
+         raw: bool,
+         callback_group: CallbackGroup,
+         event_callbacks: SubscriptionEventCallbacks,
+    ) -> None:
+        """
+        Create a container for a ROS subscription.
+
+        .. warning:: Users should not create a subscription with this constructor, instead they
+           should call :meth:`.Node.create_subscription`.
+
+        :param subscription_impl: :class:`Subscription` wrapping the underlying
+            ``rcl_subscription_t`` object.
+        :param msg_type: The type of ROS messages the subscription will subscribe to.
+        :param topic: The name of the topic the subscription will subscribe to.
+        :param callback: A user-defined callback function that is called when a message is
+            received by the subscription.
+        :param callback_group: The callback group for the subscription. If ``None``, then the
+            nodes default callback group is used.
+        :param qos_profile: The quality of service profile to apply to the subscription.
+        :param raw: If ``True``, then received messages will be stored in raw binary
+            representation.
+        """
+        super().__init__(
+            subscription_impl=subscription_impl,
+            msg_type=msg_type,
+            topic=topic,
+            callback=callback,
+            qos_profile=qos_profile,
+            raw=raw
+        )
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
+
+        self.event_handlers = event_callbacks.create_event_handlers(
+            callback_group, subscription_impl, topic)
+
+    @property
+    def callback(self) -> SubscriptionCallbackUnion[MsgT]:
+        return super().callback
+
+    @callback.setter
+    def callback(self, value: SubscriptionCallbackUnion[MsgT]) -> None:
+        self._callback = value
+        self._set_callback_type(value)
+
+    def destroy(self) -> None:
+        """
+        Destroy a container for a ROS subscription.
+
+        .. warning:: Users should not destroy a subscription with this method, instead they
+           should call :meth:`.Node.destroy_subscription`.
+        """
+        for handler in self.event_handlers:
+            handler.destroy()
+        super().destroy()

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -155,7 +155,7 @@ class BaseSubscription(Generic[MsgT]):
         except TypeError:
             pass
         raise RuntimeError(
-            'Subscription.__init__(): callback should be either be callable with one argument'
+            'Subscription callback should be either be callable with one argument'
             '(to get only the message) or two (to get message and message info)')
 
     @property
@@ -192,7 +192,7 @@ class BaseSubscription(Generic[MsgT]):
         with self.handle:
             return self.__subscription.get_content_filter()
 
-    def __enter__(self) -> 'Subscription[MsgT]':
+    def __enter__(self) -> 'BaseSubscription[MsgT]':
         return self
 
     def __exit__(

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -145,7 +145,7 @@ class BaseTimer:
         with self.__timer:
             return self.__timer.time_until_next_call()
 
-    def __enter__(self) -> 'Timer':
+    def __enter__(self) -> 'BaseTimer':
         return self
 
     def __exit__(

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -164,10 +164,10 @@ class Timer(BaseTimer):
         callback: Optional[TimerCallbackUnion],
         timer_period_ns: int,
         clock: Clock,
-        callback_group: Optional[CallbackGroup],
         *,
         context: Optional[Context] = None,
-        autostart: bool = True
+        autostart: bool = True,
+        callback_group: Optional[CallbackGroup] = None
     ) -> None:
         """
         Create a Timer.

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -118,8 +118,8 @@ class BaseTimer:
     @timer_period_ns.setter
     def timer_period_ns(self, value: int) -> None:
         val = int(value)
-        with self.handle:
-            self.handle.change_timer_period(val)
+        with self.__timer:
+            self.__timer.change_timer_period(val)
 
     def is_ready(self) -> bool:
         with self.__timer:

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -76,7 +76,7 @@ class BaseTimer:
 
     def __init__(
         self,
-        callback: AsyncTimerCallbackType,
+        callback: Optional[TimerCallbackUnion],
         timer_period_ns: int,
         clock: Clock,
         *,
@@ -90,7 +90,6 @@ class BaseTimer:
         with self._clock.handle, self._context.handle:
             self.__timer = _rclpy.Timer(
                 self._clock.handle, self._context.handle, timer_period_ns, autostart)
-        self.timer_period_ns = timer_period_ns
         self.callback = callback
 
     @property
@@ -119,8 +118,8 @@ class BaseTimer:
     @timer_period_ns.setter
     def timer_period_ns(self, value: int) -> None:
         val = int(value)
-        with self.__timer:
-            self.__timer.change_timer_period(val)
+        with self.handle:
+            self.handle.change_timer_period(val)
 
     def is_ready(self) -> bool:
         with self.__timer:

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -15,8 +15,8 @@
 import threading
 
 from types import TracebackType
+from typing import Awaitable
 from typing import Callable
-from typing import Coroutine
 from typing import Optional
 from typing import Type
 from typing import Union
@@ -66,42 +66,23 @@ class TimerInfo:
 
 
 TimerCallbackType: TypeAlias = Union[Callable[[], None],
-                                     Callable[[TimerInfo], None],
-                                     Callable[[], Coroutine[None, None, None]]]
+                                     Callable[[TimerInfo], None]]
+AsyncTimerCallbackType: TypeAlias = Union[Callable[[], Awaitable[None]],
+                                          Callable[[TimerInfo], Awaitable[None]]]
+TimerCallbackUnion: TypeAlias = Union[TimerCallbackType, AsyncTimerCallbackType]
 
 
-class Timer:
+class BaseTimer:
 
     def __init__(
         self,
-        callback: Optional[TimerCallbackType],
-        callback_group: Optional[CallbackGroup],
+        callback: AsyncTimerCallbackType,
         timer_period_ns: int,
         clock: Clock,
         *,
         context: Optional[Context] = None,
         autostart: bool = True
     ) -> None:
-        """
-        Create a Timer.
-
-        If autostart is ``True`` (the default), the timer will be started and every
-        ``timer_period_sec`` number of seconds the provided callback function will be called.
-        If autostart is ``False``, the timer will be created but not started; it can then be
-        started by calling ``reset()`` on the timer object.
-
-        .. warning:: Users should not create a timer with this constructor, instead they
-           should call :meth:`.Node.create_timer`.
-
-        :param callback: A user-defined callback function that is called when the timer expires.
-        :param callback_group: The callback group for the timer. If ``None``, then the
-            default callback group for the node is used.
-        :param timer_period_ns: The period (in nanoseconds) of the timer.
-        :param clock: The clock which the timer gets time from.
-        :param context: The context to be associated with.
-        :param autostart: Whether to automatically start the timer after creation; defaults to
-            ``True``.
-        """
         self._context = get_default_context() if context is None else context
         self._clock = clock
         if self._context.handle is None:
@@ -111,9 +92,6 @@ class Timer:
                 self._clock.handle, self._context.handle, timer_period_ns, autostart)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
-        self.callback_group = callback_group
-        # True when the callback is ready to fire but has not been "taken" by an executor
-        self._executor_event = False
 
     @property
     def handle(self) -> _rclpy.Timer:
@@ -136,7 +114,6 @@ class Timer:
     def timer_period_ns(self) -> int:
         with self.__timer:
             val = self.__timer.get_timer_period()
-        self.__timer_period_ns = val
         return val
 
     @timer_period_ns.setter
@@ -144,7 +121,6 @@ class Timer:
         val = int(value)
         with self.__timer:
             self.__timer.change_timer_period(val)
-        self.__timer_period_ns = val
 
     def is_ready(self) -> bool:
         with self.__timer:
@@ -180,6 +156,50 @@ class Timer:
         exc_tb: Optional[TracebackType],
     ) -> None:
         self.destroy()
+
+
+class Timer(BaseTimer):
+
+    def __init__(
+        self,
+        callback: Optional[TimerCallbackUnion],
+        timer_period_ns: int,
+        clock: Clock,
+        callback_group: Optional[CallbackGroup],
+        *,
+        context: Optional[Context] = None,
+        autostart: bool = True
+    ) -> None:
+        """
+        Create a Timer.
+
+        If autostart is ``True`` (the default), the timer will be started and every
+        ``timer_period_sec`` number of seconds the provided callback function will be called.
+        If autostart is ``False``, the timer will be created but not started; it can then be
+        started by calling ``reset()`` on the timer object.
+
+        .. warning:: Users should not create a timer with this constructor, instead they
+           should call :meth:`.Node.create_timer`.
+
+        :param callback: A user-defined callback function that is called when the timer expires.
+        :param callback_group: The callback group for the timer. If ``None``, then the
+            default callback group for the node is used.
+        :param timer_period_ns: The period (in nanoseconds) of the timer.
+        :param clock: The clock which the timer gets time from.
+        :param context: The context to be associated with.
+        :param autostart: Whether to automatically start the timer after creation; defaults to
+            ``True``.
+        """
+        super().__init__(
+            callback=callback,
+            timer_period_ns=timer_period_ns,
+            clock=clock,
+            context=context,
+            autostart=autostart
+        )
+        self.callback_group = callback_group
+        # True when the callback is ready to fire but has not been "taken" by an executor
+        self._executor_event = False
 
 
 class Rate:

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -135,6 +135,29 @@ def test_subscription_callback_type() -> None:
     node.destroy_node()
 
 
+def test_subscription_callback_setter() -> None:
+    node = Node('test_node', namespace='test_subscription/test_subscription_callback_setter')
+    sub = node.create_subscription(
+        msg_type=Empty,
+        topic='test_subscription/test_subscription_callback_/topic',
+        qos_profile=10,
+        callback=lambda _, _2: None)
+
+    sub.callback = lambda _: None
+    assert sub._callback_type == Subscription.CallbackType.MessageOnly
+
+    sub.callback = callback = lambda _, _2: None
+    assert sub._callback_type == Subscription.CallbackType.WithMessageInfo
+
+    with pytest.raises(RuntimeError):
+        sub.callback = lambda: None
+
+    assert sub.callback is callback
+
+    sub.destroy()
+    node.destroy_node()
+
+
 def test_subscription_context_manager() -> None:
     node = Node('test_node', namespace='test_subscription/test_subscription_callback_type')
     with node.create_subscription(


### PR DESCRIPTION
Part of #1620 

## Changes
* New BasePublisher, BaseService, BaseSubscription, BaseClient and BaseTimer classes
* `__init__` parameter changes
    * Subscription, Publisher: `callback_group` and `event_callbacks` are now keyword only
    * Service, Client, Timer: `callback_group` is now keyword only
    * Timer: callback_group defaults to None

## Notes
* Callback groups and event handlers were not moved to base classes
    * Callback groups are exclusive to executors and would not be supported in AsyncNode. More detailed discussion is in #1399.
    * We have no callback mechanism for waitables yet, so AsyncNode won't support event handlers for now.
* Service's send_response() is used publicly only in executor, so it was made protected in the BaseService