### PR TITLE
Show rosidl buffer backend metadata in topic endpoint info

### DIFF
--- a/rclpy/rclpy/endpoint_info.py
+++ b/rclpy/rclpy/endpoint_info.py
@@ -60,8 +60,9 @@ class TopicEndpointInfo:
         topic_type_hash: Union[TypeHash, TypeHashDictionary] = TypeHash(),
         endpoint_type: Union[EndpointTypeEnum, int] = EndpointTypeEnum.INVALID,
         endpoint_gid: list[int] = [],
-        qos_profile: Union[QoSProfile, '_rclpy._rmw_qos_profile_dict'] =
-            QoSPresetProfiles.UNKNOWN.value,
+        qos_profile: Union[QoSProfile, '_rclpy._rmw_qos_profile_dict'] = (
+            QoSPresetProfiles.UNKNOWN.value
+        ),
         buffer_backend_metadata: dict[str, str] = {}
     ):
         self.node_name = node_name

--- a/rclpy/rclpy/endpoint_info.py
+++ b/rclpy/rclpy/endpoint_info.py
@@ -48,7 +48,8 @@ class TopicEndpointInfo:
         '_topic_type_hash',
         '_endpoint_type',
         '_endpoint_gid',
-        '_qos_profile'
+        '_qos_profile',
+        '_buffer_backend_metadata'
     ]
 
     def __init__(
@@ -60,7 +61,8 @@ class TopicEndpointInfo:
         endpoint_type: Union[EndpointTypeEnum, int] = EndpointTypeEnum.INVALID,
         endpoint_gid: list[int] = [],
         qos_profile: Union[QoSProfile, '_rclpy._rmw_qos_profile_dict'] =
-            QoSPresetProfiles.UNKNOWN.value
+            QoSPresetProfiles.UNKNOWN.value,
+        buffer_backend_metadata: dict[str, str] = {}
     ):
         self.node_name = node_name
         self.node_namespace = node_namespace
@@ -69,6 +71,7 @@ class TopicEndpointInfo:
         self.endpoint_type = endpoint_type
         self.endpoint_gid = endpoint_gid
         self.qos_profile = qos_profile
+        self.buffer_backend_metadata = buffer_backend_metadata
 
     @property
     def node_name(self) -> str:
@@ -183,6 +186,21 @@ class TopicEndpointInfo:
         else:
             assert False
 
+    @property
+    def buffer_backend_metadata(self) -> dict[str, str]:
+        """
+        Get field 'buffer_backend_metadata'.
+
+        :returns: mapping from buffer backend name to backend metadata
+        """
+        return self._buffer_backend_metadata
+
+    @buffer_backend_metadata.setter
+    def buffer_backend_metadata(self, value: dict[str, str]) -> None:
+        assert isinstance(value, dict)
+        assert all(isinstance(k, str) and isinstance(v, str) for k, v in value.items())
+        self._buffer_backend_metadata = value
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TopicEndpointInfo):
             return False
@@ -196,6 +214,9 @@ class TopicEndpointInfo:
             history_depth_str = self.qos_profile.history.name
         else:
             history_depth_str = f'{self.qos_profile.history.name} ({self.qos_profile.depth})'
