### PR TITLE
Add types to `test_waitable.py`

### DIFF
--- a/rclpy/rclpy/__init__.py
+++ b/rclpy/rclpy/__init__.py
@@ -57,7 +57,8 @@ from rclpy.signals import SignalHandlerOptions
 from rclpy.signals import uninstall_signal_handlers
 from rclpy.task import Future as Future
 from rclpy.utilities import get_default_context as get_default_context
-from rclpy.utilities import get_rmw_implementation_identifier  # noqa: F401
+from rclpy.utilities import get_rmw_implementation_identifier as \
+    get_rmw_implementation_identifier  # noqa: F401
 from rclpy.utilities import ok as ok  # noqa: F401 forwarding to this module
 from rclpy.utilities import shutdown as _shutdown
 from rclpy.utilities import try_shutdown as _try_shutdown

--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -290,7 +290,7 @@ class Service(Destroyable, Generic[SrvRequestT, SrvResponseT]):
     def service_take_request(
         self,
         pyrequest_type: type[SrvRequestT]
-    ) -> tuple[rmw_service_info_t, SrvRequestT] | tuple[None, None]:
+    ) -> tuple[SrvRequestT, rmw_service_info_t] | tuple[None, None]:
         """Take a request from a given service."""
 
     def configure_introspection(

--- a/rclpy/src/rclpy/client.cpp
+++ b/rclpy/src/rclpy/client.cpp
@@ -147,7 +147,6 @@ Client::take_response(py::object pyresponse_type)
   }
 
   result_tuple[0] = header;
-
   result_tuple[1] = convert_to_py(taken_response.get(), pyresponse_type);
 
   return result_tuple;

--- a/rclpy/src/rclpy/service.cpp
+++ b/rclpy/src/rclpy/service.cpp
@@ -143,8 +143,8 @@ Service::service_take_request(py::object pyrequest_type)
     throw RCLError("service failed to take request");
   }
 
-  result_tuple[1] = header;
   result_tuple[0] = convert_to_py(taken_request.get(), pyrequest_type);
+  result_tuple[1] = header;
 
   return result_tuple;
 }

--- a/rclpy/test/test_service.py
+++ b/rclpy/test/test_service.py
@@ -21,13 +21,8 @@ import pytest
 
 import rclpy
 from rclpy.node import Node
-from rclpy.service import Service
 
 from test_msgs.srv import Empty
-
-from typing_extensions import TypeAlias
-
-EmptyService: TypeAlias = Service[Empty.Request, Empty.Response]
 
 
 NODE_NAME = 'test_node'
@@ -41,17 +36,17 @@ def default_context() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def test_node():
+def test_node() -> Generator[Node, None, None]:
     node = Node(NODE_NAME)
     yield node
     node.destroy_node()
 
 
-def test_logger_name_is_equal_to_node_name(test_node):
+def test_logger_name_is_equal_to_node_name(test_node: Node) -> None:
     srv = test_node.create_service(
         srv_type=Empty,
         srv_name='test_srv',
-        callback=lambda _: None
+        callback=lambda _1, _2: Empty.Response()
     )
 
     assert srv.logger_name == NODE_NAME
@@ -72,10 +67,10 @@ def test_logger_name_is_equal_to_node_name(test_node):
 ])
 def test_get_service_name(service_name: str, namespace: Optional[str], expected: str) -> None:
     node = Node('node_name', namespace=namespace, cli_args=None, start_parameter_services=False)
