### PR TITLE
Add tests for parameter_dict_from_yaml_file type and namespace handling

### DIFF
--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -18,6 +18,7 @@ from tempfile import NamedTemporaryFile
 import unittest
 
 import pytest
+import yaml
 from rcl_interfaces.msg import Parameter as ParameterMsg
 from rcl_interfaces.msg import ParameterType
 from rcl_interfaces.msg import ParameterValue
@@ -473,6 +474,121 @@ class TestParameter(unittest.TestCase):
             if os.path.exists(f.name):
                 os.unlink(f.name)
         self.assertRaises(FileNotFoundError, parameter_dict_from_yaml_file, 'unknown_file')
+
+    def test_parameter_dict_from_yaml_file_scalar_types(self) -> None:
+        yaml_string = """
+            /node:
+                ros__parameters:
+                    count: 42
+                    ratio: 3.5
+                    label: foo
+                    flag: true
+            """
+        with NamedTemporaryFile(mode='w', delete=False, suffix='.yaml') as f:
+            f.write(yaml_string)
+            f.flush()
+        try:
+            result = parameter_dict_from_yaml_file(f.name)
+            assert result['count'].value.type == ParameterType.PARAMETER_INTEGER
+            assert result['count'].value.integer_value == 42
+            assert result['ratio'].value.type == ParameterType.PARAMETER_DOUBLE
+            assert result['ratio'].value.double_value == 3.5
+            assert result['label'].value.type == ParameterType.PARAMETER_STRING
+            assert result['label'].value.string_value == 'foo'
+            assert result['flag'].value.type == ParameterType.PARAMETER_BOOL
+            assert result['flag'].value.bool_value is True
+        finally:
+            os.unlink(f.name)
+
+    def test_parameter_dict_from_yaml_file_array_types(self) -> None:
+        yaml_string = """
+            /node:
+                ros__parameters:
+                    bools: [true, false, true]
+                    ints: [1, 2, 3]
+                    doubles: [1.0, 2.5, 3.25]
+                    strings: ['a', 'b', 'c']
+            """
+        with NamedTemporaryFile(mode='w', delete=False, suffix='.yaml') as f:
+            f.write(yaml_string)
+            f.flush()
+        try:
+            result = parameter_dict_from_yaml_file(f.name)
+            assert result['bools'].value.type == ParameterType.PARAMETER_BOOL_ARRAY
+            assert list(result['bools'].value.bool_array_value) == [True, False, True]
+            assert result['ints'].value.type == ParameterType.PARAMETER_INTEGER_ARRAY
+            assert list(result['ints'].value.integer_array_value) == [1, 2, 3]
+            assert result['doubles'].value.type == ParameterType.PARAMETER_DOUBLE_ARRAY
+            assert list(result['doubles'].value.double_array_value) == [1.0, 2.5, 3.25]
+            assert result['strings'].value.type == ParameterType.PARAMETER_STRING_ARRAY
+            assert list(result['strings'].value.string_array_value) == ['a', 'b', 'c']
+        finally:
+            os.unlink(f.name)
+
+    def test_parameter_dict_from_yaml_file_namespace_prepends(self) -> None:
+        yaml_string = """
+            /node:
+                ros__parameters:
+                    foo: 1
+                    bar: 2
+            """
+        with NamedTemporaryFile(mode='w', delete=False, suffix='.yaml') as f:
+            f.write(yaml_string)
+            f.flush()
+        try:
+            result = parameter_dict_from_yaml_file(f.name, namespace='my_ns.')
+            assert 'my_ns.foo' in result
+            assert 'my_ns.bar' in result
+            assert result['my_ns.foo'].name == 'my_ns.foo'
+            assert result['my_ns.foo'].value.integer_value == 1
+        finally:
+            os.unlink(f.name)
+
+    def test_parameter_dict_from_yaml_file_nested_keys_flattened(self) -> None:
+        yaml_string = """
+            /node:
+                ros__parameters:
+                    outer:
+                        inner: 7
+                        leaf: hello
+            """
+        with NamedTemporaryFile(mode='w', delete=False, suffix='.yaml') as f:
+            f.write(yaml_string)
+            f.flush()
+        try:
+            result = parameter_dict_from_yaml_file(f.name)
+            assert 'outer.inner' in result
+            assert 'outer.leaf' in result
+            assert result['outer.inner'].value.integer_value == 7
+            assert result['outer.leaf'].value.string_value == 'hello'
+        finally:
+            os.unlink(f.name)
+
+    def test_parameter_dict_from_yaml_file_malformed_raises(self) -> None:
+        yaml_string = '/node:\n    ros__parameters: [unclosed'
+        with NamedTemporaryFile(mode='w', delete=False, suffix='.yaml') as f:
+            f.write(yaml_string)
+            f.flush()
+        try:
+            with pytest.raises(yaml.YAMLError):
+                parameter_dict_from_yaml_file(f.name)
+        finally:
+            os.unlink(f.name)
+
+    def test_parameter_dict_from_yaml_file_empty_params_raises(self) -> None:
+        yaml_string = """
+            /node:
+                ros__parameters: {}
+            """
+        with NamedTemporaryFile(mode='w', delete=False, suffix='.yaml') as f:
+            f.write(yaml_string)
+            f.flush()
+        try:
+            with pytest.raises(RuntimeError,
+                               match='Param file does not contain any valid parameters'):
+                parameter_dict_from_yaml_file(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -18,7 +18,6 @@ from tempfile import NamedTemporaryFile
 import unittest
 
 import pytest
-import yaml
 from rcl_interfaces.msg import Parameter as ParameterMsg
 from rcl_interfaces.msg import ParameterType
 from rcl_interfaces.msg import ParameterValue
@@ -26,6 +25,7 @@ from rclpy.parameter import get_parameter_value
 from rclpy.parameter import Parameter
 from rclpy.parameter import parameter_dict_from_yaml_file
 from rclpy.parameter import parameter_value_to_python
+import yaml
 
 
 class TestParameter(unittest.TestCase):


### PR DESCRIPTION

## Description

  Regression fixtures ahead of #1606 (replace `parameter_dict_from_yaml_file`
  with `rcl_parse_yaml_file`). Covers scalar/array types, namespace prepend,                                                               
  nested-key flattening, malformed YAML, and empty `ros__parameters` —
  cases not exercised by the existing wildcard-focused test                                                                                
  (`test_parameter_dict_from_yaml_file`, ~lines 261-476 of `test_parameter.py`).
                                                                                                                                           
  This is PR 1 of 2 planned for #1606:                                                                                                     
  - PR-1 (this PR): purely additive test coverage against current behavior,                                                                
    no implementation change                                                                                                               
  - PR-2 (later): replace implementation to delegate to `rcl_parse_yaml_file`;
    tests from PR-1 become parity guards. If divergence shows up, it surfaces                                                              
    a bug to address separately.                                                                                                           
                                                                                                                                           
  Related to #1606.                                                                                                                        
                                                                                                                                           
  Important: use Related to #1606, not Fixes #1606 — this PR does not resolve the issue, only scaffolds for it. Fixes would auto-close on  
  merge.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?



