### PR TITLE
Fix rclpy async executor sleep.

### DIFF
--- a/rclpy/rclpy/experimental/async_clock.py
+++ b/rclpy/rclpy/experimental/async_clock.py
@@ -88,20 +88,35 @@ class AsyncClock(BaseClock):
             return
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[None] = loop.create_future()
-        timer_handle: Optional[asyncio.TimerHandle] = None
-        target: Optional[Time] = None
 
         if self.ros_time_is_active:
-            target = self.now() + duration
-        else:
-            timer_handle = loop.call_later(
-                duration_sec, AsyncClock._resolve_future, future)
+            # _on_jump resolves the future only when self.now() >= target,
+            # so this branch already provides "at least duration" semantics.
+            future: asyncio.Future[None] = loop.create_future()
+            target: Time = self.now() + duration
+            self._pending_sleeps[future] = target
+            try:
+                await future
+            finally:
+                self._pending_sleeps.pop(future)
+            return
 
-        self._pending_sleeps[future] = target
-        try:
-            await future
-        finally:
-            self._pending_sleeps.pop(future)
-            if timer_handle is not None:
+        # asyncio.call_later is allowed to fire up to loop._clock_resolution
+        # early -- on Windows that window is the OS scheduler tick (~15 ms).
+        # Re-arm until the deadline is actually reached so callers get an
+        # "at least duration_sec" guarantee, matching the strict semantics
+        # of Clock.sleep_for in rclpy/rclcpp.
+        deadline = loop.time() + duration_sec
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return
+            future = loop.create_future()
+            timer_handle = loop.call_later(
+                remaining, AsyncClock._resolve_future, future)
+            self._pending_sleeps[future] = None
+            try:
+                await future
+            finally:
+                self._pending_sleeps.pop(future)
                 timer_handle.cancel()


### PR DESCRIPTION
## Description

The python asyncio sleep allows for a bit of clock resolution sloppiness (see https://github.com/python/cpython/blob/50476a7e87926cf6a9ea978943c4a3d5d771c95f/Lib/asyncio/base_events.py#L2036) which means that the asyncio sleep can actually wake up *before* the requested amount of time has passed. This is mostly a problem on Windows, where the tick time is 15ms, and we see some tests in rclpy fail a number of times there before eventually succeeding.

There are 2 ways we can fix this: either by making the tests accept some slop, or by making the rclpy AsyncClock sleep go back to sleep if it wakes up early.  The former is more like Python's asyncio, the latter is more like the rclcpp RCL_TIME sleep.

I chose to go with the latter because this is a robotics framework and waking up too early is as bad as waking up too late.  But everyone has to deal with the latter situation *anyway*, so it seems more predictable to always sleep at least the requested amount of time.  That's what this commit does.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes, Claude Opus 4.7

### Additional Information

N/A