### PR TITLE
fix(docs): mock rcl_interfaces to fix empty Node API page

### DIFF
--- a/rclpy/docs/source/conf.py
+++ b/rclpy/docs/source/conf.py
@@ -202,3 +202,6 @@ autodoc_default_options = {
     'members': True,  # document members
     'undoc-members': True,  # also document members without documentation
 }
+
+# rclpy.node imports rcl_interfaces.msg
+autodoc_mock_imports = ['rcl_interfaces']


### PR DESCRIPTION
## Description

Fixes the empty [Node API docs page](https://docs.ros.org/en/rolling/p/rclpy/api/node.html) reported in #1681.

`rclpy.node` imports `rcl_interfaces.msg` at module level, which transitively requires `rosidl_pycommon.interface_base_classes` — unavailable in the Sphinx docs build environment. The import silently fails and autodoc renders a blank page. Adding `autodoc_mock_imports = ['rcl_interfaces']` to `conf.py` unblocks the import without affecting the build.

All other modules (`publisher`, `client`, etc.) happen to avoid this because they don't import `rcl_interfaces` directly.

## Testing

```bash
# Clone and check out this branch
git clone https://github.com/ros2/rclpy.git && cd rclpy

# Install deps (rclpy must be importable — source your ROS install first)
source /opt/ros/rolling/setup.bash
pip install sphinx sphinx-rtd-theme

# Build docs
cd rclpy/docs
sphinx-build -b html source /tmp/rclpy-docs

# Open the Node page and confirm it has content (not just a heading)
xdg-open /tmp/rclpy-docs/api/node.html
# or: grep -c 'py class\|py method' /tmp/rclpy-docs/api/node.html
```

**Before** this fix: `api/node.html` contains only `<h1>Node</h1>` — no class or method entries.
**After** this fix: `Node` class with all ~124 methods is documented.

To reproduce the failure, revert `conf.py` and rebuild.

## Did you use Generative AI?

Yes — Antigravity (Gemini CLI / Claude Sonnet 4.6) was used to diagnose the root cause and author the fix.