### PR TITLE
Preserve float type in parameter_dict_from_yaml_file

### DIFF
--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -342,6 +342,46 @@ def parameter_value_to_python(parameter_value: ParameterValue) -> AllowableParam
         raise RuntimeError(f'unexpected parameter type {parameter_value.type}')
 
 
+def _parameter_value_from_python_value(value: Any) -> ParameterValue:
+    """
+    Build a ParameterValue from an already-parsed Python value.
+
+    Mirrors the type-inference of :func:`get_parameter_value` but skips the
+    ``str(value) -> yaml.safe_load`` round-trip. That round-trip lost
+    ``float`` values whose ``str()`` representation lacks a decimal point
+    (e.g. ``0.00001`` -> ``'1e-05'`` -> reparsed as ``str`` by PyYAML 1.1).
+    """
+    pv = ParameterValue()
+    if isinstance(value, bool):
+        pv.type = ParameterType.PARAMETER_BOOL
+        pv.bool_value = value
+    elif isinstance(value, int):
+        pv.type = ParameterType.PARAMETER_INTEGER
+        pv.integer_value = value
+    elif isinstance(value, float):
+        pv.type = ParameterType.PARAMETER_DOUBLE
+        pv.double_value = value
+    elif isinstance(value, list):
+        if all(isinstance(v, bool) for v in value):
+            pv.type = ParameterType.PARAMETER_BOOL_ARRAY
+            pv.bool_array_value = value
+        elif all(isinstance(v, int) for v in value):
+            pv.type = ParameterType.PARAMETER_INTEGER_ARRAY
+            pv.integer_array_value = value
+        elif all(isinstance(v, float) for v in value):
+            pv.type = ParameterType.PARAMETER_DOUBLE_ARRAY
+            pv.double_array_value = value
+        elif all(isinstance(v, str) for v in value):
+            pv.type = ParameterType.PARAMETER_STRING_ARRAY
+            pv.string_array_value = value
+        else:
+            pv.type = ParameterType.PARAMETER_STRING
+            pv.string_value = str(value)
+    else:
+        return get_parameter_value(str(value))
+    return pv
+
+
 def parameter_dict_from_yaml_file(
     parameter_file: str,
     use_wildcard: bool = False,
@@ -562,6 +602,6 @@ def _unpack_parameter_dict(namespace: str,
         else:
             parameter = ParameterMsg()
             parameter.name = full_param_name
-            parameter.value = get_parameter_value(str(param_value))
+            parameter.value = _parameter_value_from_python_value(param_value)
             parameters[full_param_name] = parameter
     return parameters

--- a/rclpy/rclpy/parameter.py
+++ b/rclpy/rclpy/parameter.py
@@ -342,46 +342,6 @@ def parameter_value_to_python(parameter_value: ParameterValue) -> AllowableParam
         raise RuntimeError(f'unexpected parameter type {parameter_value.type}')
 
 
-def _parameter_value_from_python_value(value: Any) -> ParameterValue:
-    """
-    Build a ParameterValue from an already-parsed Python value.
-
-    Mirrors the type-inference of :func:`get_parameter_value` but skips the
-    ``str(value) -> yaml.safe_load`` round-trip. That round-trip lost
-    ``float`` values whose ``str()`` representation lacks a decimal point
-    (e.g. ``0.00001`` -> ``'1e-05'`` -> reparsed as ``str`` by PyYAML 1.1).
-    """
-    pv = ParameterValue()
-    if isinstance(value, bool):
-        pv.type = ParameterType.PARAMETER_BOOL
-        pv.bool_value = value
-    elif isinstance(value, int):
-        pv.type = ParameterType.PARAMETER_INTEGER
-        pv.integer_value = value
-    elif isinstance(value, float):
-        pv.type = ParameterType.PARAMETER_DOUBLE
-        pv.double_value = value
-    elif isinstance(value, list):
-        if all(isinstance(v, bool) for v in value):
-            pv.type = ParameterType.PARAMETER_BOOL_ARRAY
-            pv.bool_array_value = value
-        elif all(isinstance(v, int) for v in value):
-            pv.type = ParameterType.PARAMETER_INTEGER_ARRAY
-            pv.integer_array_value = value
-        elif all(isinstance(v, float) for v in value):
-            pv.type = ParameterType.PARAMETER_DOUBLE_ARRAY
-            pv.double_array_value = value
-        elif all(isinstance(v, str) for v in value):
-            pv.type = ParameterType.PARAMETER_STRING_ARRAY
-            pv.string_array_value = value
-        else:
-            pv.type = ParameterType.PARAMETER_STRING
-            pv.string_value = str(value)
-    else:
-        return get_parameter_value(str(value))
-    return pv
-
-
 def parameter_dict_from_yaml_file(
     parameter_file: str,
     use_wildcard: bool = False,
@@ -602,6 +562,7 @@ def _unpack_parameter_dict(namespace: str,
         else:
             parameter = ParameterMsg()
             parameter.name = full_param_name
-            parameter.value = _parameter_value_from_python_value(param_value)
+            parameter.value = Parameter(
+                full_param_name, value=param_value).to_parameter_msg().value
             parameters[full_param_name] = parameter
     return parameters

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -474,31 +474,26 @@ class TestParameter(unittest.TestCase):
                 os.unlink(f.name)
         self.assertRaises(FileNotFoundError, parameter_dict_from_yaml_file, 'unknown_file')
 
-    def test_parameter_dict_from_yaml_file_preserves_float_type(self) -> None:
-        # Regression test for floats whose ``str()`` representation lacks a
-        # decimal point (e.g. ``0.00001`` -> ``'1e-05'``). The previous
-        # ``get_parameter_value(str(param_value))`` round-trip caused PyYAML 1.1
-        # to reparse these as strings rather than as doubles.
-        yaml_string = """
-            node:
-                ros__parameters:
-                    tiny: 0.00001
-                    arr: [0.00001, 0.00002]
-            """
-        try:
-            with NamedTemporaryFile(mode='w', delete=False) as f:
-                f.write(yaml_string)
-                f.flush()
-                f.close()
-                parameter_dict = parameter_dict_from_yaml_file(f.name)
-                assert parameter_dict['tiny'].value.type == ParameterType.PARAMETER_DOUBLE
-                assert parameter_dict['tiny'].value.double_value == 0.00001
-                assert parameter_dict['arr'].value.type == ParameterType.PARAMETER_DOUBLE_ARRAY
-                assert list(parameter_dict['arr'].value.double_array_value) == [
-                    0.00001, 0.00002]
-        finally:
-            if os.path.exists(f.name):
-                os.unlink(f.name)
+
+def test_parameter_dict_from_yaml_file_preserves_float_type(tmp_path) -> None:
+    # Regression test for floats whose ``str()`` representation lacks a
+    # decimal point (e.g. ``0.00001`` -> ``'1e-05'``). The previous
+    # ``get_parameter_value(str(param_value))`` round-trip caused PyYAML 1.1
+    # to reparse these as strings rather than as doubles.
+    yaml_string = """
+        node:
+            ros__parameters:
+                tiny: 0.00001
+                arr: [0.00001, 0.00002]
+        """
+    temp_file = tmp_path / 'test_params.yaml'
+    temp_file.write_text(yaml_string)
+    parameter_dict = parameter_dict_from_yaml_file(str(temp_file))
+    assert parameter_dict['tiny'].value.type == ParameterType.PARAMETER_DOUBLE
+    assert parameter_dict['tiny'].value.double_value == pytest.approx(0.00001)
+    assert parameter_dict['arr'].value.type == ParameterType.PARAMETER_DOUBLE_ARRAY
+    arr_values = list(parameter_dict['arr'].value.double_array_value)
+    assert arr_values == pytest.approx([0.00001, 0.00002])
 
 
 if __name__ == '__main__':

--- a/rclpy/test/test_parameter.py
+++ b/rclpy/test/test_parameter.py
@@ -474,6 +474,32 @@ class TestParameter(unittest.TestCase):
                 os.unlink(f.name)
         self.assertRaises(FileNotFoundError, parameter_dict_from_yaml_file, 'unknown_file')
 
+    def test_parameter_dict_from_yaml_file_preserves_float_type(self) -> None:
+        # Regression test for floats whose ``str()`` representation lacks a
+        # decimal point (e.g. ``0.00001`` -> ``'1e-05'``). The previous
+        # ``get_parameter_value(str(param_value))`` round-trip caused PyYAML 1.1
+        # to reparse these as strings rather than as doubles.
+        yaml_string = """
+            node:
+                ros__parameters:
+                    tiny: 0.00001
+                    arr: [0.00001, 0.00002]
+            """
+        try:
+            with NamedTemporaryFile(mode='w', delete=False) as f:
+                f.write(yaml_string)
+                f.flush()
+                f.close()
+                parameter_dict = parameter_dict_from_yaml_file(f.name)
+                assert parameter_dict['tiny'].value.type == ParameterType.PARAMETER_DOUBLE
+                assert parameter_dict['tiny'].value.double_value == 0.00001
+                assert parameter_dict['arr'].value.type == ParameterType.PARAMETER_DOUBLE_ARRAY
+                assert list(parameter_dict['arr'].value.double_array_value) == [
+                    0.00001, 0.00002]
+        finally:
+            if os.path.exists(f.name):
+                os.unlink(f.name)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Towards #1672.

`_unpack_parameter_dict` round-tripped each parsed value through `str()` and `yaml.safe_load`, which lost `float` values whose `str()` representation lacks a decimal point (e.g. `0.00001` → `'1e-05'` reparsed as `str` by PyYAML 1.1). This builds the `ParameterValue` directly from the parsed Python value instead, preserving float type for both scalars and arrays.

Scope is limited to the rclpy-side round-trip. Unquoted `5e-06` / `1e+20` in YAML source are still parsed as strings by PyYAML 1.1 itself and are not addressed here — that is a PyYAML resolver limitation.

Regression test added; existing parameter tests pass.