### PR TITLE
Feature: streamlined entity destroy

### DIFF
--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -15,7 +15,7 @@
 import threading
 import time
 from types import TracebackType
-from typing import Dict
+from typing import Callable, Dict
 from typing import Generic
 from typing import Optional
 from typing import Type
@@ -44,12 +44,16 @@ class BaseClient(Generic[SrvRequestT, SrvResponseT]):
         srv_type: type[Srv[SrvRequestT, SrvResponseT]],
         srv_name: str,
         qos_profile: QoSProfile,
+        *,
+        on_destroy: Optional[Callable[['BaseClient[SrvRequestT, SrvResponseT]'], None]] = None,
     ) -> None:
         self.context = context
         self.__client = client_impl
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.qos_profile = qos_profile
+        self._on_destroy = on_destroy
+        self._destroyed = False
 
     def service_is_ready(self) -> bool:
         """
@@ -93,13 +97,17 @@ class BaseClient(Generic[SrvRequestT, SrvResponseT]):
             return self.__client.get_logger_name()
 
     def destroy(self) -> None:
-        """
-        Destroy a container for a ROS service client.
+        """Destroy the client, notifying the owning node and releasing the handle."""
+        if self._destroyed:
+            return
+        self._destroyed = True
+        if self._on_destroy is not None:
+            self._on_destroy(self)
+            self._on_destroy = None
+        self._destroy()
 
-        .. warning:: Users should not destroy a service client with this destructor, instead they
-           should call :meth:`.Node.destroy_client`.
-        """
-        self.__client.destroy_when_not_in_use()
+    def _destroy(self) -> None:
+        self.handle.destroy_when_not_in_use()
 
     def __enter__(self) -> 'BaseClient[SrvRequestT, SrvResponseT]':
         return self
@@ -122,6 +130,7 @@ class Client(BaseClient[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvResp
         srv_name: str,
         qos_profile: QoSProfile,
         *,
+        on_destroy: Optional[Callable[['BaseClient[SrvRequestT, SrvResponseT]'], None]] = None,
         callback_group: CallbackGroup
     ) -> None:
         """
