### PR TITLE
Fix EventsExecutor segfault when a task raises an exception

### DIFF
--- a/rclpy/src/rclpy/events_executor/events_executor.cpp
+++ b/rclpy/src/rclpy/events_executor/events_executor.cpp
@@ -832,7 +832,7 @@ void EventsExecutor::IterateTask(py::handle task)
         // can use the logger from that, otherwise we'll have to leave it undefined.
         py::object logger = py::none();
         if (nodes_.size() == 1) {
-          logger = nodes_[0].attr("get_logger")();
+          logger = py::list(nodes_)[0].attr("get_logger")();
         }
         HandleCallbackExceptionWithLogger(cpp_ex, logger, "task");
         throw;

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -489,8 +489,7 @@ class TestExecutor(unittest.TestCase):
     def test_coroutine_exception_after_await(self) -> None:
         """Exception in a coroutine after awaiting a future must propagate."""
         self.assertIsNotNone(self.node.handle)
-        # EventsExecutor excluded - segfaults on exception propagation (#1641)
-        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor, EventsExecutor]:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)
@@ -517,8 +516,7 @@ class TestExecutor(unittest.TestCase):
     def test_cancel_task_while_awaiting_future(self) -> None:
         """Cancelling a task parked on a future must not crash the dispatch loop."""
         self.assertIsNotNone(self.node.handle)
-        # EventsExecutor excluded - see #1641
-        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor, EventsExecutor]:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)
@@ -548,8 +546,7 @@ class TestExecutor(unittest.TestCase):
     def test_await_already_completed_future(self) -> None:
         """Awaiting an already-completed future must resume and return its result."""
         self.assertIsNotNone(self.node.handle)
-        # EventsExecutor excluded - see #1641
-        for cls in [SingleThreadedExecutor, MultiThreadedExecutor]:
+        for cls in [SingleThreadedExecutor, MultiThreadedExecutor, EventsExecutor]:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)

--- a/rclpy/test/test_executor.py
+++ b/rclpy/test/test_executor.py
@@ -489,7 +489,10 @@ class TestExecutor(unittest.TestCase):
     def test_coroutine_exception_after_await(self) -> None:
         """Exception in a coroutine after awaiting a future must propagate."""
         self.assertIsNotNone(self.node.handle)
-        for cls in [SingleThreadedExecutor, MultiThreadedExecutor, EventsExecutor]:
+        executor_types: list[ExcutorTypeLike] = [SingleThreadedExecutor,
+                                                 MultiThreadedExecutor,
+                                                 EventsExecutor]
+        for cls in executor_types:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)
@@ -516,7 +519,10 @@ class TestExecutor(unittest.TestCase):
     def test_cancel_task_while_awaiting_future(self) -> None:
         """Cancelling a task parked on a future must not crash the dispatch loop."""
         self.assertIsNotNone(self.node.handle)
-        for cls in [SingleThreadedExecutor, MultiThreadedExecutor, EventsExecutor]:
+        executor_types: list[ExcutorTypeLike] = [SingleThreadedExecutor,
+                                                 MultiThreadedExecutor,
+                                                 EventsExecutor]
+        for cls in executor_types:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)
@@ -546,7 +552,10 @@ class TestExecutor(unittest.TestCase):
     def test_await_already_completed_future(self) -> None:
         """Awaiting an already-completed future must resume and return its result."""
         self.assertIsNotNone(self.node.handle)
-        for cls in [SingleThreadedExecutor, MultiThreadedExecutor, EventsExecutor]:
+        executor_types: list[ExcutorTypeLike] = [SingleThreadedExecutor,
+                                                 MultiThreadedExecutor,
+                                                 EventsExecutor]
+        for cls in executor_types:
             with self.subTest(cls=cls):
                 executor = cls(context=self.context)
                 executor.add_node(self.node)


### PR DESCRIPTION
## Description

`EventsExecutor::IterateTask` picks a logger to report a failed task on, and reads it with `nodes_[0]`. `nodes_` is a `pybind11::set`, which is not subscriptable. It compiles because `object_api::operator[]` takes a `py::handle` and the literal `0` converts to a null handle, so pybind builds `py::str(nullptr)` and the process dies in `strlen()`.

The line only runs when a task raises *and* exactly one node is registered, which is why normal use never reaches it.

This takes the element through `py::list(nodes_)`, the idiom already used for `nodes_` elsewhere in the same file.

Three tests in `test_executor.py` had `EventsExecutor` removed from their executor list because of this crash; they are re-enabled here.

Fixes #1641

### Is this user-facing behavior change?

Yes. Under `EventsExecutor`, a task that raises an exception previously killed the process with SIGSEGV. It now logs the exception and propagates it, matching `SingleThreadedExecutor` and `MultiThreadedExecutor`.

### Did you use Generative AI?

Yes, Claude Code (Claude Opus 5), for the analysis and the patch.

### Additional Information

Verified with a control rather than a single passing run:

- with the fix: the three re-enabled tests give `3 passed, 9 subtests passed`
- with only the source line reverted and the tests left re-enabled: the runner dies with `SIGSEGV` (exit 139)

One caveat on that verification: it was done against tag `11.0.2`, not `rolling` HEAD, because HEAD needs a newer `rcl_action` than the released Rolling debs provide (`rcl_action_endpoint_info_array_t` is missing), so HEAD would not build in my environment. Both changed regions are byte-identical between `11.0.2` and `9b61076`, which I checked directly, but I have not built HEAD itself.

The issue reported this on aarch64; it reproduces on x86_64 as well, so it is not architecture-specific.

