### PR TITLE
Fix InvalidQoSProfileException message prefix

### DIFF
--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -57,7 +57,7 @@ class InvalidQoSProfileException(Exception):
     """Raised when constructing a QoSProfile with invalid arguments."""
 
     def __init__(self, message: str) -> None:
-        Exception(self, f'Invalid QoSProfile: {message}')
+        super().__init__(f'Invalid QoSProfile: {message}')
 
 
 class QoSProfile:

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -106,6 +106,10 @@ class TestQosProfile(unittest.TestCase):
             # History is KEEP_LAST, but no depth is provided
             QoSProfile(history=QoSHistoryPolicy.KEEP_LAST)
 
+    def test_invalid_qos_message(self) -> None:
+        exception = InvalidQoSProfileException('some reason')
+        self.assertEqual(str(exception), 'Invalid QoSProfile: some reason')
+
     def test_policy_short_names(self) -> None:
         # Full test on History to show the mechanism works
         assert (


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fix `InvalidQoSProfileException` to properly initialize with the `'Invalid QoSProfile: '` prefix.

Currently, calling `Exception(self, ...)` inside `__init__` does not set the exception message on `self`, causing the custom prefix to be ignored. Using `super().__init__()` fixes this.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
