### PR TITLE
Add acceptable_buffer_backends as subscription option in rclpy

### DIFF
--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1648,7 +1648,7 @@ class Node:
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: Literal[True],
         content_filter_options: Optional[ContentFilterOptions] = None,
-        acceptable_buffer_backends: Optional[str] = 'cpu'
+        acceptable_buffer_backends: Optional[str] = None
     ) -> Subscription[MsgT]: ...
 
     @overload
@@ -1679,7 +1679,7 @@ class Node:
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: bool = False,
         content_filter_options: Optional[ContentFilterOptions] = None,
-        acceptable_buffer_backends: Optional[str] = 'cpu'
+        acceptable_buffer_backends: Optional[str] = None
     ) -> Subscription[MsgT]: ...
 
     def create_subscription(
@@ -1694,7 +1694,7 @@ class Node:
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: bool = False,
         content_filter_options: Optional[ContentFilterOptions] = None,
-        acceptable_buffer_backends: Optional[str] = 'cpu'
+        acceptable_buffer_backends: Optional[str] = None
     ) -> Subscription[MsgT]:
         """
         Create a new subscription.

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1647,7 +1647,8 @@ class Node:
         event_callbacks: Optional[SubscriptionEventCallbacks] = None,
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: Literal[True],
-        content_filter_options: Optional[ContentFilterOptions] = None
+        content_filter_options: Optional[ContentFilterOptions] = None,
+        acceptable_buffer_backends: Optional[str] = 'cpu'
     ) -> Subscription[MsgT]: ...
 
     @overload
@@ -1677,7 +1678,8 @@ class Node:
         event_callbacks: Optional[SubscriptionEventCallbacks] = None,
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: bool = False,
-        content_filter_options: Optional[ContentFilterOptions] = None
+        content_filter_options: Optional[ContentFilterOptions] = None,
+        acceptable_buffer_backends: Optional[str] = 'cpu'
     ) -> Subscription[MsgT]: ...
 
     def create_subscription(
@@ -1691,7 +1693,8 @@ class Node:
         event_callbacks: Optional[SubscriptionEventCallbacks] = None,
         qos_overriding_options: Optional[QoSOverridingOptions] = None,
         raw: bool = False,
-        content_filter_options: Optional[ContentFilterOptions] = None
+        content_filter_options: Optional[ContentFilterOptions] = None,
+        acceptable_buffer_backends: Optional[str] = 'cpu'
     ) -> Subscription[MsgT]:
         """
         Create a new subscription.
@@ -1710,6 +1713,10 @@ class Node:
         :param raw: If ``True``, then received messages will be stored in raw binary
             representation.
         :param content_filter_options: The filter expression and parameters for content filtering.