-    srv: EmptyService = node.create_service(
+    srv = node.create_service(
         srv_type=Empty,
         srv_name=service_name,
-        callback=lambda _, _1: None
+        callback=lambda _1, _2: Empty.Response()
     )
 
     assert srv.service_name == expected
@@ -99,10 +94,10 @@ def test_get_service_name_after_remapping(service_name: str, namespace: Optional
         namespace=namespace,
         cli_args=cli_args,
         start_parameter_services=False)
-    srv: EmptyService = node.create_service(
+    srv = node.create_service(
         srv_type=Empty,
         srv_name=service_name,
-        callback=lambda _, _1: None
+        callback=lambda _1, _2: Empty.Response()
     )
 
     assert srv.service_name == expected
@@ -113,13 +108,14 @@ def test_get_service_name_after_remapping(service_name: str, namespace: Optional
 
 def test_service_context_manager() -> None:
     with rclpy.create_node('ctx_mgr_test') as node:
-        srv: EmptyService
         with node.create_service(
-                srv_type=Empty, srv_name='empty_service', callback=lambda _, _1: None) as srv:
+                srv_type=Empty,
+                srv_name='empty_service',
+                callback=lambda _1, _2: Empty.Response()) as srv:
             assert srv.service_name == '/empty_service'
 
 
-def test_set_on_new_request_callback(test_node) -> None:
+def test_set_on_new_request_callback(test_node: Node) -> None:
     cli = test_node.create_client(Empty, '/service')
     srv = test_node.create_service(Empty, '/service', lambda req, res: res)
     cb = Mock()

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Generator
 import time
 from typing import List
 from typing import Optional
@@ -21,6 +22,7 @@ import pytest
 
 import rclpy
 from rclpy.node import Node
+from rclpy.publisher import Publisher
 from rclpy.subscription import Subscription
 from rclpy.subscription_content_filter_options import ContentFilterOptions
 
@@ -37,7 +39,7 @@ def setup_ros() -> None:
 
 
 @pytest.fixture
-def test_node():
+def test_node() -> Generator[Node, None, None]:
     node = Node(NODE_NAME)
     yield node
     node.destroy_node()
@@ -72,7 +74,7 @@ def test_get_subscription_topic_name(topic_name: str, namespace: Optional[str],
     node.destroy_node()
 
 
-def test_logger_name_is_equal_to_node_name(test_node):
+def test_logger_name_is_equal_to_node_name(test_node: Node) -> None:
     sub = test_node.create_subscription(
         msg_type=Empty,
         topic='topic',
@@ -181,7 +183,7 @@ def test_subscription_publisher_count() -> None:
     node.destroy_node()
 
 
-def test_on_new_message_callback(test_node) -> None:
+def test_on_new_message_callback(test_node: Node) -> None:
     topic_name = '/topic'
     cb = Mock()
     sub = test_node.create_subscription(
@@ -217,7 +219,7 @@ def test_on_new_message_callback(test_node) -> None:
     cb.assert_not_called()
 
 
-def test_subscription_set_content_filter(test_node) -> None:
+def test_subscription_set_content_filter(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \
        rclpy.get_rmw_implementation_identifier() != 'rmw_connextdds':
@@ -245,7 +247,7 @@ def test_subscription_set_content_filter(test_node) -> None:
     sub.destroy()
 
 
-def test_subscription_is_cft_enabled(test_node) -> None:
+def test_subscription_is_cft_enabled(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \
        rclpy.get_rmw_implementation_identifier() != 'rmw_connextdds':
@@ -272,7 +274,7 @@ def test_subscription_is_cft_enabled(test_node) -> None:
     sub.destroy()
 
 
-def test_subscription_get_content_filter(test_node) -> None:
+def test_subscription_get_content_filter(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \
        rclpy.get_rmw_implementation_identifier() != 'rmw_connextdds':
@@ -305,7 +307,7 @@ def test_subscription_get_content_filter(test_node) -> None:
     sub.destroy()
 
 
-def test_subscription_content_filter_effect(test_node) -> None:
+def test_subscription_content_filter_effect(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \
        rclpy.get_rmw_implementation_identifier() != 'rmw_connextdds':
@@ -316,7 +318,7 @@ def test_subscription_content_filter_effect(test_node) -> None:
 
     received_msgs = []
 
-    def sub_callback(msg):
+    def sub_callback(msg: BasicTypes) -> None:
         received_msgs.append(msg.int32_value)
 
     sub = test_node.create_subscription(
@@ -327,13 +329,13 @@ def test_subscription_content_filter_effect(test_node) -> None:
 
     assert sub.is_cft_enabled is False
 
-    def wait_msgs(timeout, expected_msg_count):
+    def wait_msgs(timeout: float, expected_msg_count: int) -> None:
         end_time = time.time() + timeout
         while rclpy.ok() and time.time() < end_time and len(received_msgs) < expected_msg_count:
             rclpy.spin_once(test_node, timeout_sec=0.2)
 
     # Publish 3 messages
-    def publish_messages(pub):
+    def publish_messages(pub: Publisher[BasicTypes]) -> None:
         msg = BasicTypes()
         msg.int32_value = 10
         pub.publish(msg)
@@ -372,7 +374,7 @@ def test_subscription_content_filter_effect(test_node) -> None:
     sub.destroy()
 
 
-def test_subscription_content_filter_reset(test_node) -> None:
+def test_subscription_content_filter_reset(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \
        rclpy.get_rmw_implementation_identifier() != 'rmw_connextdds':
@@ -383,7 +385,7 @@ def test_subscription_content_filter_reset(test_node) -> None:
 
     received_msgs = []
 
-    def sub_callback(msg):
+    def sub_callback(msg: BasicTypes) -> None:
         received_msgs.append(msg.int32_value)
 
     sub = test_node.create_subscription(
@@ -399,13 +401,13 @@ def test_subscription_content_filter_reset(test_node) -> None:
     )
     assert sub.is_cft_enabled is True
 
-    def wait_msgs(timeout, expected_msg_count):
+    def wait_msgs(timeout: float, expected_msg_count: int) -> None:
         end_time = time.time() + timeout
         while rclpy.ok() and time.time() < end_time and len(received_msgs) < expected_msg_count:
             rclpy.spin_once(test_node, timeout_sec=0.2)
 
     # Publish 3 messages
-    def publish_messages(pub):
+    def publish_messages(pub: Publisher[BasicTypes]) -> None:
         msg = BasicTypes()
         msg.int32_value = 10
         pub.publish(msg)
@@ -436,7 +438,7 @@ def test_subscription_content_filter_reset(test_node) -> None:
     assert len(received_msgs) == expected_msg_count
 
 
-def test_subscription_content_filter_at_create_subscription(test_node) -> None:
+def test_subscription_content_filter_at_create_subscription(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \
        rclpy.get_rmw_implementation_identifier() != 'rmw_connextdds':
@@ -451,7 +453,7 @@ def test_subscription_content_filter_at_create_subscription(test_node) -> None:
         filter_expression='int32_value > %0',
         expression_parameters=['15'])
 
-    def sub_callback(msg):
+    def sub_callback(msg: BasicTypes) -> None:
         received_msgs.append(msg.int32_value)
 
     sub = test_node.create_subscription(
@@ -463,13 +465,13 @@ def test_subscription_content_filter_at_create_subscription(test_node) -> None:
 
     assert sub.is_cft_enabled is True
 
-    def wait_msgs(timeout, expected_msg_count):
+    def wait_msgs(timeout: float, expected_msg_count: int) -> None:
         end_time = time.time() + timeout
         while rclpy.ok() and time.time() < end_time and len(received_msgs) < expected_msg_count:
             rclpy.spin_once(test_node, timeout_sec=0.2)
 
     # Publish 3 messages
-    def publish_messages(pub):
+    def publish_messages(pub: Publisher[BasicTypes]) -> None:
         msg = BasicTypes()
         msg.int32_value = 10
         pub.publish(msg)

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Generator
 import functools
 import os
 import platform
@@ -25,23 +26,24 @@ import rclpy
 from rclpy.clock_type import ClockType
 from rclpy.constants import S_TO_NS
 from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
 from rclpy.timer import TimerInfo
 
 
 @pytest.fixture
-def context() -> None:
+def context() -> rclpy.context.Context:
     return rclpy.context.Context()
 
 
 @pytest.fixture
-def setup_ros(context) -> None:
+def setup_ros(context: rclpy.context.Context) -> Generator[None, None, None]:
     rclpy.init(context=context)
     yield
     rclpy.shutdown(context=context)
 
 
 @pytest.fixture
-def test_node(context, setup_ros):
+def test_node(context: rclpy.context.Context, setup_ros: None) -> Generator[Node, None, None]:
     node = rclpy.create_node('test_node', context=context)
     yield node
     node.destroy_node()
@@ -350,7 +352,7 @@ def test_timer_info_with_partial() -> None:
         rclpy.shutdown(context=context)
 
 
-def test_on_reset_callback(test_node):
+def test_on_reset_callback(test_node: Node) -> None:
     tmr = test_node.create_timer(1, lambda: None)
     cb = Mock()
     tmr.handle.set_on_reset_callback(cb)

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import threading
 import time
+from types import TracebackType
+from typing import Any
+from typing import Optional
 from typing import TYPE_CHECKING
+from typing import Union
 import unittest
 
 import rclpy
@@ -24,6 +30,7 @@ from rclpy.clock_type import ClockType
 import rclpy.context
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.task import Future
 from rclpy.type_support import check_for_type_support
@@ -33,138 +40,164 @@ from rclpy.waitable import Waitable
 from test_msgs.msg import Empty as EmptyMsg
 from test_msgs.srv import Empty as EmptySrv
 
+from typing_extensions import TypeAlias
+
 
 check_for_type_support(EmptyMsg)
 check_for_type_support(EmptySrv)
 
 
-class ClientWaitable(Waitable):
+class ClientWaitable(Waitable[Optional[tuple[_rclpy.rmw_service_info_t, EmptySrv.Response]]]):
 
-    def __init__(self, node):
+    def __init__(self, node: Node):
         super().__init__(ReentrantCallbackGroup())
 
         with node.handle:
             self.client = _rclpy.Client(
                 node.handle, EmptySrv, 'test_client', QoSProfile(depth=10).get_c_qos_profile())
-        self.client_index = None
+        self.client_index: int
         self.client_is_ready = False
 
         self.node = node
-        self.future = None
+        self.future: Future[dict[str, EmptySrv.Response]]
 
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
-    def is_ready(self, wait_set):
+    def is_ready(self, wait_set: _rclpy.WaitSet) -> bool:
         """Return True if entities are ready in the wait set."""
         if wait_set.is_ready('client', self.client_index):
             self.client_is_ready = True
         return self.client_is_ready
 
-    def take_data(self):
+    def take_data(self) -> Optional[tuple[_rclpy.rmw_service_info_t, EmptySrv.Response]]:
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.client_is_ready:
             self.client_is_ready = False
-            return self.client.take_response(EmptySrv.Response)
+            taken_response = self.client.take_response(EmptySrv.Response)
+            if taken_response[0] is None:
+                return None
+            return taken_response
         return None
 
-    async def execute(self, taken_data):
+    async def execute(self, taken_data: Optional[tuple[_rclpy.rmw_service_info_t,
+                                                       EmptySrv.Response]]) -> None:
         """Execute work after data has been taken from a ready wait set."""
         test_data = {}
-        if isinstance(taken_data[1], EmptySrv.Response):
+        if isinstance(taken_data, tuple) and isinstance(taken_data[1], EmptySrv.Response):
             test_data['client'] = taken_data[1]
         self.future.set_result(test_data)
 
-    def get_num_entities(self):
+    def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used."""
         return NumberOfEntities(0, 0, 0, 1, 0)
 
-    def add_to_wait_set(self, wait_set):
+    def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         """Add entities to wait set."""
         self.client_index = wait_set.add_client(self.client)
 
 
-class ServerWaitable(Waitable):
+class ServerWaitable(Waitable[Optional[tuple[EmptySrv.Request, _rclpy.rmw_service_info_t]]]):
 
-    def __init__(self, node):
+    def __init__(self, node: Node):
         super().__init__(ReentrantCallbackGroup())
 
         with node.handle:
             self.server = _rclpy.Service(
                 node.handle, EmptySrv, 'test_server', QoSProfile(depth=10).get_c_qos_profile())
-        self.server_index = None
+        self.server_index: int
         self.server_is_ready = False
 
         self.node = node
-        self.future = None
+        self.future: Future[dict[str, EmptySrv.Request]]
 
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
-    def is_ready(self, wait_set):
+    def is_ready(self, wait_set: _rclpy.WaitSet) -> bool:
         """Return True if entities are ready in the wait set."""
         if wait_set.is_ready('service', self.server_index):
             self.server_is_ready = True
         return self.server_is_ready
 
-    def take_data(self):
+    def take_data(self) -> Optional[tuple[EmptySrv.Request, _rclpy.rmw_service_info_t]]:
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.server_is_ready:
             self.server_is_ready = False
-            return self.server.service_take_request(EmptySrv.Request)
+            taken_request = self.server.service_take_request(EmptySrv.Request)
+            if taken_request[0] is None:
+                return None
+            return taken_request
         return None
 
-    async def execute(self, taken_data):
+    async def execute(self, taken_data: Optional[tuple[EmptySrv.Request,
+                                                       _rclpy.rmw_service_info_t]]) -> None:
         """Execute work after data has been taken from a ready wait set."""
         test_data = {}
-        if isinstance(taken_data[0], EmptySrv.Request):
+        if isinstance(taken_data, tuple) and isinstance(taken_data[0], EmptySrv.Request):
             test_data['server'] = taken_data[0]
         self.future.set_result(test_data)
 
-    def get_num_entities(self):
+    def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used."""
         return NumberOfEntities(0, 0, 0, 0, 1)
 
-    def add_to_wait_set(self, wait_set):
+    def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         """Add entities to wait set."""
         self.server_index = wait_set.add_service(self.server)
 
 
-class TimerWaitable(Waitable):
+class TimerWaitable(Waitable[Optional[str]]):
 
-    def __init__(self, node):
+    def __init__(self, node: Node):
         super().__init__(ReentrantCallbackGroup())
 
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         period_nanoseconds = 10000
+        assert node.context.handle
         with self._clock.handle, node.context.handle:
             self.timer = _rclpy.Timer(
                 self._clock.handle, node.context.handle, period_nanoseconds, True)
-        self.timer_index = None
+        self.timer_index: int
         self.timer_is_ready = False
 
         self.node = node
-        self.future = None
+        self.future: Future[dict[str, str]]
 
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
-    def is_ready(self, wait_set):
+    def is_ready(self, wait_set: _rclpy.WaitSet) -> bool:
         """Return True if entities are ready in the wait set."""
         if wait_set.is_ready('timer', self.timer_index):
             self.timer_is_ready = True
         return self.timer_is_ready
 
-    def take_data(self):
+    def take_data(self) -> Optional[str]:
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.timer_is_ready:
             self.timer_is_ready = False
@@ -172,49 +205,54 @@ class TimerWaitable(Waitable):
             return 'timer'
         return None
 
-    async def execute(self, taken_data):
+    async def execute(self, taken_data: Optional[str]) -> None:
         """Execute work after data has been taken from a ready wait set."""
         test_data = {}
         if 'timer' == taken_data:
             test_data['timer'] = taken_data
         self.future.set_result(test_data)
 
-    def get_num_entities(self):
+    def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used."""
         return NumberOfEntities(0, 0, 1, 0, 0)
 
-    def add_to_wait_set(self, wait_set):
+    def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         """Add entities to wait set."""
         self.timer_index = wait_set.add_timer(self.timer)
 
 
-class SubscriptionWaitable(Waitable):
+class SubscriptionWaitable(Waitable[Optional[EmptyMsg]]):
 
-    def __init__(self, node):
+    def __init__(self, node: Node):
         super().__init__(ReentrantCallbackGroup())
 
         with node.handle:
             self.subscription = _rclpy.Subscription(
                 node.handle, EmptyMsg, 'test_topic', QoSProfile(depth=10).get_c_qos_profile())
-        self.subscription_index = None
+        self.subscription_index: int
         self.subscription_is_ready = False
 
         self.node = node
-        self.future = None
+        self.future: Future[dict[str, EmptyMsg]]
 
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
-    def is_ready(self, wait_set):
+    def is_ready(self, wait_set: _rclpy.WaitSet) -> bool:
         """Return True if entities are ready in the wait set."""
         if wait_set.is_ready('subscription', self.subscription_index):
             self.subscription_is_ready = True
         return self.subscription_is_ready
 
-    def take_data(self):
+    def take_data(self) -> Optional[EmptyMsg]:
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.subscription_is_ready:
             self.subscription_is_ready = False
@@ -223,72 +261,78 @@ class SubscriptionWaitable(Waitable):
                 return msg_info[0]
         return None
 
-    async def execute(self, taken_data):
+    async def execute(self, taken_data: Optional[EmptyMsg]) -> None:
         """Execute work after data has been taken from a ready wait set."""
         test_data = {}
         if isinstance(taken_data, EmptyMsg):
             test_data['subscription'] = taken_data
         self.future.set_result(test_data)
 
-    def get_num_entities(self):
+    def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used."""
         return NumberOfEntities(1, 0, 0, 0, 0)
 
-    def add_to_wait_set(self, wait_set):
+    def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         """Add entities to wait set."""
         self.subscription_index = wait_set.add_subscription(
             self.subscription)
 
 
-class GuardConditionWaitable(Waitable):
+class GuardConditionWaitable(Waitable[Optional[str]]):
 
-    def __init__(self, node):
+    def __init__(self, node: Node):
         super().__init__(ReentrantCallbackGroup())
 
+        assert node.context.handle
         with node.context.handle:
             self.guard_condition = _rclpy.GuardCondition(node.context.handle)
-        self.guard_condition_index = None
+        self.guard_condition_index: int
         self.guard_is_ready = False
 
         self.node = node
-        self.future = None
+        self.future: Future[dict[str, bool]]
 
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
-    def is_ready(self, wait_set):
+    def is_ready(self, wait_set: _rclpy.WaitSet) -> bool:
         """Return True if entities are ready in the wait set."""
         if wait_set.is_ready('guard_condition', self.guard_condition_index):
             self.guard_is_ready = True
         return self.guard_is_ready
 
-    def take_data(self):
+    def take_data(self) -> Optional[str]:
         """Take stuff from lower level so the wait set doesn't immediately wake again."""
         if self.guard_is_ready:
             self.guard_is_ready = False
             return 'guard_condition'
         return None
 
-    async def execute(self, taken_data):
+    async def execute(self, taken_data: Optional[str]) -> None:
         """Execute work after data has been taken from a ready wait set."""
         test_data = {}
         if 'guard_condition' == taken_data:
             test_data['guard_condition'] = True
         self.future.set_result(test_data)
 
-    def get_num_entities(self):
+    def get_num_entities(self) -> NumberOfEntities:
         """Return number of each type of entity used."""
         return NumberOfEntities(0, 1, 0, 0, 0)
 
-    def add_to_wait_set(self, wait_set):
+    def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         """Add entities to wait set."""
         self.guard_condition_index = wait_set.add_guard_condition(self.guard_condition)
 
 
-class MutuallyExclusiveWaitable(Waitable):
+class MutuallyExclusiveWaitable(Waitable[None]):
 
     def __init__(self) -> None:
         super().__init__(MutuallyExclusiveCallbackGroup())
@@ -296,23 +340,32 @@ class MutuallyExclusiveWaitable(Waitable):
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
-    def is_ready(self, wait_set):
+    def is_ready(self, wait_set: _rclpy.WaitSet) -> bool:
         return False
 
     def take_data(self) -> None:
         return None
 
-    async def execute(self, taken_data):
+    async def execute(self, taken_data: None) -> None:
         pass
 
-    def get_num_entities(self):
+    def get_num_entities(self) -> NumberOfEntities:
         return NumberOfEntities(0, 0, 0, 0, 0)
 
-    def add_to_wait_set(self, wait_set):
+    def add_to_wait_set(self, wait_set: _rclpy.WaitSet) -> None:
         pass
+
+
+_Waitables: TypeAlias = Union[ClientWaitable, ServerWaitable, TimerWaitable,
+                              SubscriptionWaitable, GuardConditionWaitable]
 
 
 class TestWaitable(unittest.TestCase):
@@ -321,9 +374,10 @@ class TestWaitable(unittest.TestCase):
         node: rclpy.node.Node
         context: rclpy.context.Context
         executor: SingleThreadedExecutor
+        waitable: Waitable[Any]
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.context = rclpy.context.Context()
         rclpy.init(context=cls.context)
         cls.node = rclpy.create_node(
@@ -333,12 +387,12 @@ class TestWaitable(unittest.TestCase):
         cls.executor.add_node(cls.node)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         cls.executor.shutdown()
         cls.node.destroy_node()
         rclpy.shutdown(context=cls.context)
 
-    def start_spin_thread(self, waitable):
+    def start_spin_thread(self, waitable: _Waitables) -> threading.Thread:
         waitable.future = Future(executor=self.executor)
         self.thr = threading.Thread(
             target=self.executor.spin_until_future_complete, args=(waitable.future,), daemon=True)
@@ -367,7 +421,9 @@ class TestWaitable(unittest.TestCase):
         thr.join()
 
         assert self.waitable.future.done()
-        assert isinstance(self.waitable.future.result()['client'], EmptySrv.Response)
+        result = self.waitable.future.result()
+        assert result
+        assert isinstance(result['client'], EmptySrv.Response)
         self.node.destroy_service(server)
 
     def test_waitable_with_server(self) -> None:
@@ -380,7 +436,9 @@ class TestWaitable(unittest.TestCase):
         thr.join()
 
         assert self.waitable.future.done()
-        assert isinstance(self.waitable.future.result()['server'], EmptySrv.Request)
+        result = self.waitable.future.result()
+        assert result
+        assert isinstance(result['server'], EmptySrv.Request)
         self.node.destroy_client(client)
 
     def test_waitable_with_timer(self) -> None:
@@ -391,7 +449,9 @@ class TestWaitable(unittest.TestCase):
         thr.join()
 
         assert self.waitable.future.done()
-        assert self.waitable.future.result()['timer']
+        result = self.waitable.future.result()
+        assert result
+        assert result['timer']
 
     def test_waitable_with_subscription(self) -> None:
         self.waitable = SubscriptionWaitable(self.node)
@@ -403,7 +463,9 @@ class TestWaitable(unittest.TestCase):
         thr.join()
 
         assert self.waitable.future.done()
-        assert isinstance(self.waitable.future.result()['subscription'], EmptyMsg)
+        result = self.waitable.future.result()
+        assert result
+        assert isinstance(result['subscription'], EmptyMsg)
         self.node.destroy_publisher(pub)
 
     def test_waitable_with_guard_condition(self) -> None:
@@ -415,7 +477,9 @@ class TestWaitable(unittest.TestCase):
         thr.join()
 
         assert self.waitable.future.done()
-        assert self.waitable.future.result()['guard_condition']
+        result = self.waitable.future.result()
+        assert result
+        assert result['guard_condition']
 
     # Test that waitable doesn't crash with MutuallyExclusiveCallbackGroup
     # https://github.com/ros2/rclpy/issues/264


### PR DESCRIPTION
## Description

Adds static types to `test_waitable.py`. Fixes a bug in the _rclpy impl stubs caught by the tests. Also fixes `test_timer` and `test_subscription` and `test_service` as a side effect.

Gets `rclpy` closer to being fully statically typed for `Lyrical`.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
