### PR TITLE
Fix a race in the executors.

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -442,6 +442,18 @@ class Executor(ContextManager['Executor']):
         finally:
             self._exit_spin()
 
+        # If the future completed with an exception, re-raise it. The
+        # SingleThreadedExecutor re-raises synchronously inside _spin_once_impl
+        # so we never reach this code in that case. The MultiThreadedExecutor
+        # runs handlers on worker threads; the outer loop above can observe
+        # future.done() == True and exit before the next _spin_once_impl
+        # iteration would have called future.result(). Surfacing the
+        # exception here keeps the contract uniform across executor types.
+        if future.done():
+            exc = future.exception()
+            if exc is not None:
+                raise exc
+
     def spin_once(self, timeout_sec: Optional[float] = None) -> None:
         """
         Wait for and execute a single callback.

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -1032,6 +1032,22 @@ class TestExecutor(unittest.TestCase):
                 finally:
                     executor.shutdown()
 
+    def test_spin_until_future_complete_propagates_already_done_exception(self) -> None:
+        # Test that spin_until_future_complete surfaces a future's exception even if
+        # the future was already done before the spin loop ran.
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+            with self.subTest(cls=cls):
+                executor = cls(context=self.context)
+                try:
+                    future: Future[None] = executor.create_future()
+                    future.set_exception(RuntimeError('pre-set exception'))
+
+                    with self.assertRaises(RuntimeError) as cm:
+                        executor.spin_until_future_complete(future, timeout_sec=1)
+                    self.assertIn('pre-set exception', str(cm.exception))
+                finally:
+                    executor.shutdown()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

This is complicated to explain, but in the MultiThreadedExecutor spin_once_impl hands a task to a worker and adds it to the list of futures.  It then goes into a loop looking to finish/reap futures, but the one we just added is almost never done at this point.

However, if it completes fast enough to beat the outer-loop check in spin_until_future_complete, then the future will be done, we'll exit the loop without calling spin_once_impl again, and we'll never raise.

The fix is simple; after we've broken out of the outer loop in spin_until_future_complete, check one more time to see if the future was marked done with an exception, and if so, raise the exception.  There is no chance of throwing a double exception, since if we earlier threw the exception in spin_once, we never would have made it here.

### Is this user-facing behavior change?

Sort of.  It means that we'll raise in some cases where we didn't before, but those were cases where we *should* have been raising anyway.  So it is more a bugfix.

### Did you use Generative AI?

Yes, Claude Opus 4.7

### Additional Information

This should make Windows CI slightly less flaky.