### PR TITLE
Fix pep765 violation

### DIFF
--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -475,7 +475,6 @@ class TestExecutor(unittest.TestCase):
                             executor.spin_once()
                         finally:
                             executor.shutdown()
-                            break
 
                 # Start spinning in a separate thread
                 thr = threading.Thread(target=spin_until_task_done, args=(executor, ), daemon=True)


### PR DESCRIPTION
## Description

https://github.com/ros2/ci/issues/838#issuecomment-4118939903

Apparently [this](https://peps.python.org/pep-0765/) is bad now starting in python3.14

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