@@ -143,7 +152,8 @@ class Client(BaseClient[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvResp
             client_impl=client_impl,
             srv_type=srv_type,
             srv_name=srv_name,
-            qos_profile=qos_profile
+            qos_profile=qos_profile,
+            on_destroy=on_destroy
         )
         # Key is a sequence number, value is an instance of a Future
         self._pending_requests: Dict[int, Future[SrvResponseT]] = {}

--- a/rclpy/rclpy/client.py
+++ b/rclpy/rclpy/client.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 import threading
 import time
 from types import TracebackType
-from typing import Callable, Dict
+from typing import Dict
 from typing import Generic
 from typing import Optional
 from typing import Type

--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -144,6 +144,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 self._state_machine.service_change_state.name,
                 self.__on_change_state,
                 QoSProfile(**self._state_machine.service_change_state.qos),
+                on_destroy=self._on_destroy_service,
                 callback_group=callback_group)
             self._service_get_state = Service(
                 self._state_machine.service_get_state,
@@ -151,6 +152,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 self._state_machine.service_get_state.name,
                 self.__on_get_state,
                 QoSProfile(**self._state_machine.service_get_state.qos),
+                on_destroy=self._on_destroy_service,
                 callback_group=callback_group)
             self._service_get_available_states = Service(
                 self._state_machine.service_get_available_states,
@@ -158,6 +160,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 self._state_machine.service_get_available_states.name,
                 self.__on_get_available_states,
                 QoSProfile(**self._state_machine.service_get_available_states.qos),
+                on_destroy=self._on_destroy_service,
                 callback_group=callback_group)
             self._service_get_available_transitions = Service(
                 self._state_machine.service_get_available_transitions,
@@ -165,6 +168,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 self._state_machine.service_get_available_transitions.name,
                 self.__on_get_available_transitions,
                 QoSProfile(**self._state_machine.service_get_available_transitions.qos),
+                on_destroy=self._on_destroy_service,
                 callback_group=callback_group)
             self._service_get_transition_graph = Service(
                 self._state_machine.service_get_transition_graph,
@@ -172,6 +176,7 @@ class LifecycleNodeMixin(ManagedEntity):
                 self._state_machine.service_get_transition_graph.name,
                 self.__on_get_transition_graph,
                 QoSProfile(**self._state_machine.service_get_transition_graph.qos),
+                on_destroy=self._on_destroy_service,
                 callback_group=callback_group)
 
             lifecycle_services = [

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Generic, Tuple, Type, TYPE_CHECKING, TypedDict, Union
+from typing import Callable, Generic, Optional, Tuple, Type, TYPE_CHECKING, TypedDict, Union
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.event_handler import PublisherEventCallbacks
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         msg_type: Type[MsgT]
         topic: str
         qos_profile: QoSProfile
+        on_destroy: Optional[Callable[['Publisher[MsgT]'], None]]
         event_callbacks: PublisherEventCallbacks
         callback_group: CallbackGroup
 

--- a/rclpy/rclpy/lifecycle/publisher.py
+++ b/rclpy/rclpy/lifecycle/publisher.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, Generic, Optional, Tuple, Type, TYPE_CHECKING, TypedDict, Union
+from collections.abc import Callable
+from typing import Generic, Optional, Tuple, Type, TYPE_CHECKING, TypedDict, Union
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.event_handler import PublisherEventCallbacks

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -50,7 +50,7 @@ from rcl_interfaces.srv import ListParameters
 from rclpy.callback_groups import CallbackGroup
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.client import Client
+from rclpy.client import BaseClient, Client
 from rclpy.clock import Clock
 from rclpy.clock import ROSClock
 from rclpy.constants import S_TO_NS
@@ -78,20 +78,20 @@ from rclpy.logging_service import LoggingService
 from rclpy.parameter import (AllowableParameterValue, AllowableParameterValueT, Parameter,
                              PARAMETER_SEPARATOR_STRING)
 from rclpy.parameter_service import ParameterService
-from rclpy.publisher import Publisher
+from rclpy.publisher import BasePublisher, Publisher
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_rosout_default
 from rclpy.qos import qos_profile_services_default
 from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import QoSOverridingOptions
-from rclpy.service import Service
-from rclpy.subscription import GenericSubscriptionCallback
+from rclpy.service import BaseService, Service
+from rclpy.subscription import BaseSubscription, GenericSubscriptionCallback
 from rclpy.subscription import Subscription
 from rclpy.subscription import SubscriptionCallbackUnion
 from rclpy.subscription_content_filter_options import ContentFilterOptions
 from rclpy.time_source import TimeSource
-from rclpy.timer import Rate
+from rclpy.timer import BaseTimer, Rate
 from rclpy.timer import Timer
 from rclpy.timer import TimerCallbackType
 from rclpy.type_description_service import TypeDescriptionService
@@ -1620,6 +1620,7 @@ class Node:
         try:
             publisher = publisher_class(
                 publisher_object, msg_type, topic, qos_profile,
+                on_destroy=self._on_destroy_publisher,
                 event_callbacks=event_callbacks or PublisherEventCallbacks(),
                 callback_group=callback_group)
         except Exception:
@@ -1731,6 +1732,7 @@ class Node:
             subscription = Subscription(
                 subscription_object, msg_type,
                 topic, callback, qos_profile, raw,
+                on_destroy=self._on_destroy_subscription,
                 callback_group=callback_group,
                 event_callbacks=event_callbacks or SubscriptionEventCallbacks())
         except Exception:
@@ -1781,6 +1783,7 @@ class Node:
         client = Client(
             self.context,
             client_impl, srv_type, srv_name, qos_profile,
+            on_destroy=self._on_destroy_client,
             callback_group=callback_group)
         callback_group.add_entity(client)
         self._clients.append(client)
@@ -1826,6 +1829,7 @@ class Node:
         service = Service(
             service_impl,
             srv_type, srv_name, callback, qos_profile,
+            on_destroy=self._on_destroy_service,
             callback_group=callback_group)
         callback_group.add_entity(service)
         self._services.append(service)
@@ -1864,6 +1868,7 @@ class Node:
         timer = Timer(
             callback, timer_period_nsec, clock,
             callback_group=callback_group,
+            on_destroy=self._on_destroy_timer,
             context=self.context,
             autostart=autostart
         )
@@ -1917,6 +1922,30 @@ class Node:
         timer = self.create_timer(period, callback, group, clock)
         return Rate(timer, context=self.context)
 
+    def _on_destroy_publisher(self, publisher: BasePublisher) -> None:
+        self._publishers.remove(publisher)
+        for event_handler in publisher.event_handlers:
+            self.__waitables.remove(event_handler)
+        self._wake_executor()
+
+    def _on_destroy_subscription(self, subscription: BaseSubscription) -> None:
+        self._subscriptions.remove(subscription)
+        for event_handler in subscription.event_handlers:
+            self.__waitables.remove(event_handler)
+        self._wake_executor()
+
+    def _on_destroy_client(self, client: BaseClient) -> None:
+        self._clients.remove(client)
+        self._wake_executor()
+
+    def _on_destroy_service(self, service: BaseService) -> None:
+        self._services.remove(service)
+        self._wake_executor()
+
+    def _on_destroy_timer(self, timer: BaseTimer) -> None:
+        self._timers.remove(timer)
+        self._wake_executor()
+
     def destroy_publisher(self, publisher: Publisher[Any]) -> bool:
         """
         Destroy a publisher created by the node.
@@ -1924,14 +1953,7 @@ class Node:
         :return: ``True`` if successful, ``False`` otherwise.
         """
         if publisher in self._publishers:
-            self._publishers.remove(publisher)
-            for event_handler in publisher.event_handlers:
-                self.__waitables.remove(event_handler)
-            try:
-                publisher.destroy()
-            except InvalidHandle:
-                return False
-            self._wake_executor()
+            publisher.destroy()
             return True
         return False
 
@@ -1942,14 +1964,7 @@ class Node:
         :return: ``True`` if successful, ``False`` otherwise.
         """
         if subscription in self._subscriptions:
-            self._subscriptions.remove(subscription)
-            for event_handler in subscription.event_handlers:
-                self.__waitables.remove(event_handler)
-            try:
-                subscription.destroy()
-            except InvalidHandle:
-                return False
-            self._wake_executor()
+            subscription.destroy()
             return True
         return False
 
@@ -1960,12 +1975,7 @@ class Node:
         :return: ``True`` if successful, ``False`` otherwise.
         """
         if client in self._clients:
-            self._clients.remove(client)
-            try:
-                client.destroy()
-            except InvalidHandle:
-                return False
-            self._wake_executor()
+            client.destroy()
             return True
         return False
 
@@ -1976,12 +1986,7 @@ class Node:
         :return: ``True`` if successful, ``False`` otherwise.
         """
         if service in self._services:
-            self._services.remove(service)
-            try:
-                service.destroy()
-            except InvalidHandle:
-                return False
-            self._wake_executor()
+            service.destroy()
             return True
         return False
 
@@ -1992,12 +1997,7 @@ class Node:
         :return: ``True`` if successful, ``False`` otherwise.
         """
         if timer in self._timers:
-            self._timers.remove(timer)
-            try:
-                timer.destroy()
-            except InvalidHandle:
-                return False
-            self._wake_executor()
+            timer.destroy()
             return True
         return False
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -78,7 +78,7 @@ from rclpy.logging_service import LoggingService
 from rclpy.parameter import (AllowableParameterValue, AllowableParameterValueT, Parameter,
                              PARAMETER_SEPARATOR_STRING)
 from rclpy.parameter_service import ParameterService
-from rclpy.publisher import BasePublisher, Publisher
+from rclpy.publisher import Publisher
 from rclpy.qos import qos_profile_parameter_events
 from rclpy.qos import qos_profile_rosout_default
 from rclpy.qos import qos_profile_services_default
@@ -86,7 +86,7 @@ from rclpy.qos import QoSProfile
 from rclpy.qos_overriding_options import _declare_qos_parameters
 from rclpy.qos_overriding_options import QoSOverridingOptions
 from rclpy.service import BaseService, Service
-from rclpy.subscription import BaseSubscription, GenericSubscriptionCallback
+from rclpy.subscription import GenericSubscriptionCallback
 from rclpy.subscription import Subscription
 from rclpy.subscription import SubscriptionCallbackUnion
 from rclpy.subscription_content_filter_options import ContentFilterOptions
@@ -1922,13 +1922,13 @@ class Node:
         timer = self.create_timer(period, callback, group, clock)
         return Rate(timer, context=self.context)
 
-    def _on_destroy_publisher(self, publisher: BasePublisher) -> None:
+    def _on_destroy_publisher(self, publisher: Publisher) -> None:
         self._publishers.remove(publisher)
         for event_handler in publisher.event_handlers:
             self.__waitables.remove(event_handler)
         self._wake_executor()
 
-    def _on_destroy_subscription(self, subscription: BaseSubscription) -> None:
+    def _on_destroy_subscription(self, subscription: Subscription) -> None:
         self._subscriptions.remove(subscription)
         for event_handler in subscription.event_handlers:
             self.__waitables.remove(event_handler)
@@ -2061,7 +2061,6 @@ class Node:
             self.destroy_timer(self._timers[0])
         while self._guards:
             self.destroy_guard_condition(self._guards[0])
-        self._type_description_service.destroy()
         self.__node.destroy_when_not_in_use()
         self._wake_executor()
 

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1946,17 +1946,17 @@ class Node:
             self.__waitables.remove(event_handler)
         self._wake_executor()
 
-    def _on_destroy_subscription(self, subscription: Subscription) -> None:
+    def _on_destroy_subscription(self, subscription: Subscription[Any]) -> None:
         self._subscriptions.remove(subscription)
         for event_handler in subscription.event_handlers:
             self.__waitables.remove(event_handler)
         self._wake_executor()
 
-    def _on_destroy_client(self, client: BaseClient) -> None:
+    def _on_destroy_client(self, client: BaseClient[Any, Any]) -> None:
         self._clients.remove(client)
         self._wake_executor()
 
-    def _on_destroy_service(self, service: BaseService) -> None:
+    def _on_destroy_service(self, service: BaseService[Any, Any]) -> None:
         self._services.remove(service)
         self._wake_executor()
 

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from types import TracebackType
-from typing import Callable, Generic, List, Optional, Type, TypeVar, Union
+from typing import Generic, List, Optional, Type, TypeVar, Union
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.duration import Duration

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from types import TracebackType
-from typing import Generic, List, Optional, Type, TypeVar, Union
+from typing import Callable, Generic, List, Optional, Type, TypeVar, Union
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.duration import Duration
@@ -34,11 +34,15 @@ class BasePublisher(Generic[MsgT]):
         msg_type: Type[MsgT],
         topic: str,
         qos_profile: QoSProfile,
+        *,
+        on_destroy: Optional[Callable[['BasePublisher[MsgT]'], None]] = None,
     ) -> None:
         self.__publisher = publisher_impl
         self.msg_type = msg_type
         self.topic = topic
         self.qos_profile = qos_profile
