### PR TITLE
[kilted] Fix incorrect action client feedback callback type hint

### DIFF
--- a/rclpy/rclpy/action/client.py
+++ b/rclpy/rclpy/action/client.py
@@ -17,6 +17,7 @@ import time
 from types import TracebackType
 from typing import Any
 from typing import Callable
+from typing import Coroutine
 from typing import Dict
 from typing import Generic
 from typing import Optional
@@ -25,6 +26,7 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypedDict
 from typing import TypeVar
+from typing import Union
 
 import uuid
 import weakref
@@ -69,16 +71,20 @@ if TYPE_CHECKING:
         result: Tuple[int, GetResultServiceResponse[ClientGoalHandleDictResultT]]
         feedback: FeedbackMessage[ClientGoalHandleDictFeedbackT]
         status: GoalStatusArray
+
+    FeedbackCallbackUnion: TypeAlias = Union[
+        Callable[[FeedbackMessage[FeedbackT]], None],
+        Callable[[FeedbackMessage[FeedbackT]], Coroutine[Any, Any, None]],
+    ]
+
+    class SendGoalKWargs(TypedDict, Generic[FeedbackT]):
+        feedback_callback: Optional[FeedbackCallbackUnion[FeedbackT]]
+        goal_uuid: Optional[UUID]
 else:
     ClientGoalHandleDict: 'TypeAlias' = Dict[str, object]
 
 
 T = TypeVar('T')
-
-
-class SendGoalKWargs(TypedDict):
-    feedback_callback: Optional[Callable[[FeedbackT], None]]
-    goal_uuid: Optional[UUID]
 
 
 class ClientGoalHandle(Generic[GoalT, ResultT, FeedbackT]):
@@ -237,7 +243,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
         # key: result request sequence_number, value: UUID
         self._result_sequence_number_to_goal_id: Dict[int, UUID] = {}
         # key: UUID in bytes, value: callback function
-        self._feedback_callbacks: Dict[bytes, Callable[[FeedbackT], None]] = {}
+        self._feedback_callbacks: Dict[bytes, 'FeedbackCallbackUnion[FeedbackT]'] = {}
 
         self._logger = self._node.get_logger().get_child('action_client')
         self._lock = threading.Lock()
@@ -444,7 +450,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
 
     # End Waitable API
 
-    def send_goal(self, goal: GoalT, **kwargs: 'Unpack[SendGoalKWargs]'
+    def send_goal(self, goal: GoalT, **kwargs: 'Unpack[SendGoalKWargs[FeedbackT]]'
                   ) -> Optional[GetResultServiceResponse[ResultT]]:
         """
         Send a goal and wait for the result.
@@ -494,7 +500,7 @@ class ActionClient(Generic[GoalT, ResultT, FeedbackT],
     def send_goal_async(
         self,
         goal: GoalT,
-        feedback_callback: Optional[Callable[[FeedbackT], None]] = None,
+        feedback_callback: 'Optional[FeedbackCallbackUnion[FeedbackT]]' = None,
         goal_uuid: Optional[UUID] = None
     ) -> Future[ClientGoalHandle[GoalT, ResultT, FeedbackT]]:
         """

--- a/rclpy/test/test_action_client.py
+++ b/rclpy/test/test_action_client.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 import unittest
+from typing import TYPE_CHECKING
 import uuid
 
 import rclpy
@@ -28,6 +31,9 @@ from service_msgs.msg import ServiceEventInfo
 from test_msgs.action import Fibonacci
 
 from unique_identifier_msgs.msg import UUID
+
+if TYPE_CHECKING:
+    from rclpy.type_support import FeedbackMessage
 
 
 # TODO(jacobperron) Reduce fudge once wait_for_service uses node graph events
@@ -88,7 +94,7 @@ class TestActionClient(unittest.TestCase):
     def setUp(self) -> None:
         self.feedback = None
 
-    def feedback_callback(self, feedback):
+    def feedback_callback(self, feedback: FeedbackMessage[Fibonacci.Feedback]) -> None:
         self.feedback = feedback
 
     def timed_spin(self, duration):


### PR DESCRIPTION
## What Problem Are We Trying to Solve?

- `ActionClient.send_goal_async()` declares `feedback_callback` as `Callable[[FeedbackT], None]`, but the runtime dispatcher in the same file invokes the registered callback with a `FeedbackMessage[FeedbackT]` (the wrapper with `goal_id` and `feedback` fields), not a bare `FeedbackT`.
- Consumers typing their callback correctly according to the declared signature cannot reach the feedback payload. The type hint is simply wrong.
- This was fixed on rolling by #1616 (commit f735d59) but was never backported to kilted. kilted users still see the incorrect hint.

## How Did We Solve the Problem?

- Backport the client-side portion of #1616 to kilted.
- Introduce a `FeedbackCallbackUnion` `TypeAlias` in the `TYPE_CHECKING` block, move `SendGoalKWargs` into the same block as `Generic[FeedbackT]`, and use the new alias in `_feedback_callbacks`, `send_goal`, and `send_goal_async`.
- Update `test_action_client.py` to type `feedback_callback` with `FeedbackMessage[Fibonacci.Feedback]`, documenting the corrected signature.
- Server-side changes from #1616 are not included: they depend on the `ImplT` generic parameter introduced after kilted.
- Pure type-hint correction; no runtime behavior change.
