### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/rclpy/rclpy/action/graph.py
+++ b/rclpy/rclpy/action/graph.py
@@ -33,7 +33,7 @@ def get_action_client_names_and_types_by_node(
 
     :param node: The node used for discovery.
     :param remote_node_name: The name of a remote node to get action clients for.
-    :param node_namespace: Namespace of the remote node.
+    :param remote_node_namespace: Namespace of the remote node.
     :return: List of tuples.
       The first element of each tuple is the action name and the second element is a list of
       action types.
@@ -62,7 +62,7 @@ def get_action_server_names_and_types_by_node(
 
     :param node: The node used for discovery.
     :param remote_node_name: The name of a remote node to get action servers for.
-    :param node_namespace: Namespace of the remote node.
+    :param remote_node_namespace: Namespace of the remote node.
     :return: List of tuples.
       The first element of each tuple is the action name and the second element is a list of
       action types.

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -708,8 +708,8 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
         There can only be one handle accepted callback per :class:`ActionServer`, therefore
         calling this function will replace any previously registered callback.
 
-        :param handle_accepted_callback: Callback function, if `None`, then unregisters any previously
-            registered callback.
+        :param handle_accepted_callback: Callback function, if `None`, then unregisters any
+            previously registered callback.
         """
         if handle_accepted_callback is None:
             handle_accepted_callback = default_handle_accepted_callback

--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -708,7 +708,7 @@ class ActionServer(Generic[GoalT, ResultT, FeedbackT, ImplT],
         There can only be one handle accepted callback per :class:`ActionServer`, therefore
         calling this function will replace any previously registered callback.
 
-        :param goal_callback: Callback function, if `None`, then unregisters any previously
+        :param handle_accepted_callback: Callback function, if `None`, then unregisters any previously
             registered callback.
         """
         if handle_accepted_callback is None:

--- a/rclpy/rclpy/node.py
+++ b/rclpy/rclpy/node.py
@@ -2723,7 +2723,7 @@ class Node(BaseNode):
 
         The node name should be the full name with namespace.
 
-        :param node_name: Fully qualified name of the node to wait for.
+        :param fully_qualified_node_name: Fully qualified name of the node to wait for.
         :param timeout: Seconds to wait for the node to be present. If negative, the function
                          won't timeout.
         :return: ``True`` if the node was found, ``False`` if timeout.


### PR DESCRIPTION
Several `:param:` entries documented names that don't match the actual function signatures. This corrects them so the API docs render the right parameter names.

- `Node.wait_for_node`: `node_name` -> `fully_qualified_node_name`
- `get_action_client_names_and_types_by_node`: `node_namespace` -> `remote_node_namespace`
- `get_action_server_names_and_types_by_node`: `node_namespace` -> `remote_node_namespace`
- `ActionServer.register_handle_accepted_callback`: `goal_callback` -> `handle_accepted_callback`

Documentation-only change; no behavior change.