+        self._on_destroy = on_destroy
+        self._destroyed = False
 
     def publish(self, msg: Union[MsgT, bytes]) -> None:
         """
@@ -77,7 +81,17 @@ class BasePublisher(Generic[MsgT]):
             return self.__publisher.get_logger_name()
 
     def destroy(self) -> None:
-        self.__publisher.destroy_when_not_in_use()
+        """Destroy the publisher, notifying the owning node and releasing the handle."""
+        if self._destroyed:
+            return
+        self._destroyed = True
+        if self._on_destroy is not None:
+            self._on_destroy(self)
+            self._on_destroy = None
+        self._destroy()
+
+    def _destroy(self) -> None:
+        self.handle.destroy_when_not_in_use()
 
     def assert_liveliness(self) -> None:
         """
@@ -110,6 +124,7 @@ class Publisher(BasePublisher[MsgT], Generic[MsgT]):
         topic: str,
         qos_profile: QoSProfile,
         *,
+        on_destroy: Optional[Callable[['BasePublisher[MsgT]'], None]] = None,
         event_callbacks: PublisherEventCallbacks,
         callback_group: CallbackGroup,
     ) -> None:
@@ -131,7 +146,8 @@ class Publisher(BasePublisher[MsgT], Generic[MsgT]):
             publisher_impl=publisher_impl,
             msg_type=msg_type,
             topic=topic,