+        buffer_backend_str = ', '.join(sorted(self.buffer_backend_metadata.keys()))
+        if not buffer_backend_str:
+            buffer_backend_str = '<none>'
         return '\n'.join([
             f'Node name: {self.node_name}',
             f'Node namespace: {self.node_namespace}',
@@ -203,6 +224,7 @@ class TopicEndpointInfo:
             f'Topic type hash: {self.topic_type_hash}',
             f'Endpoint type: {self.endpoint_type.name}',
             f'GID: {gid}',
+            f'Buffer backends: {buffer_backend_str}',
             'QoS profile:',
             f'  Reliability: {self.qos_profile.reliability.name}',
             f'  History (Depth): {history_depth_str}',

--- a/rclpy/rclpy/endpoint_info.py
+++ b/rclpy/rclpy/endpoint_info.py
@@ -214,7 +214,9 @@ class TopicEndpointInfo:
             history_depth_str = self.qos_profile.history.name
         else:
             history_depth_str = f'{self.qos_profile.history.name} ({self.qos_profile.depth})'
-        buffer_backend_str = ', '.join(sorted(self.buffer_backend_metadata.keys()))
+        buffer_backend_str = ', '.join(
+            f'{backend}({metadata})' if metadata else backend
+            for backend, metadata in sorted(self.buffer_backend_metadata.items()))
         if not buffer_backend_str:
             buffer_backend_str = '<none>'
         return '\n'.join([

--- a/rclpy/rclpy/impl/_rclpy_pybind11.pyi
+++ b/rclpy/rclpy/impl/_rclpy_pybind11.pyi
@@ -801,6 +801,7 @@ class _TopicEndpointInfoDict(TypedDict):
     endpoint_type: int
     endpoint_gid: list[int]
     qos_profile: _rmw_qos_profile_dict
+    buffer_backend_metadata: dict[str, str]
 
 
 class _ServiceEndpointInfoDict(TypedDict):

--- a/rclpy/src/rclpy/utils.cpp
+++ b/rclpy/src/rclpy/utils.cpp
@@ -313,6 +313,17 @@ _convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic_endpo
   py_endpoint_info_dict["endpoint_gid"] = py_endpoint_gid;
   py_endpoint_info_dict["qos_profile"] =
     convert_to_qos_dict(&topic_endpoint_info->qos_profile);
+  py::dict py_buffer_backend_metadata;
+  const char * current_key = rcutils_string_map_get_next_key(
+    &topic_endpoint_info->buffer_backend_metadata, nullptr);
+  while (current_key) {
+    const char * current_value = rcutils_string_map_get(
+      &topic_endpoint_info->buffer_backend_metadata, current_key);
+    py_buffer_backend_metadata[py::str(current_key)] = py::str(current_value ? current_value : "");
+    current_key = rcutils_string_map_get_next_key(
+      &topic_endpoint_info->buffer_backend_metadata, current_key);
+  }
+  py_endpoint_info_dict["buffer_backend_metadata"] = py_buffer_backend_metadata;
 
   return py_endpoint_info_dict;
 }

--- a/rclpy/src/rclpy/utils.cpp
+++ b/rclpy/src/rclpy/utils.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include <rcpputils/scope_exit.hpp>
+#include <rmw/impl/cpp/buffer_backend_metadata.hpp>
 
 #include "exceptions.hpp"
 #include "utils.hpp"
@@ -314,14 +315,10 @@ _convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic_endpo
   py_endpoint_info_dict["qos_profile"] =
     convert_to_qos_dict(&topic_endpoint_info->qos_profile);
   py::dict py_buffer_backend_metadata;
-  const char * current_key = rcutils_string_map_get_next_key(
-    &topic_endpoint_info->buffer_backend_metadata, nullptr);
-  while (current_key) {
-    const char * current_value = rcutils_string_map_get(
-      &topic_endpoint_info->buffer_backend_metadata, current_key);
-    py_buffer_backend_metadata[py::str(current_key)] = py::str(current_value ? current_value : "");
-    current_key = rcutils_string_map_get_next_key(
-      &topic_endpoint_info->buffer_backend_metadata, current_key);
+  for (const auto & backend_pair :
+    rmw::impl::cpp::parse_buffer_backend_metadata(topic_endpoint_info->buffer_backend_metadata))
+  {
+    py_buffer_backend_metadata[py::str(backend_pair.first)] = py::str(backend_pair.second);
   }
   py_endpoint_info_dict["buffer_backend_metadata"] = py_buffer_backend_metadata;
 

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -89,7 +89,7 @@ class TestQosProfile(unittest.TestCase):
         self.assertEqual(test_qos_profile, info_from_ctor.qos_profile)
 
     def test_buffer_backend_metadata_only_constructor(self) -> None:
-        test_buffer_backend_metadata = {'cuda': 'version=1.0'}
+        test_buffer_backend_metadata = {'cpu': ''}
 
         info_for_ref = TopicEndpointInfo()
         info_for_ref.buffer_backend_metadata = test_buffer_backend_metadata

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -88,6 +88,19 @@ class TestQosProfile(unittest.TestCase):
         self.assertEqual(info_for_ref, info_from_ctor)
         self.assertEqual(test_qos_profile, info_from_ctor.qos_profile)
 
+    def test_buffer_backend_metadata_only_constructor(self) -> None:
+        test_buffer_backend_metadata = {'cuda': 'version=1.0'}
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.buffer_backend_metadata = test_buffer_backend_metadata
+
+        info_from_ctor = TopicEndpointInfo(
+            buffer_backend_metadata=test_buffer_backend_metadata)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(
+            test_buffer_backend_metadata, info_from_ctor.buffer_backend_metadata)
+
     def test_print(self) -> None:
         actual_info_str = str(TopicEndpointInfo())
         expected_info_str = 'Node name: \n' \
@@ -96,6 +109,7 @@ class TestQosProfile(unittest.TestCase):
             'Topic type hash: INVALID\n' \
             'Endpoint type: INVALID\n' \
             'GID: \n' \
+            'Buffer backends: <none>\n' \
             'QoS profile:\n' \
             '  Reliability: UNKNOWN\n' \
             '  History (Depth): UNKNOWN\n' \


### PR DESCRIPTION
## Description

Expose rosidl buffer backend metadata in `rclpy.TopicEndpointInfo` and include it in the string representation used by verbose topic introspection.

With the matching RMW/RMW implementation changes, `ros2 topic info <topic> -v` can now show buffer backend support for publishers and subscriptions.

### Is this user-facing behavior change?

Yes. `ros2 topic info <topic> -v` can display a `Buffer backends: <backends>` line for each topic endpoint.

### Did you use Generative AI?

Yes. GPT-5.5 in Cursor was used to help draft changes in this pull request.

### Additional Information

Depending on:
- https://github.com/ros2/rmw/pull/419

Relevant but not directly dependent:
- https://github.com/ros2/rmw_dds_common/pull/88
- https://github.com/ros2/rmw_fastrtps/pull/889