### PR TITLE
Handle exceptions in lifecycle transition callbacks

### DIFF
--- a/rclpy/rclpy/lifecycle/node.py
+++ b/rclpy/rclpy/lifecycle/node.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import traceback
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -238,7 +239,13 @@ class LifecycleNodeMixin(ManagedEntity):
             else:
                 raise ValueError(f'Not valid callback name "{callback_name}" given.')
 
-            ret = cb(state)
+            try:
+                ret = cb(state)
+            except Exception:
+                self._logger.error(
+                    f'Caught exception in {callback_name}() callback of managed entity '
+                    f'{entity}:\n{traceback.format_exc()}')
+                return TransitionCallbackReturn.ERROR
             if not isinstance(ret, _rclpy.TransitionCallbackReturnType):
                 raise TypeError(
                     f'{callback_name}() return value of class {type(entity)} should be'
@@ -397,7 +404,9 @@ class LifecycleNodeMixin(ManagedEntity):
             ret = cb(previous_state)
             return ret
         except Exception:
-            # TODO(ivanpauno): log sth here
+            self._logger.error(
+                f'Caught exception in transition callback for state {current_state_id}:\n'
+                f'{traceback.format_exc()}')
             return TransitionCallbackReturn.ERROR
 
     def __change_state(self, transition_id: int) -> TransitionCallbackReturn:

--- a/rclpy/test/test_lifecycle.py
+++ b/rclpy/test/test_lifecycle.py
@@ -31,6 +31,7 @@ from rclpy.client import Client
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.lifecycle import LifecycleNode
 from rclpy.lifecycle import LifecycleState
+from rclpy.lifecycle import ManagedEntity
 from rclpy.lifecycle import TransitionCallbackReturn
 from rclpy.node import Node
 from rclpy.publisher import BasePublisher
@@ -119,6 +120,36 @@ def test_lifecycle_state_transitions() -> None:
         'test_lifecycle_state_transitions_3', enable_communication_interface=False)
     assert node.trigger_configure() == TransitionCallbackReturn.ERROR
     assert node._state_machine.current_state[1] == 'finalized'
+
+
+def test_lifecycle_exception_in_managed_entity_callback() -> None:
+    class RaisingManagedEntity(ManagedEntity):
+
+        def on_configure(self, state: LifecycleState) -> TransitionCallbackReturn:
+            raise RuntimeError('exception in on_configure')
+
+    node = LifecycleNode(
+        'test_lifecycle_exception_in_managed_entity_callback',
+        enable_communication_interface=False)
+    node.add_managed_entity(RaisingManagedEntity())
+    assert node.trigger_configure() == TransitionCallbackReturn.ERROR
+    assert node._state_machine.current_state[1] == 'unconfigured'
+    node.destroy_node()
+
+
+def test_lifecycle_exception_in_overridden_callback() -> None:
+    class RaiseOnActivateNode(LifecycleNode):
+
+        def on_activate(self, state: LifecycleState) -> TransitionCallbackReturn:
+            raise RuntimeError('exception in on_activate')
+
+    node = RaiseOnActivateNode(
+        'test_lifecycle_exception_in_overridden_callback',
+        enable_communication_interface=False)
+    assert node.trigger_configure() == TransitionCallbackReturn.SUCCESS
+    assert node.trigger_activate() == TransitionCallbackReturn.ERROR
+    assert node._state_machine.current_state[1] == 'unconfigured'
+    node.destroy_node()
 
 
 def test_lifecycle_services(request: FixtureRequest) -> None:


### PR DESCRIPTION
## Description

In rclcpp_lifecycle the exceptions are properly handled here during transistion callbacks: https://github.com/ros2/rclcpp/blob/527275027cee68bf817a5d0824f15803114a4d2d/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp#L514-L527

However, in rclpy currently, it simply crashes the node. I think it is better to be consistent between both the libraries, for this reason this PR is opened 

### Is this user-facing behavior change?
Yes, previously it crashes, but now the node ends up unconfigured

### Did you use Generative AI?
Claude, to refine the added tests