-            qos_profile=qos_profile
+            qos_profile=qos_profile,
+            on_destroy=on_destroy
         )
 
         self.event_handlers: List[EventHandler] = event_callbacks.create_event_handlers(
@@ -157,13 +173,7 @@ class Publisher(BasePublisher[MsgT], Generic[MsgT]):
         with self.handle:
             return self.handle.wait_for_all_acked(timeout._duration_handle)
 
-    def destroy(self) -> None:
-        """
-        Destroy a container for a ROS publisher.
-
-        .. warning:: Users should not destroy a publisher with this method, instead they should
-           call :meth:`.Node.destroy_publisher`.
-        """
+    def _destroy(self) -> None:
         for handler in self.event_handlers:
             handler.destroy()
-        super().destroy()
+        super()._destroy()

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -127,7 +127,7 @@ class Publisher(BasePublisher[MsgT], Generic[MsgT]):
         topic: str,
         qos_profile: QoSProfile,
         *,
-        on_destroy: Optional[Callable[['BasePublisher[MsgT]'], None]] = None,
+        on_destroy: Optional[Callable[['Publisher[MsgT]'], None]] = None,
         event_callbacks: PublisherEventCallbacks,
         callback_group: CallbackGroup,
     ) -> None:
@@ -150,8 +150,8 @@ class Publisher(BasePublisher[MsgT], Generic[MsgT]):
             msg_type=msg_type,
             topic=topic,
             qos_profile=qos_profile,
