### PR TITLE
Use perf_counter() rather than monotonic() for consistency.

### DIFF
--- a/rclpy/rclpy/executors.py
+++ b/rclpy/rclpy/executors.py
@@ -421,7 +421,13 @@ class Executor(ContextManager['Executor']):
                 ):
                     self._spin_once_until_future_complete(future, timeout_sec)
             else:
-                start = time.monotonic()
+                # Use perf_counter() rather than monotonic(): on Windows with
+                # CPython < 3.13, monotonic() is based on GetTickCount64() with
+                # ~15.6ms resolution, which can quantize the start time such
+                # that this loop exits up to one tick earlier than timeout_sec
+                # in real time. perf_counter() is monotonic on all supported
+                # platforms and has sub-microsecond resolution.
+                start = time.perf_counter()
                 end = start + timeout_sec
                 timeout_left = TimeoutObject(timeout_sec)
 
@@ -432,7 +438,7 @@ class Executor(ContextManager['Executor']):
                     and not self._is_shutdown
                 ):
                     self._spin_once_until_future_complete(future, timeout_left)
-                    now = time.monotonic()
+                    now = time.perf_counter()
 
                     if now >= end:
                         break


### PR DESCRIPTION
## Description

please read the comments in the code.

closes https://github.com/ros2/rclpy/issues/1480

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Not really, and only Windows gets affected.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Fable 5.

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
