### PR TITLE
Fix: skip flaky executor test

### DIFF
--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -80,6 +80,7 @@ class TestExecutor(unittest.TestCase):
                 finally:
                     executor.shutdown()
 
+    @unittest.skip('Flaky on CI - see issue #1648')
     def test_executor_immediate_shutdown(self) -> None:
         self.assertIsNotNone(self.node.handle)
         for cls in [SingleThreadedExecutor, EventsExecutor]:


### PR DESCRIPTION
Following #1648 - skipping `test_executor_immediate_shutdown` until the race condition is fixed to prevent CI failures.