### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/rclpy/rclpy/expand_topic_name.py
+++ b/rclpy/rclpy/expand_topic_name.py
@@ -26,7 +26,7 @@ def expand_topic_name(topic_name: str, node_name: str, node_namespace: str) -> s
 
     :param topic_name: topic name to be expanded
     :param node_name: name of the node that this topic is associated with
-    :param namespace: namespace that the topic is within
+    :param node_namespace: namespace that the topic is within
     :returns: expanded topic name which is fully qualified
     :raises: ValueError if the topic name, node name or namespace are invalid
     """

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -1358,7 +1358,7 @@ class BaseNode(ABC):
         """
         Get the parameter descriptors of a given list of parameters.
 
-        :param name: List of fully-qualified names of the parameters to describe.
+        :param names: List of fully-qualified names of the parameters to describe.
         :return: List of ParameterDescriptors corresponding to the given parameters.
             Default ParameterDescriptors shall be returned for parameters that
             had not been declared before if undeclared parameters are allowed.

--- a/rclpy/rclpy/task.py
+++ b/rclpy/rclpy/task.py
@@ -140,7 +140,7 @@ class Future(Generic[T]):
         """
         Set the exception raised by the task.
 
-        :param result: The output of a long running task.
+        :param exception: The exception raised by the task.
         """
         with self._lock:
             self._exception = exception


### PR DESCRIPTION
Three docstrings reference parameter names that do not match their function signatures:

- `expand_topic_name` documents `:param namespace:` but the parameter is `node_namespace`.
- `Node.describe_parameters` documents `:param name:` but the parameter is `names`.
- `Future.set_exception` documents `:param result: The output of a long running task.` but the parameter is `exception` (the wording was copied from `set_result`).

This corrects the documented names (and the `set_exception` description) to match the signatures. Documentation-only change; no behaviour is affected.
