### PR TITLE
fix flaky test_multi_threaded_executor_closes_threads.

### DIFF
--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -187,7 +187,7 @@ class TestExecutor(unittest.TestCase):
         try:
             self.assertTrue(self.func_execution(executor))
         finally:
-            executor.shutdown()
+            executor.shutdown(wait_for_threads=True)
 
     def test_multi_threaded_executor_closes_threads(self) -> None:
         self.assertIsNotNone(self.node.handle)
@@ -198,6 +198,15 @@ class TestExecutor(unittest.TestCase):
             return {t.name for t in threading.enumerate()
                     if t.name and t.name.startswith(executor_prefix)}
 
+        def wait_for_threads_to_stop() -> None:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if not get_executor_threads():
+                    break
+                time.sleep(0.1)
+
+        # Wait for any leftover threads from prior tests to finish.
+        wait_for_threads_to_stop()
         self.assertEqual(set(), get_executor_threads())
         # Explicitly specify 2_threads for single thread system failure
         executor = MultiThreadedExecutor(context=self.context, num_threads=2)
@@ -210,11 +219,7 @@ class TestExecutor(unittest.TestCase):
             executor.shutdown(wait_for_threads=True)
             # Worker threads may still be tearing down briefly after shutdown
             # returns, so poll with a timeout instead of a single-shot check.
-            deadline = time.monotonic() + 5.0
-            while time.monotonic() < deadline:
-                if not get_executor_threads():
-                    break
-                time.sleep(0.1)
+            wait_for_threads_to_stop()
             self.assertEqual(set(), get_executor_threads())
 
     def test_add_node_to_executor(self) -> None:

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -192,10 +192,13 @@ class TestExecutor(unittest.TestCase):
     def test_multi_threaded_executor_closes_threads(self) -> None:
         self.assertIsNotNone(self.node.handle)
 
-        def get_threads() -> Set[str]:
-            return {t.name for t in threading.enumerate()}
+        executor_prefix = 'ThreadPoolExecutor-'
 
-        main_thread_name = get_threads()
+        def get_executor_threads() -> Set[str]:
+            return {t.name for t in threading.enumerate()
+                    if t.name and t.name.startswith(executor_prefix)}
+
+        self.assertEqual(set(), get_executor_threads())
         # Explicitly specify 2_threads for single thread system failure
         executor = MultiThreadedExecutor(context=self.context, num_threads=2)
 
@@ -203,9 +206,16 @@ class TestExecutor(unittest.TestCase):
             # Give the executor a callback so at least one thread gets spun up
             self.assertTrue(self.func_execution(executor))
         finally:
-            self.assertTrue(main_thread_name != get_threads())
+            self.assertNotEqual(set(), get_executor_threads())
             executor.shutdown(wait_for_threads=True)
-            self.assertTrue(main_thread_name == get_threads())
+            # Worker threads may still be tearing down briefly after shutdown
+            # returns, so poll with a timeout instead of a single-shot check.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if not get_executor_threads():
+                    break
+                time.sleep(0.1)
+            self.assertEqual(set(), get_executor_threads())
 
     def test_add_node_to_executor(self) -> None:
         self.assertIsNotNone(self.node.handle)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -198,16 +198,15 @@ class TestExecutor(unittest.TestCase):
             return {t.name for t in threading.enumerate()
                     if t.name and t.name.startswith(executor_prefix)}
 
-        def wait_for_threads_to_stop() -> None:
+        def wait_for_no_new_threads(baseline: Set[str]) -> None:
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
-                if not get_executor_threads():
+                if not (get_executor_threads() - baseline):
                     break
                 time.sleep(0.1)
 
-        # Wait for any leftover threads from prior tests to finish.
-        wait_for_threads_to_stop()
-        self.assertEqual(set(), get_executor_threads())
+        # Snapshot any pre-existing threads (e.g. still tearing down from prior tests).
+        baseline_threads = get_executor_threads()
         # Explicitly specify 2_threads for single thread system failure
         executor = MultiThreadedExecutor(context=self.context, num_threads=2)
 
@@ -215,12 +214,13 @@ class TestExecutor(unittest.TestCase):
             # Give the executor a callback so at least one thread gets spun up
             self.assertTrue(self.func_execution(executor))
         finally:
-            self.assertNotEqual(set(), get_executor_threads())
+            new_threads = get_executor_threads() - baseline_threads
+            self.assertNotEqual(set(), new_threads)
             executor.shutdown(wait_for_threads=True)
             # Worker threads may still be tearing down briefly after shutdown
             # returns, so poll with a timeout instead of a single-shot check.
-            wait_for_threads_to_stop()
-            self.assertEqual(set(), get_executor_threads())
+            wait_for_no_new_threads(baseline_threads)
+            self.assertEqual(set(), get_executor_threads() - baseline_threads)
 
     def test_add_node_to_executor(self) -> None:
         self.assertIsNotNone(self.node.handle)


### PR DESCRIPTION
## Description

see https://ci.ros2.org/job/ci_linux-aarch64/21188/testReport/junit/rclpy.rclpy.test.test_executor/TestExecutor/test_multi_threaded_executor_closes_threads/

CC: @InvincibleRMC 

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