### Did you use Generative AI?

  Regression fixtures ahead of #1606 (replace `parameter_dict_from_yaml_file`
  with `rcl_parse_yaml_file`). Covers scalar/array types, namespace prepend,                                                               
  nested-key flattening, malformed YAML, and empty `ros__parameters` —
  cases not exercised by the existing wildcard-focused test                                                                                
  (`test_parameter_dict_from_yaml_file`, ~lines 261-476 of `test_parameter.py`).
                                                                                                                                           
  This is PR 1 of 2 planned for #1606:                                                                                                     
  - PR-1 (this PR): purely additive test coverage against current behavior,                                                                
    no implementation change                                                                                                               
  - PR-2 (later): replace implementation to delegate to `rcl_parse_yaml_file`;
    tests from PR-1 become parity guards. If divergence shows up, it surfaces                                                              
    a bug to address separately.                                                                                                           
                                                                                                                                           
  Related to #1606.                                                                                                                        
                                                                                                                                           
  Important: use Related to #1606, not Fixes #1606 — this PR does not resolve the issue, only scaffolds for it. Fixes would auto-close on  
  merge.

### Additional Information

  Regression fixtures ahead of #1606 (replace `parameter_dict_from_yaml_file`
  with `rcl_parse_yaml_file`). Covers scalar/array types, namespace prepend,                                                               
  nested-key flattening, malformed YAML, and empty `ros__parameters` —
  cases not exercised by the existing wildcard-focused test                                                                                
  (`test_parameter_dict_from_yaml_file`, ~lines 261-476 of `test_parameter.py`).
                                                                                                                                           
  This is PR 1 of 2 planned for #1606:                                                                                                     
  - PR-1 (this PR): purely additive test coverage against current behavior,                                                                
    no implementation change                                                                                                               
  - PR-2 (later): replace implementation to delegate to `rcl_parse_yaml_file`;
    tests from PR-1 become parity guards. If divergence shows up, it surfaces                                                              
    a bug to address separately.                                                                                                           
                                                                                                                                           
  Related to #1606.                                                                                                                        
                                                                                                                                           
  Important: use Related to #1606, not Fixes #1606 — this PR does not resolve the issue, only scaffolds for it. Fixes would auto-close on  
  merge.

Validation:                                                                                                                              
  - Local: all 7 yaml_file-related tests pass in `ros:rolling` docker image                                                                
    (python 3.12.3, pytest 7.4.4, 0.18s).                                                                                                  
  - CI: expected to exercise the same tests against rolling HEAD.
                                                                                                                                           
  `_malformed_raises` currently asserts `yaml.YAMLError` — this documents                                                                  
  the current behavior where PyYAML exceptions leak through the function                                                                   
  despite its docstring promising `RuntimeError`. PR-2 will reconcile the                                                                  
  docstring/behavior mismatch; this test will be updated accordingly.  
