### PR TITLE
Bugfix: executor doesn't propagate exception from task that awaited a future

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -743,6 +743,10 @@ class Executor(ContextManager['Executor']):
                 ready_tasks_count = len(self._ready_tasks)
             for _ in range(ready_tasks_count):
                 task = self._ready_tasks.popleft()
+                # Skip tasks that were cancelled or set done while awaiting a
+                # future and got rescheduled when the future completed
+                if task.cancelled() or task.done():
+                    continue
                 task_data = self._pending_tasks[task]
                 node = task_data.source_node
                 if node is None or node in nodes_to_use:

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -172,6 +172,9 @@ class Future(Generic[T]):
             # No executor, call right away
             for callback in callbacks:
                 if isinstance(callback, Task):
+                    warnings.warn(
+                        'Dropping task awaiting future: '
+                        'executor reference could not be resolved')
                     continue
                 try:
                     callback(self)
@@ -222,7 +225,10 @@ class Future(Generic[T]):
                 executor = self._executor()
                 if executor is not None:
                     executor._call_task_in_next_spin(task)
-
+                else:
+                    warnings.warn(
+                        'Dropping task awaiting future: '
+                        'executor reference could not be resolved')
             else:
                 self._callbacks.append(task)
 
@@ -370,6 +376,7 @@ class Task(Future[T]):
         elif future_executor is not executor:
             raise RuntimeError('A task can only await futures associated with the same executor')
 
+        # Register the task to resume when the future is done or cancelled
         future._add_waiting_task(self)
 
     def _complete_task(self) -> None:

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -50,8 +50,8 @@ class Future(Generic[T]):
         # An exception raised by the handler when called
         self._exception: Optional[Exception] = None
         self._exception_fetched = False
-        # callbacks to be scheduled after this task completes
-        self._callbacks: List[Callable[['Future[T]'], None]] = []
+        # callbacks or tasks to be scheduled after this task completes
+        self._callbacks: List[Union[Callable[['Future[T]'], None], 'Task[Any]']] = []
         # Lock for threadsafety
         self._lock = threading.Lock()
         # An executor to use when scheduling done callbacks
@@ -164,10 +164,15 @@ class Future(Generic[T]):
         if executor is not None:
             # Have the executor take care of the callbacks
             for callback in callbacks:
-                executor.create_task(callback, self)
+                if isinstance(callback, Task):
+                    executor._call_task_in_next_spin(callback)
+                else:
+                    executor.create_task(callback, self)
         else:
             # No executor, call right away
             for callback in callbacks:
+                if isinstance(callback, Task):
+                    continue
                 try:
                     callback(self)
                 except Exception as e:
@@ -208,6 +213,18 @@ class Future(Generic[T]):
         # Invoke when not holding self._lock
         if invoke:
             callback(self)