-            on_destroy=on_destroy
         )
+        self._on_destroy = on_destroy
 
         self.event_handlers: List[EventHandler] = event_callbacks.create_event_handlers(
             callback_group, publisher_impl, topic)

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -52,13 +52,17 @@ class BaseService(Generic[SrvRequestT, SrvResponseT]):
         srv_type: type[Srv[SrvRequestT, SrvResponseT]],
         srv_name: str,
         callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
-        qos_profile: QoSProfile
+        qos_profile: QoSProfile,
+        *,
+        on_destroy: Optional[Callable[['BaseService[SrvRequestT, SrvResponseT]'], None]] = None,
     ) -> None:
         self.__service = service_impl
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.callback = callback
         self.qos_profile = qos_profile
+        self._on_destroy = on_destroy
+        self._destroyed = False
 
     def _send_response(
         self,
@@ -108,13 +112,17 @@ class BaseService(Generic[SrvRequestT, SrvResponseT]):
             return self.__service.get_logger_name()
 
     def destroy(self) -> None:
-        """
-        Destroy a container for a ROS service server.
+        """Destroy the service, notifying the owning node and releasing the handle."""
+        if self._destroyed:
+            return
+        self._destroyed = True
+        if self._on_destroy is not None:
+            self._on_destroy(self)
+            self._on_destroy = None
+        self._destroy()
 
-        .. warning:: Users should not destroy a service server with this destructor, instead they
-           should call :meth:`.Node.destroy_service`.
-        """
-        self.__service.destroy_when_not_in_use()
+    def _destroy(self) -> None:
+        self.handle.destroy_when_not_in_use()
 
     def __enter__(self) -> 'BaseService[SrvRequestT, SrvResponseT]':
         return self
@@ -137,6 +145,7 @@ class Service(BaseService[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvRe
         callback: ServiceCallbackUnion[SrvRequestT, SrvResponseT],
         qos_profile: QoSProfile,
         *,
+        on_destroy: Optional[Callable[['Service[SrvRequestT, SrvResponseT]'], None]] = None,
         callback_group: CallbackGroup
     ) -> None:
         """
@@ -159,7 +168,8 @@ class Service(BaseService[SrvRequestT, SrvResponseT], Generic[SrvRequestT, SrvRe
             srv_type=srv_type,
             srv_name=srv_name,
             callback=callback,
-            qos_profile=qos_profile
+            qos_profile=qos_profile,
+            on_destroy=on_destroy
         )
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -83,6 +83,8 @@ class BaseSubscription(Generic[MsgT]):
          callback: GenericSubscriptionCallbackUnion[bytes],
          qos_profile: QoSProfile,
          raw: Literal[True],
+         *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
     ) -> None: ...
 
     @overload
@@ -94,6 +96,8 @@ class BaseSubscription(Generic[MsgT]):
          callback: GenericSubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: Literal[False],
+         *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
     ) -> None: ...
 
     @overload
@@ -105,6 +109,8 @@ class BaseSubscription(Generic[MsgT]):
          callback: SubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
+         *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
     ) -> None: ...
 
     def __init__(
@@ -115,6 +121,8 @@ class BaseSubscription(Generic[MsgT]):
          callback: SubscriptionCallbackUnion[MsgT],
          qos_profile: QoSProfile,
          raw: bool,
+         *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
     ) -> None:
         self.__subscription = subscription_impl
         self.msg_type = msg_type
@@ -122,6 +130,8 @@ class BaseSubscription(Generic[MsgT]):
         self.callback = callback
         self.qos_profile = qos_profile
         self.raw = raw
+        self._on_destroy = on_destroy
+        self._destroyed = False
 
     def get_publisher_count(self) -> int:
         """Get the number of publishers that this subscription has."""
@@ -133,6 +143,16 @@ class BaseSubscription(Generic[MsgT]):
         return self.__subscription
 
     def destroy(self) -> None:
+        """Destroy the subscription, notifying the owning node and releasing the handle."""
+        if self._destroyed:
+            return
+        self._destroyed = True
+        if self._on_destroy is not None:
+            self._on_destroy(self)
+            self._on_destroy = None
+        self._destroy()
+
+    def _destroy(self) -> None:
         self.handle.destroy_when_not_in_use()
 
     @property
@@ -224,6 +244,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: Literal[True],
          *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -238,6 +259,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: Literal[False],
          *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -252,6 +274,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: bool,
          *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -265,6 +288,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: bool,
          *,
+         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None:
@@ -292,7 +316,8 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
             topic=topic,
             callback=callback,
             qos_profile=qos_profile,
-            raw=raw
+            raw=raw,
+            on_destroy=on_destroy
         )
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor
@@ -301,13 +326,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
         self.event_handlers = event_callbacks.create_event_handlers(
             callback_group, subscription_impl, topic)
 
-    def destroy(self) -> None:
-        """
-        Destroy a container for a ROS subscription.
-
-        .. warning:: Users should not destroy a subscription with this method, instead they
-           should call :meth:`.Node.destroy_subscription`.
-        """
+    def _destroy(self) -> None:
         for handler in self.event_handlers:
             handler.destroy()
-        super().destroy()
+        super()._destroy()

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -251,7 +251,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: Literal[True],
          *,
-         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
+         on_destroy: Optional[Callable[['Subscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -266,7 +266,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: Literal[False],
          *,
-         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
+         on_destroy: Optional[Callable[['Subscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -281,7 +281,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: bool,
          *,
-         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
+         on_destroy: Optional[Callable[['Subscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None: ...
@@ -295,7 +295,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
          qos_profile: QoSProfile,
          raw: bool,
          *,
-         on_destroy: Optional[Callable[['BaseSubscription[MsgT]'], None]] = None,
+         on_destroy: Optional[Callable[['Subscription[MsgT]'], None]] = None,
          callback_group: CallbackGroup,
          event_callbacks: SubscriptionEventCallbacks,
     ) -> None:
@@ -324,8 +324,8 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
             callback=callback,
             qos_profile=qos_profile,
             raw=raw,
-            on_destroy=on_destroy
         )
+        self._on_destroy = on_destroy
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor
         self._executor_event = False

--- a/rclpy/rclpy/subscription.py
+++ b/rclpy/rclpy/subscription.py
@@ -323,7 +323,7 @@ class Subscription(BaseSubscription[MsgT], Generic[MsgT]):
             topic=topic,
             callback=callback,
             qos_profile=qos_profile,
-            raw=raw,
+            raw=raw
         )
         self._on_destroy = on_destroy
         self.callback_group = callback_group

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -80,6 +80,7 @@ class BaseTimer:
         timer_period_ns: int,
         clock: Clock,
         *,
+        on_destroy: Optional[Callable[['BaseTimer'], None]] = None,
         context: Optional[Context] = None,
         autostart: bool = True
     ) -> None:
@@ -91,18 +92,24 @@ class BaseTimer:
             self.__timer = _rclpy.Timer(
                 self._clock.handle, self._context.handle, timer_period_ns, autostart)
         self.callback = callback
+        self._on_destroy = on_destroy
+        self._destroyed = False
 
     @property
     def handle(self) -> _rclpy.Timer:
         return self.__timer
 
     def destroy(self) -> None:
-        """
-        Destroy a container for a ROS timer.
+        """Destroy the timer, notifying the owning node and releasing the handle."""
+        if self._destroyed:
+            return
+        self._destroyed = True
+        if self._on_destroy is not None:
+            self._on_destroy(self)
+            self._on_destroy = None
+        self._destroy()
 
-        .. warning:: Users should not destroy a timer with this method, instead they should
-           call :meth:`.Node.destroy_timer`.
-        """
+    def _destroy(self) -> None:
         self.__timer.destroy_when_not_in_use()
 
     @property
@@ -165,6 +172,7 @@ class Timer(BaseTimer):
         timer_period_ns: int,
         clock: Clock,
         *,
+        on_destroy: Optional[Callable[['BaseTimer'], None]] = None,
         context: Optional[Context] = None,
         autostart: bool = True,
         callback_group: Optional[CallbackGroup] = None
@@ -194,7 +202,8 @@ class Timer(BaseTimer):
             timer_period_ns=timer_period_ns,
             clock=clock,
             context=context,
-            autostart=autostart
+            autostart=autostart,
+            on_destroy=on_destroy
         )
         self.callback_group = callback_group
         # True when the callback is ready to fire but has not been "taken" by an executor

--- a/rclpy/rclpy/type_description_service.py
+++ b/rclpy/rclpy/type_description_service.py
@@ -94,6 +94,7 @@ class TypeDescriptionService:
             srv_type=GetTypeDescription,
             srv_name=self.service_name,
             callback=self._service_callback,
+            on_destroy=node._on_destroy_service,
             callback_group=node.default_callback_group,
             qos_profile=qos_profile_services_default)
         node.default_callback_group.add_entity(service)

--- a/rclpy/rclpy/type_description_service.py
+++ b/rclpy/rclpy/type_description_service.py
@@ -77,12 +77,6 @@ class TypeDescriptionService:
         if self.enabled:
             self._start_service()
 
-    def destroy(self) -> None:
-        # Required manual destruction because this is not managed by rclpy.Service
-        if self._type_description_srv is not None:
-            self._type_description_srv.destroy_when_not_in_use()
-            self._type_description_srv = None
-
     def _start_service(self) -> None:
         node = self._get_node()
         self._type_description_srv = _rclpy.TypeDescriptionService(node.handle)

--- a/rclpy/test/test_client.py
+++ b/rclpy/test/test_client.py
@@ -309,6 +309,15 @@ class TestClient(unittest.TestCase):
                 finally:
                     executor.shutdown()
 
+    def test_client_direct_destroy(self) -> None:
+        cli = self.node.create_client(Empty, '/test_direct_destroy')
+
+        self.assertIn(cli, list(self.node.clients))
+        cli.destroy()
+        self.assertNotIn(cli, list(self.node.clients))
+        cli.destroy()
+        self.assertFalse(self.node.destroy_client(cli))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rclpy/test/test_publisher.py
+++ b/rclpy/test/test_publisher.py
@@ -138,6 +138,15 @@ class TestPublisher(unittest.TestCase):
         with self.node.create_publisher(BasicTypes, TEST_TOPIC, 10) as pub:
             self.assertEqual(pub.logger_name, 'node')
 
+    def test_direct_destroy(self) -> None:
+        pub = self.node.create_publisher(BasicTypes, 'topic', 1)
+
+        self.assertIn(pub, list(self.node.publishers))
+        pub.destroy()
+        self.assertNotIn(pub, list(self.node.publishers))
+        pub.destroy()
+        self.assertFalse(self.node.destroy_publisher(pub))
+
 
 def test_publisher_context_manager() -> None:
     rclpy.init()

--- a/rclpy/test/test_service.py
+++ b/rclpy/test/test_service.py
@@ -115,6 +115,19 @@ def test_service_context_manager() -> None:
             assert srv.service_name == '/empty_service'
 
 
+def test_service_direct_destroy(test_node: Node) -> None:
+    srv = test_node.create_service(
+        srv_type=Empty,
+        srv_name='test_direct_destroy_srv',
+        callback=lambda _req, res: res)
+
+    assert srv in list(test_node.services)
+    srv.destroy()
+    assert srv not in list(test_node.services)
+    srv.destroy()
+    assert not test_node.destroy_service(srv)
+
+
 def test_set_on_new_request_callback(test_node: Node) -> None:
     cli = test_node.create_client(Empty, '/service')
     srv = test_node.create_service(Empty, '/service', lambda req, res: res)

--- a/rclpy/test/test_subscription.py
+++ b/rclpy/test/test_subscription.py
@@ -461,6 +461,20 @@ def test_subscription_content_filter_reset(test_node: Node) -> None:
     assert len(received_msgs) == expected_msg_count
 
 
+def test_subscription_direct_destroy(test_node: Node) -> None:
+    sub = test_node.create_subscription(
+        msg_type=Empty,
+        topic='test_direct_destroy_topic',
+        callback=lambda msg: None,
+        qos_profile=10)
+
+    assert sub in list(test_node.subscriptions)
+    sub.destroy()
+    assert sub not in list(test_node.subscriptions)
+    sub.destroy()
+    assert not test_node.destroy_subscription(sub)
+
+
 def test_subscription_content_filter_at_create_subscription(test_node: Node) -> None:
 
     if rclpy.get_rmw_implementation_identifier() != 'rmw_fastrtps_cpp' and \

--- a/rclpy/test/test_timer.py
+++ b/rclpy/test/test_timer.py
@@ -362,3 +362,13 @@ def test_on_reset_callback(test_node: Node) -> None:
     tmr.handle.clear_on_reset_callback()
     tmr.reset()
     cb.assert_called_once()
+
+
+def test_timer_direct_destroy(test_node: Node) -> None:
+    tmr = test_node.create_timer(1, lambda: None)
+
+    assert tmr in list(test_node.timers)
+    tmr.destroy()
+    assert tmr not in list(test_node.timers)
+    tmr.destroy()
+    assert not test_node.destroy_timer(tmr)


### PR DESCRIPTION
Part of #1620
## Changes
* Unified `destroy()` pattern across all entity base classes (BasePublisher, BaseSubscription, BaseClient, BaseService, BaseTimer)
* Each base class `destroy()` is now idempotent via `_destroyed` flag, calls an `on_destroy` callback to notify the owning node, then calls `_destroy()` for handle cleanup
* `Node.destroy_*()` methods now delegate entirely to `entity.destroy()` — node-list removal and executor wake-up happen via `on_destroy` callbacks instead of being duplicated in the node
* Entities can be destroyed directly (`entity.destroy()`) without going through `Node.destroy_*()`, enabling AsyncNode to use the same entity classes

## Notes
* `on_destroy` is an optional keyword-only argument defaulting to `None`, so all existing third-party code constructing entities directly continues to work
* The `.. warning:: Users should not destroy ...` docstrings are removed — direct `entity.destroy()` is now the supported API
* `Node.destroy_*()` methods no longer catch `InvalidHandle` — double-destroy is handled by the idempotent `_destroyed` flag instead