+        :param acceptable_buffer_backends: Comma-separated list of acceptable buffer backend
+            names. ``None``, empty, or ``"cpu"`` all mean CPU-only (default for backward
+            compatibility). ``"any"`` means all installed backends are acceptable.
+            CPU is always implicitly acceptable.
         """
         qos_profile = self._validate_qos_or_depth_parameter(qos_profile)
 
@@ -1738,7 +1745,7 @@ class Node:
             with self.handle:
                 subscription_object = _rclpy.Subscription(
                     self.handle, msg_type, topic, qos_profile.get_c_qos_profile(),
-                    content_filter_options)
+                    content_filter_options, acceptable_buffer_backends)
         except ValueError:
             failed = True
         if failed:

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -62,7 +62,8 @@ get_c_vector_string(const std::vector<std::string> & strings_in)
 
 Subscription::Subscription(
   Node & node, py::object pymsg_type, std::string topic,
-  py::object pyqos_profile, py::object content_filter_options)
+  py::object pyqos_profile, py::object content_filter_options,
+  py::object acceptable_buffer_backends)
 : node_(node)
 {
   auto msg_type = static_cast<rosidl_message_type_support_t *>(
@@ -75,6 +76,13 @@ Subscription::Subscription(
 
   if (!pyqos_profile.is_none()) {
     subscription_ops.qos = pyqos_profile.cast<rmw_qos_profile_t>();
+  }
+
+  std::string acceptable_backends_str;
+  if (!acceptable_buffer_backends.is_none()) {
+    acceptable_backends_str = acceptable_buffer_backends.cast<std::string>();
+    subscription_ops.rmw_subscription_options.acceptable_buffer_backends =
+      acceptable_backends_str.c_str();
   }
 
   rcl_subscription_ = std::shared_ptr<rcl_subscription_t>(
@@ -368,12 +376,13 @@ void
 define_subscription(py::object module)
 {
   py::class_<Subscription, Destroyable, std::shared_ptr<Subscription>>(module, "Subscription")
-  .def(py::init<Node &, py::object, std::string, py::object, py::object>(),
+  .def(py::init<Node &, py::object, std::string, py::object, py::object, py::object>(),
     py::arg("node"),
     py::arg("msg_type"),
     py::arg("topic"),
     py::arg("qos_profile"),
-    py::arg("content_filter_options") = py::none())
+    py::arg("content_filter_options") = py::none(),
+    py::arg("acceptable_buffer_backends") = py::none())
   .def_property_readonly(
     "pointer", [](const Subscription & subscription) {
       return reinterpret_cast<size_t>(subscription.rcl_ptr());

--- a/rclpy/src/rclpy/subscription.cpp
+++ b/rclpy/src/rclpy/subscription.cpp
@@ -78,11 +78,14 @@ Subscription::Subscription(
     subscription_ops.qos = pyqos_profile.cast<rmw_qos_profile_t>();
   }
 
-  std::string acceptable_backends_str;
   if (!acceptable_buffer_backends.is_none()) {
-    acceptable_backends_str = acceptable_buffer_backends.cast<std::string>();
-    subscription_ops.rmw_subscription_options.acceptable_buffer_backends =
-      acceptable_backends_str.c_str();
+    std::string acceptable_backends_str = acceptable_buffer_backends.cast<std::string>();
+    rcl_ret_t ret = rcl_subscription_options_set_acceptable_buffer_backends(
+      acceptable_backends_str.c_str(),
+      &subscription_ops);
+    if (RCL_RET_OK != ret) {
+      throw rclpy::RCLError("Failed to set acceptable_buffer_backends");
+    }
   }
 
   rcl_subscription_ = std::shared_ptr<rcl_subscription_t>(

--- a/rclpy/src/rclpy/subscription.hpp
+++ b/rclpy/src/rclpy/subscription.hpp
@@ -53,7 +53,8 @@ public:
    */
   Subscription(
     Node & node, py::object pymsg_type, std::string topic,
-    py::object pyqos_profile, py::object content_filter_options = py::none());
+    py::object pyqos_profile, py::object content_filter_options = py::none(),
+    py::object acceptable_buffer_backends = py::none());
 
   /// Take a message and its metadata from a subscription
   /**


### PR DESCRIPTION
## Description

This pull request adds the `acceptable_buffer_backends` subscription option in rclpy, which corresponds to the subscription field with the same name introduced in rmw in https://github.com/ros2/rmw/pull/416. This option allows subscribers to control which buffer backends they accept, with a backward-compatible default of CPU-only.

This pull request consists of the following key changes:

- **`node.py`**: `create_subscription` adds a new optional parameter `acceptable_buffer_backends: Optional[str] = 'cpu'`.
- **`subscription.cpp`, `subscription.hpp`**: pass the value through to `rmw_subscription_options.acceptable_buffer_backends`.

### Is this user-facing behavior change?

The default value `"cpu"` preserves existing behavior -- subscriptions only accept CPU-backed data unless explicitly opting in. This is a new API surface but is additive and backward-compatible. Existing code that does not pass `acceptable_buffer_backends` will behave identically to before.

### Did you use Generative AI?
8
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).