+
+    def _add_waiting_task(self, task: 'Task[Any]') -> None:
+        """Schedule a task to resume when this future completes."""
+        with self._lock:
+            if not self._pending():
+                assert self._executor is not None
+                executor = self._executor()
+                if executor is not None:
+                    executor._call_task_in_next_spin(task)
+
+            else:
+                self._callbacks.append(task)
 
     def remove_done_callback(self, callback: Callable[['Future[T]'], None]) -> bool:
         """
@@ -353,9 +370,7 @@ class Task(Future[T]):
         elif future_executor is not executor:
             raise RuntimeError('A task can only await futures associated with the same executor')
 
-        # The future is associated with the same executor, so we can resume the task directly
-        # in the done callback
-        future.add_done_callback(lambda _: self.__call__())
+        future._add_waiting_task(self)
 
     def _complete_task(self) -> None:
         """Cleanup after task finished."""

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -509,10 +509,63 @@ class TestExecutor(unittest.TestCase):
                 # Resolve the inner future — triggers resume
                 second_fut.set_result(None)
 
-                # The resumed coroutine should raise, and spin must propagate it
                 with self.assertRaises(RuntimeError) as cm:
                     executor.spin_until_future_complete(task, timeout_sec=5)
                 self.assertIn('Expected error after await', str(cm.exception))
+
+    def test_cancel_task_while_awaiting_future(self) -> None:
+        """Cancelling a task parked on a future must not crash the dispatch loop."""
+        self.assertIsNotNone(self.node.handle)
+        # EventsExecutor excluded - see #1641
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                executor.add_node(self.node)
+
+                first_fut = executor.create_future()
+                second_fut = executor.create_future()
+                third_fut = executor.create_future()
+                resumed = False
+
+                async def coro() -> None:
+                    nonlocal resumed
+                    first_fut.set_result(None)
+                    await second_fut
+                    third_fut.set_result(None)
+
+                task = executor.create_task(coro)
+
+                executor.spin_until_future_complete(first_fut, timeout_sec=5)
+                self.assertFalse(task.done())
+
+                task.cancel()
+                self.assertTrue(task.cancelled())
+
+                second_fut.set_result(None)
+
+                executor.spin_until_future_complete(first_fut, timeout_sec=5)
+                self.assertFalse(third_fut.done())
+
+    def test_await_already_completed_future(self) -> None:
+        """Awaiting an already-completed future must resume and return its result."""
+        self.assertIsNotNone(self.node.handle)
+        # EventsExecutor excluded - see #1641
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                executor.add_node(self.node)
+
+                fut: Future[str] = executor.create_future()
+                fut.set_result('done')  # complete before the task runs
+
+                async def coro() -> str:
+                    return await fut  # type: ignore[return-value]
+
+                task = executor.create_task(coro)
+
+                executor.spin_until_future_complete(task, timeout_sec=5)
+                self.assertTrue(task.done())
+                self.assertEqual('done', task.result())
 
     def test_create_task_during_spin(self) -> None:
         self.assertIsNotNone(self.node.handle)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -485,6 +485,35 @@ class TestExecutor(unittest.TestCase):
                 self.assertTrue(future1.done())
                 self.assertEqual('Sentinel Result 1', future1.result())
 
+    def test_coroutine_exception_after_await(self) -> None:
+        """Exception in a coroutine after awaiting a future must propagate."""
+        self.assertIsNotNone(self.node.handle)
+        # EventsExecutor excluded - segfaults on exception propagation (#1641)
+        for cls in [SingleThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                executor.add_node(self.node)
+
+                first_fut = executor.create_future()
+                second_fut = executor.create_future()
+
+                async def coro_that_raises() -> None:
+                    first_fut.set_result(None)
+                    await second_fut
+                    raise RuntimeError('Expected error after await')
+
+                task = executor.create_task(coro_that_raises)
+
+                executor.spin_until_future_complete(first_fut, timeout_sec=5)
+                self.assertFalse(task.done())
+                # Resolve the inner future — triggers resume
+                second_fut.set_result(None)
+
+                # The resumed coroutine should raise, and spin must propagate it
+                with self.assertRaises(RuntimeError) as cm:
+                    executor.spin_until_future_complete(task, timeout_sec=5)
+                self.assertIn('Expected error after await', str(cm.exception))
+
     def test_create_task_during_spin(self) -> None:
         self.assertIsNotNone(self.node.handle)
         for cls in [SingleThreadedExecutor, EventsExecutor]:

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -525,10 +525,8 @@ class TestExecutor(unittest.TestCase):
                 first_fut = executor.create_future()
                 second_fut = executor.create_future()
                 third_fut = executor.create_future()
-                resumed = False
 
                 async def coro() -> None:
-                    nonlocal resumed
                     first_fut.set_result(None)
                     await second_fut
                     third_fut.set_result(None)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -489,7 +489,7 @@ class TestExecutor(unittest.TestCase):
         """Exception in a coroutine after awaiting a future must propagate."""
         self.assertIsNotNone(self.node.handle)
         # EventsExecutor excluded - segfaults on exception propagation (#1641)
-        for cls in [SingleThreadedExecutor]:
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)


### PR DESCRIPTION
Fixes #1642 

### Changes
A task now registers itself on the awaited future via new `Future._add_waiting_task`.
The executor then dispatches the same `Task` object and sees its exception through `handler.exception()` as intended.

- `Future._callbacks` now holds `Union[Callable, Task]`
-  `_schedule_or_invoke_done_callbacks` handles `Task` entries through `executor._call_task_in_next_spin`.
- `_wait_for_ready_callbacks` skips tasks that were cancelled or completed between being queued and being popped.
- A `warnings.warn` fires if a waiting `Task` is dropped because the executor weakref could not be resolved.